### PR TITLE
Add /api/similarity alias endpoints for similar/duplicates/outliers

### DIFF
--- a/modules/api.py
+++ b/modules/api.py
@@ -1852,6 +1852,57 @@ def create_api_router() -> APIRouter:
             return ApiResponse(success=False, message=str(e))
 
     @router.get(
+        "/similarity/similar",
+        summary="Find similar images (similarity namespace)",
+        description="Alias endpoint for GET /api/similar under the /api/similarity namespace.",
+    )
+    def get_similar_images_similarity_namespace(
+        image_id: int = Query(..., description="ID of the query image"),
+        limit: int = Query(20, ge=1, le=100, description="Maximum number of results"),
+        folder_path: Optional[str] = Query(None, description="Scope search to folder"),
+        min_similarity: Optional[float] = Query(0.80, ge=0.0, le=1.0, description="Minimum similarity threshold"),
+    ):
+        """Compatibility alias for similarity search under /api/similarity/similar."""
+        return get_similar_images(
+            image_id=image_id,
+            limit=limit,
+            folder_path=folder_path,
+            min_similarity=min_similarity,
+        )
+
+    @router.get(
+        "/similarity/duplicates",
+        summary="Find near-duplicate images (similarity namespace)",
+        description="Detect likely duplicate image pairs using embedding cosine similarity.",
+    )
+    def get_duplicates_similarity_namespace(
+        threshold: Optional[float] = Query(
+            None,
+            ge=0.0,
+            le=1.0,
+            description="Similarity threshold. Uses config default when omitted.",
+        ),
+        folder_path: Optional[str] = Query(None, description="Restrict duplicate detection to a folder"),
+        limit: int = Query(1000, ge=1, le=10000, description="Maximum duplicate pairs to return"),
+    ):
+        """GET alias for duplicate detection under /api/similarity namespace."""
+        from modules import similar_search
+
+        try:
+            duplicates = similar_search.find_near_duplicates(
+                threshold=threshold,
+                folder_path=folder_path,
+                limit=limit,
+            )
+            return {
+                "duplicates": duplicates,
+                "count": len(duplicates),
+            }
+        except Exception as exc:
+            logger.error("Error in get_duplicates_similarity_namespace: %s", exc)
+            raise HTTPException(status_code=500, detail=str(exc))
+
+    @router.get(
         "/outliers",
         response_model=OutlierResponse,
         summary="Find visual outliers in a folder",
@@ -1893,6 +1944,26 @@ def create_api_router() -> APIRouter:
         except Exception as exc:
             logger.error("Error in get_outliers for %s: %s", folder_path, exc)
             raise HTTPException(status_code=500, detail=str(exc))
+
+    @router.get(
+        "/similarity/outliers",
+        response_model=OutlierResponse,
+        summary="Find visual outliers (similarity namespace)",
+        description="Alias endpoint for GET /api/outliers under the /api/similarity namespace.",
+    )
+    def get_outliers_similarity_namespace(
+        folder_path: str = Query(..., description="Folder path to analyze"),
+        z_threshold: Optional[float] = Query(None, ge=0.0, description="Outlier z-score threshold"),
+        k: Optional[int] = Query(None, ge=1, description="Top-K neighbors used for local density"),
+        limit: int = Query(100, ge=1, le=1000, description="Maximum outlier results to return"),
+    ):
+        """Compatibility alias for outlier search under /api/similarity/outliers."""
+        return get_outliers(
+            folder_path=folder_path,
+            z_threshold=z_threshold,
+            k=k,
+            limit=limit,
+        )
 
     # ========== Clustering Endpoints ==========
 

--- a/tests/test_api_queue.py
+++ b/tests/test_api_queue.py
@@ -224,3 +224,124 @@ def test_outliers_endpoint_returns_500_on_unexpected_exception(monkeypatch):
 
     assert response.status_code == 500
     assert response.json()["detail"] == "unexpected failure"
+
+
+def test_similarity_similar_alias_matches_existing_contract(monkeypatch):
+    from modules import similar_search
+
+    monkeypatch.setattr(db, "get_db", lambda: _FakeConn(found=True))
+
+    expected_results = [
+        {"image_id": 2, "file_path": "/photos/2.jpg", "similarity": 0.93},
+        {"image_id": 3, "file_path": "/photos/3.jpg", "similarity": 0.90},
+    ]
+
+    def fake_search_similar_images(example_image_id, limit, folder_path, min_similarity):
+        assert example_image_id == 1
+        assert limit == 5
+        assert folder_path == "/photos"
+        assert min_similarity == 0.9
+        return expected_results
+
+    monkeypatch.setattr(similar_search, "search_similar_images", fake_search_similar_images)
+
+    with _build_client() as client:
+        response = client.get(
+            "/api/similarity/similar",
+            params={"image_id": 1, "limit": 5, "folder_path": "/photos", "min_similarity": 0.9},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "query_image_id": 1,
+        "results": expected_results,
+        "count": 2,
+    }
+
+
+def test_similarity_duplicates_alias_returns_count(monkeypatch):
+    from modules import similar_search
+
+    expected_duplicates = [
+        {"a_image_id": 1, "b_image_id": 2, "similarity": 0.99},
+        {"a_image_id": 3, "b_image_id": 4, "similarity": 0.98},
+    ]
+
+    def fake_find_near_duplicates(threshold=None, folder_path=None, limit=1000):
+        assert threshold == 0.97
+        assert folder_path == "/photos"
+        assert limit == 10
+        return expected_duplicates
+
+    monkeypatch.setattr(similar_search, "find_near_duplicates", fake_find_near_duplicates)
+
+    with _build_client() as client:
+        response = client.get(
+            "/api/similarity/duplicates",
+            params={"threshold": 0.97, "folder_path": "/photos", "limit": 10},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "duplicates": expected_duplicates,
+        "count": 2,
+    }
+
+
+def test_similarity_outliers_alias_returns_detector_payload(monkeypatch):
+    expected = {
+        "outliers": [{
+            "image_id": 12,
+            "file_path": "/photos/img12.jpg",
+            "outlier_score": 0.72,
+            "z_score": -2.0,
+            "nearest_neighbors": [
+                {"image_id": 11, "file_path": "/photos/img11.jpg", "similarity": 0.94}
+            ]
+        }],
+        "stats": {
+            "total_with_embeddings": 20,
+            "folder_mean": 0.91,
+            "folder_std": 0.04,
+            "z_threshold": 1.7,
+            "k_neighbors": 4,
+            "outliers_found": 1,
+        },
+        "skipped": [],
+    }
+
+    from modules import similar_search
+    monkeypatch.setattr(similar_search, "find_outliers", lambda **kwargs: expected)
+
+    with _build_client() as client:
+        response = client.get(
+            "/api/similarity/outliers",
+            params={"folder_path": "/photos", "z_threshold": 1.7, "k": 4, "limit": 8},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == expected
+
+
+class _FakeCursor:
+    def __init__(self, found=True):
+        self._found = found
+
+    def execute(self, *_args, **_kwargs):
+        return None
+
+    def fetchone(self):
+        if self._found:
+            return (1,)
+        return None
+
+
+class _FakeConn:
+    def __init__(self, found=True):
+        self._found = found
+
+    def cursor(self):
+        return _FakeCursor(found=self._found)
+
+    def close(self):
+        return None


### PR DESCRIPTION
### Motivation
- Provide backwards-compatible endpoints for the requested `/api/similarity/*` namespace so clients can call similarity features under a canonical path. 
- Expose the existing similarity functionality (similar results, duplicate detection, outliers) without changing the original contracts. 
- Make the API consumer migration straightforward by adding aliases rather than modifying existing routes.

### Description
- Added three alias endpoints in `modules/api.py`: `GET /api/similarity/similar` (delegates to existing `get_similar_images`), `GET /api/similarity/duplicates` (GET-style wrapper around `similar_search.find_near_duplicates` that returns `{"duplicates": ..., "count": ...}`), and `GET /api/similarity/outliers` (delegates to existing `get_outliers`).
- Implemented input parameter passthrough and preserved the same parameter ranges/validation for `image_id`, `limit`, `folder_path`, `min_similarity`, `threshold`, `z_threshold`, and `k` as in the original endpoints. 
- Added simple error logging and HTTP error translation for the duplicates alias, and reused existing HTTP error handling for the other aliases. 
- Added API tests in `tests/test_api_queue.py` that assert parameter passthrough and response shape for all three new alias routes and include small DB/connection stubs used by the similar-image alias test.

### Testing
- Added unit tests in `tests/test_api_queue.py` covering `GET /api/similarity/similar`, `GET /api/similarity/duplicates`, and `GET /api/similarity/outliers` that validate parameter mapping and response contracts. 
- Attempted to run `pytest -q tests/test_api_queue.py` in the current environment, but collection failed due to missing test dependencies (`fastapi` and `pydantic`), so tests could not execute here (error: `ModuleNotFoundError: No module named 'fastapi'`, and earlier import of `pydantic` failed during test DB setup). 
- The changes were committed (`modules/api.py`, `tests/test_api_queue.py`) and are ready for CI where the test environment has required dependencies to run the new test cases.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6398f788c8323a97f59abc04782f6)