### PR TITLE
docs: add Gradio UX/UI spec for Electron migration

### DIFF
--- a/docs/technical/GRADIO_UI_UX_SPEC_FOR_ELECTRON_MIGRATION.md
+++ b/docs/technical/GRADIO_UI_UX_SPEC_FOR_ELECTRON_MIGRATION.md
@@ -1,0 +1,262 @@
+# Gradio WebUI UX/UI Specification (Current State)
+
+This document captures the **implemented** UX/UI behavior of the current Gradio WebUI so it can be migrated to an Electron app with parity.
+
+## 1) Application Shell & Information Architecture
+
+- App root is a Gradio `Blocks` app titled **Image Scoring WebUI**, mounted by FastAPI at `/app` (root redirects to `/app`).
+- Top-level IA is 3 tabs:
+  - **Pipeline** (`id="pipeline"`)
+  - **Gallery** (`id="gallery"`) — initially hidden, opened contextually by navigation.
+  - **Settings** (`id="settings"`)
+- Global states shared across tabs:
+  - `current_page` (gallery pagination)
+  - `current_paths` (raw file paths for current gallery page)
+  - `image_details` (selected image record)
+  - `current_folder_state` (folder context from tree navigation)
+  - `current_stack_state` (stack context)
+- A global timer polls status every 2 seconds to refresh pipeline progress and monitor widgets.
+
+## 2) Visual Design System (Dark Theme)
+
+- Custom CSS defines a dark theme token set:
+  - Backgrounds: `--bg-primary`, `--bg-secondary`, `--bg-tertiary`, `--bg-elevated`, `--bg-input`, `--bg-console`
+  - Text: `--text-primary`, `--text-secondary`, `--text-muted`
+- Styling emphasizes card/panel UI, badges, subtle hover states, custom scrollbars, and status color semantics (success/info/warning/error).
+- Hidden textboxes are deliberately rendered in DOM (`visible=True`) and visually hidden via `.hidden-path-storage` for JS interop/state sync.
+
+## 3) Tab: Pipeline (Primary Workflow Surface)
+
+## 3.1 Layout
+
+Two-column layout:
+
+1. **Sidebar** (left)
+   - Section title: “Folders”
+   - `Refresh` button
+   - Folder tree HTML viewer
+   - Hidden textbox `folder_tree_selection` used for JS-driven selection updates
+   - Folder summary card (selected path + image count)
+
+2. **Main dashboard** (right)
+   - Quick Start panel (context-aware step hints)
+   - Pipeline Progress panel (stepper + Run/Stop global controls)
+   - Per-phase card grid (Scoring, Culling, Keywords)
+   - Active Job Monitor panel + collapsible console output
+
+## 3.2 Folder Tree UX
+
+- Tree is generated from cached DB folder paths, normalized to local platform path style.
+- Click on a tree node runs `selectFolder(event, path)` JS:
+  - clears previous node highlighting
+  - applies selected style to clicked node
+  - updates hidden Gradio textbox value
+  - dispatches `input` event to trigger Python `.change()` callback
+- Refresh invalidates folder phase aggregate cache and rebuilds tree + selection-dependent panels.
+
+## 3.3 Quick Start Behavior
+
+Quick Start is a dynamic 3-step guide with step states (`current`, `done`, inactive):
+
+1. Select folder
+2. Run pending pipeline phases
+3. Open Gallery for review
+
+It changes based on:
+- no folder selected
+- pipeline currently running
+- pending phases still incomplete
+- all phases complete/skipped
+
+## 3.4 Pipeline Progress & Monitor
+
+- 5-step progress stepper: **Index → Meta → Scoring → Culling → Keywords**.
+- Each step displays counts (`done / total`) and state class (done/running/idle).
+- A monitor card shows active runner progress (message, counts, progress bar) plus queue preview.
+- If idle, monitor shows no-active-jobs plus job recovery summary and queue snapshot.
+- UI is polled every 2 seconds; SSE updates are skipped when content hash is unchanged to reduce redundant UI pushes.
+
+## 3.5 Phase Cards & Controls
+
+Per phase (Scoring/Culling/Keywords):
+- Status card with badge and progress bar.
+- Primary action button (`Run ...`).
+- Phase options in accordions:
+  - Scoring: `Force Re-score`
+  - Culling: `Force Re-scan`
+  - Keywords: `Overwrite Existing`, `Generate Captions`
+- `Skip ...` with two-step confirmation row.
+- `Retry Skipped` action.
+- Help/microcopy explaining Run/Skip/Retry semantics.
+
+Global actions:
+- `Run All Pending` starts orchestrator.
+- `Stop All` has two-step confirmation and stops orchestrator + all runners.
+
+Safety/interaction rules:
+- While a job is running:
+  - run buttons become non-interactive
+  - stop button becomes interactive
+- When idle, inverse button interactivity applies.
+
+## 4) Tab: Gallery (Review & Curation Surface)
+
+## 4.1 Visibility & Context
+
+- Tab declared with `visible=False`; opened programmatically via navigation from folder/stack context.
+- Context bar (when filtering by folder) shows selected folder card and `✕ Clear Filter` button.
+
+## 4.2 Header Controls
+
+- `🔄 Refresh` button
+- Sort controls:
+  - field dropdown (Date Added, Capture Date EXIF, ID, General, Technical, Aesthetic, SPAQ, AVA, KonIQ, PaQ2PiQ, LIQE)
+  - order dropdown (Highest First / Lowest First)
+
+## 4.3 Presets & Active Chips
+
+- Preset quick buttons:
+  - Top Rated
+  - Needs Review
+  - Has Keywords
+  - Reset All
+- Active filters are summarized into non-editable chips strip (rating, label, keyword, min scores, date range).
+
+## 4.4 Filter Panel
+
+Accordion: “🔍 Filters & Search” containing:
+- Rating checkbox group (1..5)
+- Color label checkbox group (Red/Yellow/Green/Blue/Purple/None)
+- Min score sliders (General/Aesthetic/Technical)
+- Date textboxes (`From Date`, `To Date`, format hint `YYYY-MM-DD`)
+- Keyword search textbox
+
+Filter behavior:
+- Any filter change resets to page 1 and refreshes results.
+- Slider/filter updates use `trigger_mode="always_last"` for debounce-like behavior.
+
+## 4.5 Export Panel
+
+Accordion: “📤 Export Data”:
+- Format dropdown: JSON / CSV / XLSX
+- `Export All Images` button
+- hidden status output area for success/failure
+- advanced options include column selection + template operations (save/load/delete) and folder/scope-aware export behavior.
+
+## 4.6 Pagination
+
+- First/Prev/Next/Last buttons (`⏮ ◀ ▶ ⏭`)
+- Page indicator button (non-interactive)
+- Pagination clamps to valid page range after operations like deletion.
+
+## 4.7 Main Content Split
+
+- Left: Gallery grid (`gr.Gallery`) with 5 columns, height 600, `object_fit="cover"`, preview enabled.
+- Right: Details panel (min width 320) containing:
+  - Summary markdown
+  - Score labels: General, Weighted, Models
+  - Culling status HTML area
+  - Accordion “Image Details”:
+    - Title, Description (read-only)
+    - Keyword chips (`HighlightedText`) with custom high-contrast color map
+    - Rating & Label dropdowns (read-only in current flow)
+    - Save button/status (currently hidden unless enabled by flow)
+  - Action buttons:
+    - Fix Data
+    - Re-Run Scoring
+    - Re-Run Keywords
+    - Find Similar
+    - Remove from DB
+    - Delete NEF (mostly hidden by default)
+  - Similar Images accordion with secondary gallery + status text
+  - Status textboxes (fix/delete)
+  - Hidden textbox `gallery-selected-path` for JS features (full-res/raw preview path retrieval)
+
+## 4.8 Gallery Item Interaction
+
+- Selecting gallery item populates detail outputs (metadata + scores + state).
+- `Find Similar` runs visual similarity search around selected image.
+- `Remove from DB` deletes DB record only and refreshes gallery.
+- `Delete NEF` attempts file delete (NEF + thumb) then DB cleanup.
+- `Fix Data` and rerun actions trigger runner wrappers for selected image.
+
+## 5) Tab: Settings (Configuration Surface)
+
+Single advanced settings page using collapsible sections:
+
+1. **Scoring Configuration**
+   - Force re-score default
+   - Default sort field/order
+
+2. **Processing Configuration**
+   - prep/scoring/result queue sizes
+   - clustering batch size
+
+3. **Stacks & Culling (Legacy)**
+   - default similarity threshold
+   - default time gap
+   - force rescan default
+   - auto export default
+
+4. **UI Preferences**
+   - gallery page size
+   - default export format
+
+5. **Tagging Configuration**
+   - overwrite existing default
+   - generate captions default
+   - max BLIP tokens
+   - CLIP model selection
+
+Actions:
+- `💾 Save All Configuration` persists to `config.json` sections.
+- `🔄 Reset to Defaults` restores predefined defaults into form controls.
+- Status textbox displays success/error outcome.
+
+## 6) Navigation & Cross-Tab UX Contracts
+
+- `open_folder_in_gallery(...)`:
+  - switches tab to `gallery`
+  - applies folder state + filters + resets to page 1
+  - shows folder context bar with folder name + parent path
+- Clearing folder context hides context bar and returns to global gallery scope.
+- `open_folder_in_pipeline(folder)` switches tab to pipeline and updates folder selection state.
+
+## 7) JavaScript-Dependent UX Behaviors
+
+Current Gradio UI relies on injected JS for critical UX:
+
+- folder tree click-to-select (`window.selectFolder`)
+- robust gallery close/back-to-grid helper for lightbox preview
+- full-resolution / raw preview path resolution with fallbacks
+- DOM queries resilient to Gradio-generated dynamic IDs
+
+Migration implication: these should become first-class renderer logic in Electron (not brittle DOM scraping).
+
+## 8) Accessibility & Interaction Notes (Current State)
+
+- Some generated HTML includes ARIA roles/labels (e.g., stepper list, phase regions).
+- Many interactions remain button/visual-first; keyboard-first and screen-reader semantics are partial.
+- Hidden state fields are implementation-driven; should become explicit state in Electron architecture.
+
+## 9) Functional UX Invariants to Preserve in Electron
+
+1. Pipeline-first workflow with folder selection and explicit phase control.
+2. Real-time job visibility with actionable stop/retry/skip controls.
+3. Rich gallery filtering + presets + chips + pagination.
+4. Side-panel detail context and per-image remediation actions.
+5. Folder-context navigation between pipeline and gallery.
+6. Configurability through a persisted advanced settings UI.
+7. Dark theme with strong status affordances and high scanability.
+
+## 10) Suggested Electron Migration Boundaries (Spec-Level)
+
+- **Shell**: Native menu/window chrome + router tabs/panes mirroring Pipeline/Gallery/Settings.
+- **State model**: Replace hidden textbox/DOM bridges with explicit store state.
+- **Polling/events**: Keep 2s status cadence initially; later switch monitor areas to websocket/event-driven updates.
+- **Component mapping**:
+  - Pipeline cards/stepper/monitor => reusable status widgets
+  - Gallery grid + side panel => split-view module
+  - Settings accordions => schema-driven form sections
+- **Parity-first phase**: Keep labels/ordering/defaults/actions equivalent before introducing UX redesign.
+


### PR DESCRIPTION
### Motivation
- Capture the implemented WebUI behavior so migration to an Electron app can be planned and executed with feature parity.
- Reduce migration risk by documenting the Gradio state model, JS dependencies, and UX invariants that must be preserved.
- Provide a single reference mapping Gradio components and interactions to target Electron components for engineering and design work.

### Description
- Add `docs/technical/GRADIO_UI_UX_SPEC_FOR_ELECTRON_MIGRATION.md` which describes the application shell, shared state, and top-level IA (tabs: `Pipeline`, `Gallery`, `Settings`).
- Document the `Pipeline` tab including the folder tree selection mechanics, quick-start guidance, 5-step pipeline stepper, phase cards, monitor, and run/stop/skip/retry interaction rules.
- Document the `Gallery` tab including sort/filter model, presets, active chips, export UX, pagination, gallery grid, details side-panel, and per-image actions such as `Find Similar`, `Remove from DB`, and `Delete NEF`.
- Record JS-dependent behaviors, accessibility notes, functional UX invariants to preserve, and suggested Electron migration boundaries and component mappings.

### Testing
- Ran repository diff/checks to ensure no whitespace or diff-errors and confirmed the new spec file is present and readable in the codebase.
- Opened and reviewed the created `docs/technical/GRADIO_UI_UX_SPEC_FOR_ELECTRON_MIGRATION.md` to verify key sections (Pipeline, Gallery, Settings, migration guidance) are included and accurate.
- No unit or integration tests were required because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b63779a74083238b9004ab762407ed)