### PR TITLE
test: add regression coverage for scoring phase gating

### DIFF
--- a/tests/test_pipeline_phase_gating.py
+++ b/tests/test_pipeline_phase_gating.py
@@ -1,0 +1,34 @@
+import queue
+import threading
+
+from modules.phases import PhaseCode
+from modules.pipeline import ImageJob, ScoringWorker
+
+
+class _DummyScorer:
+    VERSION = "test"
+
+    def preprocess_image(self, *_args, **_kwargs):
+        raise AssertionError("preprocess_image should not be called when scoring phase is not targeted")
+
+    def run_all_models(self, *_args, **_kwargs):
+        raise AssertionError("run_all_models should not be called when scoring phase is not targeted")
+
+
+def test_scoring_worker_skips_when_scoring_not_targeted():
+    input_q = queue.Queue()
+    output_q = queue.Queue()
+    stop_event = threading.Event()
+    worker = ScoringWorker(input_q, output_q, stop_event, _DummyScorer())
+
+    job = ImageJob(
+        image_path="D:/does/not/matter.jpg",
+        job_id=123,
+        target_phases=[PhaseCode.INDEXING.value, PhaseCode.METADATA.value],
+    )
+
+    worker.process(job)
+
+    processed = output_q.get_nowait()
+    assert processed is job
+    assert processed.status == "skipped"


### PR DESCRIPTION
## Summary
- add a regression test for ScoringWorker.process phase gating
- verify jobs with 	arget_phases excluding scoring are marked skipped
- ensure inference entrypoints are not invoked in that scenario

## Context
This addresses the review finding about scoring worker phase gating by preventing regressions with explicit test coverage.

## Testing
- not run locally in this environment (Python launcher/runtime is unavailable here)
