### PR TITLE
Add TODO checkbox metrics script and report reproducibility note

### DIFF
--- a/docs/reports/project-reviews/UNFINISHED_BUSINESS_EVALUATION_2026-03-14.md
+++ b/docs/reports/project-reviews/UNFINISHED_BUSINESS_EVALUATION_2026-03-14.md
@@ -20,15 +20,23 @@ The project has a healthy backlog structure, but execution is blocked less by un
 
 Checkbox count from TODO files:
 
-- `TODO.md`: **46 open**, 2 done
-- `docs/project/TODO.md`: **27 open**, 5 done
-- `docs/plans/embedding/TODO.md`: **9 open**, 0 done
-- `docs/reference/api/TODO.md`: **6 open**, 0 done
+- `TODO.md`: **46 open**, 2 done (total 48)
+- `docs/project/TODO.md`: **27 open**, 5 done (total 32)
+- `docs/plans/embedding/TODO.md`: **9 open**, 0 done (total 9)
+- `docs/reference/api/TODO.md`: **6 open**, 0 done (total 6)
 
 Interpretation:
 
 - The root TODO is an umbrella list and correctly reflects broad, mostly-unfinished roadmap work.
 - The specialized API and Embedding TODOs show **no completed items**, suggesting those tracks are queued but not actively in-flight.
+
+## Reproducibility
+
+These checkbox totals are reproducible via:
+
+- `python scripts/analysis/todo_metrics.py`
+
+The report values above are copied directly from this script output.
 
 ## Unfinished Business by Risk Category
 

--- a/scripts/analysis/todo_metrics.py
+++ b/scripts/analysis/todo_metrics.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Compute checkbox metrics across project TODO files.
+
+Usage:
+    python scripts/analysis/todo_metrics.py
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+TARGET_FILES = (
+    Path("TODO.md"),
+    Path("docs/project/TODO.md"),
+    Path("docs/plans/embedding/TODO.md"),
+    Path("docs/reference/api/TODO.md"),
+)
+
+CHECKBOX_PATTERN = re.compile(r"^\s*-\s*\[([ xX])\]", re.MULTILINE)
+
+
+def count_checkboxes(path: Path) -> tuple[int, int]:
+    text = path.read_text(encoding="utf-8")
+    open_count = 0
+    done_count = 0
+
+    for match in CHECKBOX_PATTERN.finditer(text):
+        marker = match.group(1)
+        if marker.lower() == "x":
+            done_count += 1
+        else:
+            open_count += 1
+
+    return open_count, done_count
+
+
+def main() -> None:
+    for target in TARGET_FILES:
+        open_count, done_count = count_checkboxes(target)
+        total = open_count + done_count
+        print(f"{target}: open={open_count}, done={done_count}, total={total}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation

- Provide a deterministic, easy-to-run way to measure open/done checkbox counts across the project's TODO files so report values can be reproduced. 
- Make the project review report explicitly reproducible by referencing an automated script rather than embedding ad-hoc counts.

### Description

- Add `scripts/analysis/todo_metrics.py`, which scans `TODO.md`, `docs/project/TODO.md`, `docs/plans/embedding/TODO.md`, and `docs/reference/api/TODO.md` and parses markdown checkboxes using a case-insensitive regex for `- [ ]` and `- [x]`.
- The script prints deterministic `open`, `done`, and `total` counts per file and includes a short usage example in the module docstring: `python scripts/analysis/todo_metrics.py`.
- Update `docs/reports/project-reviews/UNFINISHED_BUSINESS_EVALUATION_2026-03-14.md` to add a **Reproducibility** section referencing the script and adjust the quantitative snapshot to include totals that match the script output exactly.

### Testing

- Ran `python scripts/analysis/todo_metrics.py` and verified output: `TODO.md: open=46, done=2, total=48`; `docs/project/TODO.md: open=27, done=5, total=32`; `docs/plans/embedding/TODO.md: open=9, done=0, total=9`; `docs/reference/api/TODO.md: open=6, done=0, total=6`.
- Confirmed the report `docs/reports/project-reviews/UNFINISHED_BUSINESS_EVALUATION_2026-03-14.md` now contains the reproducibility note and the quantitative snapshot values that match the script output exactly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5932c543c83239987ae1824954c7d)