### PR TITLE
Continue DB migration: sync normalized keyword tables and prefer IMAGE_KEYWORDS in tag propagation

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -34,7 +34,8 @@
       "WebFetch(domain:127.0.0.1)",
       "Bash(python -m pytest)",
       "Bash(python -c \"import py_compile; py_compile.compile\\(''modules/db.py'', doraise=True\\); py_compile.compile\\(''modules/mcp_server.py'', doraise=True\\); print\\(''Both files compile OK''\\)\")",
-      "Bash(python -c \"from modules.db import _add_keyword_filter; print\\(''_add_keyword_filter imported successfully''\\)\")"
+      "Bash(python -c \"from modules.db import _add_keyword_filter; print\\(''_add_keyword_filter imported successfully''\\)\")",
+      "Bash(python -c \"import py_compile; py_compile.compile\\(''modules/ui/tabs/pipeline.py'', doraise=True\\); py_compile.compile\\(''modules/ui/tabs/gallery.py'', doraise=True\\); py_compile.compile\\(''modules/ui/app.py'', doraise=True\\); py_compile.compile\\(''modules/ui/assets.py'', doraise=True\\); print\\(''All files compile OK''\\)\")"
     ],
     "additionalDirectories": [
       "c:\\Users\\dmnsy\\.gemini\\antigravity",

--- a/modules/db.py
+++ b/modules/db.py
@@ -4528,6 +4528,13 @@ def update_image_metadata(file_path, keywords, title, description, rating, label
                      SET keywords = ?, title = ?, description = ?, rating = ?, label = ?
                      WHERE file_path = ?''',
                   (keywords, title, description, rating, label, file_path))
+
+        # Phase 2 dual-write: keep normalized keyword tables synchronized.
+        c.execute("SELECT id FROM images WHERE file_path = ?", (file_path,))
+        row = c.fetchone()
+        if row:
+            _sync_image_keywords(row[0], keywords)
+
         conn.commit()
         
         # Broadcast image update
@@ -6443,20 +6450,29 @@ def get_images_for_tag_propagation(folder_path=None):
             folder_filter = " AND folder_id = ?"
             params.append(frow[0])
 
-        # Untagged images with embeddings
+        # Untagged images with embeddings.
+        # Phase 2/3 migration: prefer normalized IMAGE_KEYWORDS; keep legacy
+        # IMAGES.KEYWORDS fallback for rows not yet dual-written.
         q_untagged = (
-            "SELECT id, file_path, image_embedding FROM images "
-            "WHERE image_embedding IS NOT NULL "
-            "AND (keywords IS NULL OR keywords = '')" + folder_filter
+            "SELECT i.id, i.file_path, i.image_embedding FROM images i "
+            "WHERE i.image_embedding IS NOT NULL "
+            "AND NOT EXISTS (SELECT 1 FROM image_keywords ik WHERE ik.image_id = i.id) "
+            "AND (i.keywords IS NULL OR i.keywords = '')" + folder_filter.replace("folder_id", "i.folder_id")
         )
         c.execute(q_untagged, tuple(params))
         untagged = [(row[0], row[1], bytes(row[2])) for row in c.fetchall()]
 
-        # Tagged images with embeddings
+        # Tagged images with embeddings. Build keyword CSV from normalized
+        # tables when possible, otherwise fall back to legacy IMAGES.KEYWORDS.
         q_tagged = (
-            "SELECT id, file_path, image_embedding, keywords FROM images "
-            "WHERE image_embedding IS NOT NULL "
-            "AND keywords IS NOT NULL AND keywords != ''" + folder_filter
+            "SELECT i.id, i.file_path, i.image_embedding, "
+            "COALESCE((SELECT LIST(COALESCE(kd.keyword_display, kd.keyword_norm), ', ') "
+            "FROM image_keywords ik JOIN keywords_dim kd ON kd.keyword_id = ik.keyword_id "
+            "WHERE ik.image_id = i.id), i.keywords) AS keywords_csv "
+            "FROM images i "
+            "WHERE i.image_embedding IS NOT NULL "
+            "AND (EXISTS (SELECT 1 FROM image_keywords ik WHERE ik.image_id = i.id) "
+            "OR (i.keywords IS NOT NULL AND i.keywords != ''))" + folder_filter.replace("folder_id", "i.folder_id")
         )
         c.execute(q_tagged, tuple(params))
         tagged = [(row[0], row[1], bytes(row[2]), row[3]) for row in c.fetchall()]
@@ -7094,4 +7110,3 @@ def _backfill_image_xmp():
             pass
     finally:
         conn.close()
-

--- a/modules/db.py
+++ b/modules/db.py
@@ -4529,13 +4529,16 @@ def update_image_metadata(file_path, keywords, title, description, rating, label
                      WHERE file_path = ?''',
                   (keywords, title, description, rating, label, file_path))
 
+        conn.commit()
+
         # Phase 2 dual-write: keep normalized keyword tables synchronized.
+        # Must run after commit to avoid: (1) dual-write inconsistency if outer
+        # commit fails; (2) Firebird deadlock (inner conn blocks on FK to row
+        # held by outer conn in WAIT mode).
         c.execute("SELECT id FROM images WHERE file_path = ?", (file_path,))
         row = c.fetchone()
         if row:
             _sync_image_keywords(row[0], keywords)
-
-        conn.commit()
         
         # Broadcast image update
         try:

--- a/modules/ui/app.py
+++ b/modules/ui/app.py
@@ -111,7 +111,8 @@ def create_ui():
             pipeline_components["stop_all_btn"],
             pipeline_components["scoring_run_btn"],
             pipeline_components["culling_run_btn"],
-            pipeline_components["keywords_run_btn"]
+            pipeline_components["keywords_run_btn"],
+            pipeline_components["quick_start_html"],
         ]
 
         status_timer.tick(

--- a/modules/ui/tabs/gallery.py
+++ b/modules/ui/tabs/gallery.py
@@ -11,6 +11,34 @@ from modules import debug
 IS_WINDOWS = (platform.system() == 'Windows')
 
 
+def _build_active_chips_html(rating_filter, label_filter, keyword_filter,
+                             min_gen, min_aes, min_tech, start_date, end_date):
+    """Builds HTML showing currently active filters as read-only chips."""
+    chips = []
+    if rating_filter:
+        chips.append(f"Rating: {', '.join(str(r) for r in rating_filter)}")
+    if label_filter:
+        chips.append(f"Label: {', '.join(label_filter)}")
+    if keyword_filter and keyword_filter.strip():
+        chips.append(f'Keyword: "{keyword_filter.strip()}"')
+    if min_gen and float(min_gen) > 0.0:
+        chips.append(f"Min General: {float(min_gen):.2f}")
+    if min_aes and float(min_aes) > 0.0:
+        chips.append(f"Min Aesthetic: {float(min_aes):.2f}")
+    if min_tech and float(min_tech) > 0.0:
+        chips.append(f"Min Technical: {float(min_tech):.2f}")
+    if start_date and str(start_date).strip():
+        chips.append(f"From: {str(start_date).strip()}")
+    if end_date and str(end_date).strip():
+        chips.append(f"To: {str(end_date).strip()}")
+    if not chips:
+        return ""
+    parts = ["<div class='active-chips-strip' role='list' aria-label='Active filters'>"]
+    for chip in chips:
+        parts.append(f"<span class='active-chip' role='listitem'>{chip}</span>")
+    parts.append("</div>")
+    return "".join(parts)
+
 
 # --- Helper Functions ---
 
@@ -578,6 +606,17 @@ def create_tab(shared_state, current_folder_state, current_stack_state, runner, 
                         value=app_config.get('scoring', {}).get('default_sort_order', 'desc'), 
                         label="Order", container=False)
 
+        # Filter Presets
+        with gr.Row(elem_classes=["filter-preset-row"]):
+            gr.HTML("<span style='font-size:0.82rem;color:var(--text-muted);align-self:center;'>Presets:</span>")
+            preset_top_rated = gr.Button("Top Rated", size="sm", elem_classes=["filter-chip"])
+            preset_needs_review = gr.Button("Needs Review", size="sm", elem_classes=["filter-chip"])
+            preset_has_keywords = gr.Button("Has Keywords", size="sm", elem_classes=["filter-chip"])
+            preset_reset_all = gr.Button("Reset All", size="sm", elem_classes=["secondary-btn"])
+
+        # Active Filter Chips
+        active_chips_html = gr.HTML(value="", elem_classes=["active-chips-strip"])
+
         # Filters Section
         with gr.Accordion("🔍 Filters & Search", open=False):
             with gr.Row():
@@ -731,7 +770,62 @@ def create_tab(shared_state, current_folder_state, current_stack_state, runner, 
         for inp in filter_inputs_base[:-2]: # exclude folder_state and stack_state
             # When filter changes, go to first page
              inp.change(fn=first_page, inputs=filter_inputs_base, outputs=[current_page, gallery, page_label, current_paths] + detail_outputs, trigger_mode="always_last")
-             
+
+        # Active chips: update whenever any filter changes
+        chip_inputs = [filter_rating, filter_label, filter_keyword, f_min_gen, f_min_aes, f_min_tech, f_date_start, f_date_end]
+        for inp in chip_inputs:
+            inp.change(
+                fn=_build_active_chips_html,
+                inputs=chip_inputs,
+                outputs=[active_chips_html],
+                trigger_mode="always_last",
+            )
+
+        # --- Filter Presets ---
+        gallery_outputs = [current_page, gallery, page_label, current_paths] + detail_outputs
+
+        def _apply_preset_top_rated(folder, stack_id):
+            """Top Rated: rating 4-5, sort by general score."""
+            rating = ["4", "5"]
+            gal = update_gallery(1, "score_general", "desc", rating, [], "", 0.0, 0.0, 0.0, "", "", folder, stack_id)
+            chips = _build_active_chips_html(rating, [], "", 0.0, 0.0, 0.0, "", "")
+            return [rating, [], "", 0.0, 0.0, 0.0, "", "", "score_general", "desc", chips, 1] + list(gal)
+
+        def _apply_preset_needs_review(folder, stack_id):
+            """Needs Review: no rating filter, sort by general score (unrated images surface)."""
+            gal = update_gallery(1, "score_general", "desc", [], [], "", 0.0, 0.0, 0.0, "", "", folder, stack_id)
+            chips = _build_active_chips_html([], [], "", 0.0, 0.0, 0.0, "", "")
+            return [[], [], "", 0.0, 0.0, 0.0, "", "", "score_general", "desc", chips, 1] + list(gal)
+
+        def _apply_preset_has_keywords(folder, stack_id):
+            """Has Keywords: keyword search with wildcard to surface tagged images."""
+            gal = update_gallery(1, "score_general", "desc", [], [], "%", 0.0, 0.0, 0.0, "", "", folder, stack_id)
+            chips = _build_active_chips_html([], [], "%", 0.0, 0.0, 0.0, "", "")
+            return [[], [], "%", 0.0, 0.0, 0.0, "", "", "score_general", "desc", chips, 1] + list(gal)
+
+        def _apply_preset_reset(folder, stack_id):
+            """Reset all filters to defaults."""
+            default_sort = app_config.get('scoring', {}).get('default_sort_by', 'score_general')
+            default_order = app_config.get('scoring', {}).get('default_sort_order', 'desc')
+            gal = update_gallery(1, default_sort, default_order, [], [], "", 0.0, 0.0, 0.0, "", "", folder, stack_id)
+            return [[], [], "", 0.0, 0.0, 0.0, "", "", default_sort, default_order, "", 1] + list(gal)
+
+        preset_outputs = [
+            filter_rating, filter_label, filter_keyword,
+            f_min_gen, f_min_aes, f_min_tech,
+            f_date_start, f_date_end,
+            sort_dropdown, order_dropdown,
+            active_chips_html,
+            current_page,
+        ] + [gallery, page_label, current_paths] + detail_outputs
+
+        preset_inputs = [current_folder_state, current_stack_state]
+
+        preset_top_rated.click(fn=_apply_preset_top_rated, inputs=preset_inputs, outputs=preset_outputs)
+        preset_needs_review.click(fn=_apply_preset_needs_review, inputs=preset_inputs, outputs=preset_outputs)
+        preset_has_keywords.click(fn=_apply_preset_has_keywords, inputs=preset_inputs, outputs=preset_outputs)
+        preset_reset_all.click(fn=_apply_preset_reset, inputs=preset_inputs, outputs=preset_outputs)
+
         # Reset Folder
         reset_folder_btn.click(
             fn=reset_folder_filter, 

--- a/modules/ui/tabs/pipeline.py
+++ b/modules/ui/tabs/pipeline.py
@@ -87,6 +87,12 @@ def create_tab(app_config, scoring_runner, tagging_runner, selection_runner, orc
 
             # MAIN DASHBOARD
             with gr.Column(scale=3):
+                # QUICK START PANEL
+                components["quick_start_html"] = gr.HTML(
+                    _build_quick_start_html(None),
+                    elem_classes=["animate-in"],
+                )
+
                 # PANEL: Pipeline Progress
                 with gr.Group(elem_classes=["panel"]):
                     gr.HTML(
@@ -101,6 +107,25 @@ def create_tab(app_config, scoring_runner, tagging_runner, selection_runner, orc
                         with gr.Row(elem_classes=["pipeline-actions"]):
                             components["run_all_btn"] = gr.Button("Run All Pending", variant="primary", elem_classes=["primary-btn"])
                             components["stop_all_btn"] = gr.Button("Stop All", variant="stop", elem_classes=["danger-btn"])
+                        gr.HTML(
+                            "<p class='section-microcopy'>"
+                            "<strong>Run All Pending</strong> \u2014 starts Scoring, Culling, and Keywords for images not yet processed. "
+                            "<strong>Stop All</strong> \u2014 halts the active job; progress is preserved."
+                            "</p>"
+                        )
+                        # Stop All confirmation (hidden until Stop All clicked)
+                        with gr.Row(visible=False, elem_classes=["confirm-row"]) as stop_confirm_row:
+                            gr.HTML(
+                                "<span class='confirm-text'>"
+                                "This will halt all active jobs immediately. The current batch will not complete."
+                                "</span>"
+                            )
+                            stop_confirm_yes = gr.Button("Yes, Stop All", elem_classes=["danger-btn"], size="sm")
+                            stop_confirm_cancel = gr.Button("Cancel", elem_classes=["secondary-btn"], size="sm")
+                        components["stop_confirm_row"] = stop_confirm_row
+                        components["stop_confirm_yes"] = stop_confirm_yes
+                        components["stop_confirm_cancel"] = stop_confirm_cancel
+
                         with gr.Row():
                             components["skip_reason"] = gr.Textbox(label="Skip reason", value="", placeholder="optional reason")
                             components["skip_actor"] = gr.Textbox(label="Actor", value="ui_user", placeholder="who skipped")
@@ -116,7 +141,15 @@ def create_tab(app_config, scoring_runner, tagging_runner, selection_runner, orc
                             with gr.Accordion("Options", open=False, elem_classes=["options-accordion"]):
                                 components["scoring_force"] = gr.Checkbox(label="Force Re-score", value=False)
                             components["scoring_skip_btn"] = gr.Button("Skip Scoring", elem_classes=["danger-btn"])
+                            with gr.Row(visible=False, elem_classes=["confirm-row"]) as scoring_skip_confirm:
+                                gr.HTML("<span class='confirm-text'>Marks Scoring as skipped for this folder.</span>")
+                                scoring_skip_yes = gr.Button("Yes, Skip", elem_classes=["danger-btn"], size="sm")
+                                scoring_skip_cancel = gr.Button("Cancel", elem_classes=["secondary-btn"], size="sm")
+                            components["scoring_skip_confirm"] = scoring_skip_confirm
+                            components["scoring_skip_yes"] = scoring_skip_yes
+                            components["scoring_skip_cancel"] = scoring_skip_cancel
                             components["scoring_retry_btn"] = gr.Button("Retry Skipped", elem_classes=["secondary-btn"])
+                            gr.HTML("<p class='action-help'>Run \u2014 scores unprocessed images. Skip \u2014 marks done without running. Retry \u2014 re-queues skipped.</p>")
 
                         # Culling Card
                         with gr.Column(elem_classes=["phase-card"]):
@@ -125,7 +158,15 @@ def create_tab(app_config, scoring_runner, tagging_runner, selection_runner, orc
                             with gr.Accordion("Options", open=False, elem_classes=["options-accordion"]):
                                 components["culling_force"] = gr.Checkbox(label="Force Re-run", value=False)
                             components["culling_skip_btn"] = gr.Button("Skip Culling", elem_classes=["danger-btn"])
+                            with gr.Row(visible=False, elem_classes=["confirm-row"]) as culling_skip_confirm:
+                                gr.HTML("<span class='confirm-text'>Marks Culling as skipped for this folder.</span>")
+                                culling_skip_yes = gr.Button("Yes, Skip", elem_classes=["danger-btn"], size="sm")
+                                culling_skip_cancel = gr.Button("Cancel", elem_classes=["secondary-btn"], size="sm")
+                            components["culling_skip_confirm"] = culling_skip_confirm
+                            components["culling_skip_yes"] = culling_skip_yes
+                            components["culling_skip_cancel"] = culling_skip_cancel
                             components["culling_retry_btn"] = gr.Button("Retry Skipped", elem_classes=["secondary-btn"])
+                            gr.HTML("<p class='action-help'>Run \u2014 selects picks by composition score. Skip \u2014 marks done. Retry \u2014 re-runs on skipped.</p>")
 
                         # Keywords Card
                         with gr.Column(elem_classes=["phase-card"]):
@@ -135,7 +176,15 @@ def create_tab(app_config, scoring_runner, tagging_runner, selection_runner, orc
                                 components["keywords_overwrite"] = gr.Checkbox(label="Overwrite Existing", value=False)
                                 components["keywords_captions"] = gr.Checkbox(label="Generate Captions", value=False)
                             components["keywords_skip_btn"] = gr.Button("Skip Keywords", elem_classes=["danger-btn"])
+                            with gr.Row(visible=False, elem_classes=["confirm-row"]) as keywords_skip_confirm:
+                                gr.HTML("<span class='confirm-text'>Marks Keywords as skipped for this folder.</span>")
+                                keywords_skip_yes = gr.Button("Yes, Skip", elem_classes=["danger-btn"], size="sm")
+                                keywords_skip_cancel = gr.Button("Cancel", elem_classes=["secondary-btn"], size="sm")
+                            components["keywords_skip_confirm"] = keywords_skip_confirm
+                            components["keywords_skip_yes"] = keywords_skip_yes
+                            components["keywords_skip_cancel"] = keywords_skip_cancel
                             components["keywords_retry_btn"] = gr.Button("Retry Skipped", elem_classes=["secondary-btn"])
+                            gr.HTML("<p class='action-help'>Run \u2014 generates keyword tags. Skip \u2014 skips tagging. Retry \u2014 re-tags skipped.</p>")
 
                 # PANEL: Active Job Monitor
                 with gr.Group(elem_classes=["panel", "monitor-card"]):
@@ -154,7 +203,8 @@ def create_tab(app_config, scoring_runner, tagging_runner, selection_runner, orc
             components["stepper_html"],
             components["scoring_card_html"],
             components["culling_card_html"],
-            components["keywords_card_html"]
+            components["keywords_card_html"],
+            components["quick_start_html"],
         ]
     )
 
@@ -264,26 +314,88 @@ def create_tab(app_config, scoring_runner, tagging_runner, selection_runner, orc
         inputs=[components["selected_path"]],
         outputs=[]
     )
+    # Stop All: two-step confirmation
     components["stop_all_btn"].click(
+        fn=lambda: gr.update(visible=True),
+        inputs=[],
+        outputs=[components["stop_confirm_row"]],
+    )
+    components["stop_confirm_cancel"].click(
+        fn=lambda: gr.update(visible=False),
+        inputs=[],
+        outputs=[components["stop_confirm_row"]],
+    )
+    components["stop_confirm_yes"].click(
         fn=_stop_all,
         inputs=[],
-        outputs=[]
+        outputs=[],
+    ).then(
+        fn=lambda: gr.update(visible=False),
+        inputs=[],
+        outputs=[components["stop_confirm_row"]],
     )
 
+    # Scoring skip: two-step confirmation
     components["scoring_skip_btn"].click(
+        fn=lambda: gr.update(visible=True),
+        inputs=[],
+        outputs=[components["scoring_skip_confirm"]],
+    )
+    components["scoring_skip_cancel"].click(
+        fn=lambda: gr.update(visible=False),
+        inputs=[],
+        outputs=[components["scoring_skip_confirm"]],
+    )
+    components["scoring_skip_yes"].click(
         fn=lambda p, r, a: _skip_phase(p, "scoring", r, a),
         inputs=[components["selected_path"], components["skip_reason"], components["skip_actor"]],
-        outputs=[]
+        outputs=[],
+    ).then(
+        fn=lambda: gr.update(visible=False),
+        inputs=[],
+        outputs=[components["scoring_skip_confirm"]],
     )
+
+    # Culling skip: two-step confirmation
     components["culling_skip_btn"].click(
+        fn=lambda: gr.update(visible=True),
+        inputs=[],
+        outputs=[components["culling_skip_confirm"]],
+    )
+    components["culling_skip_cancel"].click(
+        fn=lambda: gr.update(visible=False),
+        inputs=[],
+        outputs=[components["culling_skip_confirm"]],
+    )
+    components["culling_skip_yes"].click(
         fn=lambda p, r, a: _skip_phase(p, "culling", r, a),
         inputs=[components["selected_path"], components["skip_reason"], components["skip_actor"]],
-        outputs=[]
+        outputs=[],
+    ).then(
+        fn=lambda: gr.update(visible=False),
+        inputs=[],
+        outputs=[components["culling_skip_confirm"]],
     )
+
+    # Keywords skip: two-step confirmation
     components["keywords_skip_btn"].click(
+        fn=lambda: gr.update(visible=True),
+        inputs=[],
+        outputs=[components["keywords_skip_confirm"]],
+    )
+    components["keywords_skip_cancel"].click(
+        fn=lambda: gr.update(visible=False),
+        inputs=[],
+        outputs=[components["keywords_skip_confirm"]],
+    )
+    components["keywords_skip_yes"].click(
         fn=lambda p, r, a: _skip_phase(p, "keywords", r, a),
         inputs=[components["selected_path"], components["skip_reason"], components["skip_actor"]],
-        outputs=[]
+        outputs=[],
+    ).then(
+        fn=lambda: gr.update(visible=False),
+        inputs=[],
+        outputs=[components["keywords_skip_confirm"]],
     )
     components["scoring_retry_btn"].click(
         fn=lambda p: _retry_phase(p, "scoring"),
@@ -313,6 +425,7 @@ def _update_folder_selection(folder_path: str):
             _build_phase_card_html("SCORING", "Not Started", 0, 0),
             _build_phase_card_html("CULLING", "Not Started", 0, 0),
             _build_phase_card_html("KEYWORDS", "Not Started", 0, 0),
+            _build_quick_start_html(None),
         )
 
     summary_by_code, total_count = _parse_phase_summary(folder_path)
@@ -327,6 +440,7 @@ def _update_folder_selection(folder_path: str):
         _build_phase_card_html("SCORING", sc.get("status", "not_started"), sc.get("done_count", 0), total_count),
         _build_phase_card_html("CULLING", cu.get("status", "not_started"), cu.get("done_count", 0), total_count),
         _build_phase_card_html("KEYWORDS", kw.get("status", "not_started"), kw.get("done_count", 0), total_count),
+        _build_quick_start_html(folder_path, summary_by_code),
     )
 
 
@@ -353,11 +467,11 @@ def get_status_update(scoring_runner, tagging_runner, selection_runner, orchestr
     not_running = not is_running
 
     # Rebuild stepper/cards from current folder state
-    res_summary, res_stepper, res_sc, res_cu, res_kw = _update_folder_selection(selected_folder)
+    res_summary, res_stepper, res_sc, res_cu, res_kw, res_qs = _update_folder_selection(selected_folder)
 
     # Return order must match monitor_outputs in app.py:
     # stepper, scoring_card, culling_card, keywords_card,
-    # monitor, console, run_all, stop_all, sc_run, cu_run, kw_run
+    # monitor, console, run_all, stop_all, sc_run, cu_run, kw_run, quick_start
     result = (
         res_stepper,
         res_sc,
@@ -370,12 +484,13 @@ def get_status_update(scoring_runner, tagging_runner, selection_runner, orchestr
         gr.update(interactive=not_running),  # scoring_run
         gr.update(interactive=not_running),  # culling_run
         gr.update(interactive=not_running),  # keywords_run
+        res_qs,                              # quick_start
     )
 
     # Skip SSE push if nothing changed since last tick
     cache_key = (res_stepper, res_sc, res_cu, res_kw, monitor_html, console_out, is_running)
     if cache_key == _last_status_cache["state"]:
-        return tuple(gr.skip() for _ in range(11))
+        return tuple(gr.skip() for _ in range(12))
     _last_status_cache["state"] = cache_key
 
     return result
@@ -396,6 +511,58 @@ def _unified_monitor_status(scoring_runner, tagging_runner, selection_runner):
         if is_running:
             return True, name, msg, cur, tot, log
     return False, "", "", 0, 0, ""
+
+
+def _build_quick_start_html(folder_path, summary_by_code=None, is_running=False):
+    """Context-aware Quick Start guide: 1. Select folder → 2. Run All → 3. Gallery."""
+    summary_by_code = summary_by_code or {}
+
+    if not folder_path:
+        steps = [
+            ("current", "Select a folder from the tree"),
+            ("", "Run all pending pipeline phases"),
+            ("", "Open Gallery and review results"),
+        ]
+    elif is_running:
+        steps = [
+            ("done", "Folder selected"),
+            ("current", "Pipeline is running\u2026"),
+            ("", "Open Gallery and review results"),
+        ]
+    else:
+        pending = any(
+            summary_by_code.get(c, {}).get("status") not in ("done", "skipped")
+            for c in ("scoring", "culling", "keywords")
+        )
+        if pending:
+            steps = [
+                ("done", "Folder selected"),
+                ("current", "Run All Pending to process images"),
+                ("", "Open Gallery and review results"),
+            ]
+        else:
+            steps = [
+                ("done", "Folder selected"),
+                ("done", "All phases complete"),
+                ("current", "Open Gallery and review results"),
+            ]
+
+    parts = [
+        "<div class='quick-start-panel'>",
+        "<strong style='font-size:0.9rem;color:var(--text-primary)'>Quick Start</strong>",
+        "<div class='quick-start-steps'>",
+    ]
+    for i, (state, label) in enumerate(steps):
+        parts.append(
+            f"<div class='qs-step {state}' role='listitem'>"
+            f"<span class='qs-step-num'>{i + 1}</span>"
+            f"<span>{label}</span>"
+            f"</div>"
+        )
+        if i < len(steps) - 1:
+            parts.append("<span class='qs-arrow' aria-hidden='true'>\u203a</span>")
+    parts.append("</div></div>")
+    return "".join(parts)
 
 
 def _build_folder_summary(path, count):
@@ -463,20 +630,34 @@ _STATUS_LABELS = {
 }
 
 
+_STATUS_BADGE_CLASS = {
+    "done": "success",
+    "partial": "info",
+    "running": "info",
+    "failed": "error",
+    "skipped": "warning",
+    "not_started": "",
+}
+
+
 def _build_phase_card_html(title, status, done, total):
     pct = (done / total * 100) if total > 0 else 0
     initial = title[0]
     status_label = _STATUS_LABELS.get(status, status.replace("_", " ").title())
+    badge_class = _STATUS_BADGE_CLASS.get(status, "")
+    badge_cls = f"phase-status status-badge {badge_class}" if badge_class else "phase-status"
     return f"""
-    <div class="phase-head">
-      <div class="phase-title">
-        <div class="phase-icon">{initial}</div>
-        {title}
+    <div role="region" aria-label="{title} phase: {status_label}">
+      <div class="phase-head">
+        <div class="phase-title">
+          <div class="phase-icon">{initial}</div>
+          {title}
+        </div>
+        <div class="{badge_cls}">{status_label}</div>
       </div>
-      <div class="phase-status">{status_label}</div>
+      <div class="phase-stats">{done}/{total} images processed</div>
+      <div class="progress"><div class="progress-fill" style="width: {pct:.1f}%;"></div></div>
     </div>
-    <div class="phase-stats">{done}/{total} images processed</div>
-    <div class="progress"><div class="progress-fill" style="width: {pct:.1f}%;"></div></div>
     """
 
 
@@ -509,36 +690,36 @@ def _build_pipeline_stepper_html(folder_path, summary_by_code=None, total=0):
         return ""
 
     return f"""
-    <div class="stepper">
-      <div class="step {get_state(idx, total)}">
+    <div class="stepper" role="list" aria-label="Pipeline progress">
+      <div class="step {get_state(idx, total)}" role="listitem" aria-label="Index: {idx_done} of {total}">
         <div class="step-dot">1</div>
         <div class="step-label">Index</div>
         <div class="step-count">{idx_done} / {total}</div>
       </div>
-      <div class="connector {get_state(idx, total)}"></div>
+      <div class="connector {get_state(idx, total)}" aria-hidden="true"></div>
 
-      <div class="step {get_state(met, total)}">
+      <div class="step {get_state(met, total)}" role="listitem" aria-label="Metadata: {met_done} of {total}">
         <div class="step-dot">2</div>
         <div class="step-label">Meta</div>
         <div class="step-count">{met_done} / {total}</div>
       </div>
-      <div class="connector {get_state(sco, total)}"></div>
+      <div class="connector {get_state(sco, total)}" aria-hidden="true"></div>
 
-      <div class="step {get_state(sco, total)}">
+      <div class="step {get_state(sco, total)}" role="listitem" aria-label="Scoring: {sco_done} of {total}">
         <div class="step-dot">3</div>
         <div class="step-label">Scoring</div>
         <div class="step-count">{sco_done} / {total}</div>
       </div>
-      <div class="connector {get_state(cul, total)}"></div>
+      <div class="connector {get_state(cul, total)}" aria-hidden="true"></div>
 
-      <div class="step {get_state(cul, total)}">
+      <div class="step {get_state(cul, total)}" role="listitem" aria-label="Culling: {cul_done} of {total}">
         <div class="step-dot">4</div>
         <div class="step-label">Culling</div>
         <div class="step-count">{cul_done} / {total}</div>
       </div>
-      <div class="connector {get_state(key, total)}"></div>
+      <div class="connector {get_state(key, total)}" aria-hidden="true"></div>
 
-      <div class="step {get_state(key, total)}">
+      <div class="step {get_state(key, total)}" role="listitem" aria-label="Keywords: {key_done} of {total}">
         <div class="step-dot">5</div>
         <div class="step-label">Keywords</div>
         <div class="step-count">{key_done} / {total}</div>


### PR DESCRIPTION
### Motivation
- Advance Phase 2 DB migration by ensuring legacy metadata writes keep the new normalized keyword tables (`KEYWORDS_DIM` / `IMAGE_KEYWORDS`) in sync so dual-write state stays consistent.
- Move read paths for tag propagation toward the normalized schema to improve query performance and correctness while retaining legacy fallbacks during the transition.
- Keep backward compatibility so existing callers that update `images.keywords` still populate normalized tables.

### Description
- Call site sync: `update_image_metadata()` now resolves the `image_id` for the updated `file_path` and invokes `_sync_image_keywords()` after updating the legacy `images.keywords` column to perform Phase 2 dual-write.
- Read path changes: `get_images_for_tag_propagation()` now prefers normalized data by selecting untagged images that have no rows in `image_keywords` and by emitting a keyword CSV assembled from `image_keywords`/`keywords_dim` using `LIST(...)` with a `COALESCE(..., i.keywords)` fallback to legacy `images.keywords`.
- Query scoping: folder filtering is preserved by aliasing `images` as `i` and updating the `folder_id` reference so the new queries remain compatible with existing `folder_path` scoping.

### Testing
- `python -m py_compile modules/db.py` completed successfully to validate syntax.
- `pytest -q tests/test_init_db.py tests/test_ddl.py` could not run to completion in this environment due to `ModuleNotFoundError: No module named 'firebird'` (test collection failed); tests should be re-run in an environment with the `firebird-driver` and Firebird client available.
- Manual sanity: updated SQL constructs were validated by static review and local `py_compile` to ensure no syntax regressions in `modules/db.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2c2c3d2f8832390769599cc273836)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes write and read SQL paths during an in-progress schema migration; incorrect keyword syncing or query logic could impact tag propagation results or leave normalized tables out of sync.
> 
> **Overview**
> Advances the keywords schema migration by **dual-writing**: `update_image_metadata()` now looks up the image id after updating `images.keywords` and calls `_sync_image_keywords()` to keep `image_keywords`/`keywords_dim` synchronized.
> 
> Updates `get_images_for_tag_propagation()` to **prefer normalized keyword data**: untagged images are selected via `NOT EXISTS` on `image_keywords`, and tagged images emit a keyword CSV assembled from `image_keywords`+`keywords_dim` with a `COALESCE(..., i.keywords)` legacy fallback, while preserving optional folder scoping via an `images i` alias.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e9f09c04914fe309d929a4331753a8e580f097a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->