### PR TITLE
docs: clarify assumptions, limits, and non-goals in unfinished business report

### DIFF
--- a/docs/reports/project-reviews/UNFINISHED_BUSINESS_EVALUATION_2026-03-14.md
+++ b/docs/reports/project-reviews/UNFINISHED_BUSINESS_EVALUATION_2026-03-14.md
@@ -1,5 +1,16 @@
 # Unfinished Business & TODO Evaluation (2026-03-14)
 
+## Assumptions & Limits
+
+- This analysis is based on static TODO/backlog documentation, not direct execution traces.
+- No runtime or system-health execution evidence was used to produce this report.
+- Recommendations here are prioritization guidance and do not confirm implementation status.
+
+## Non-Goals
+
+- This document does not replace sprint planning artifacts.
+- This document does not replace cross-repo contract governance documentation.
+
 ## Scope Reviewed
 
 - Root consolidated backlog: `TODO.md`


### PR DESCRIPTION
### Motivation

- Make the report's scope and evidentiary limits explicit to avoid misinterpreting prioritization recommendations as deployment or runtime verification results.
- Prevent the document from being used as a substitute for sprint planning or cross-repo contract governance artifacts.

### Description

- Inserted an `## Assumptions & Limits` section near the top of `docs/reports/project-reviews/UNFINISHED_BUSINESS_EVALUATION_2026-03-14.md` stating the analysis is based on static TODO/backlog docs, excludes runtime/system-health evidence, and that recommendations are prioritization guidance only.
- Added an `## Non-Goals` section clarifying the document does not replace sprint planning artifacts or cross-repo contract governance documentation.
- Changes were applied to the target markdown file and committed with the message `docs: add assumptions, limits, and non-goals to unfinished business report`.

### Testing

- Verified the file content and placement with `nl -ba docs/reports/project-reviews/UNFINISHED_BUSINESS_EVALUATION_2026-03-14.md | sed -n '1,60p'`, which succeeded.
- Confirmed repository state with `git status --short`, which showed the modified file as staged/committed as expected.
- Created the commit with `git commit -m "docs: add assumptions, limits, and non-goals to unfinished business report"`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5932e8cf883239f41a231fb322f48)