### PR TITLE
docs(api): add concrete examples for tagging, similarity, and import endpoints

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -55,7 +55,7 @@ Tags: **[Python]** = Python backend (`modules/`, FastAPI); **[Gradio]** = Gradio
 
 - [ ] **[Python]** Streaming/progress for `POST /api/import/register` (currently single-request; no incremental progress)
 - [ ] **[Python]** Keep OpenAPI schema (`openapi.yaml`) in sync with `modules/api.py`
-- [ ] **[Python]** Add request/response examples for new endpoints to `API.md`
+- [x] **[Python]** Add request/response examples for new endpoints to `API.md`
 - [ ] **[Electron]** Update `electron/apiService.ts` and `electron/apiTypes.ts` when adding endpoints
 
 ### Model & Performance

--- a/docs/reference/api/API.md
+++ b/docs/reference/api/API.md
@@ -204,6 +204,146 @@ Content-Type: application/json
 }
 ```
 
+#### Propagate Tags by Visual Similarity
+```http
+POST /api/tagging/propagate
+Content-Type: application/json
+
+{
+  "folder_path": "/path/to/images",
+  "dry_run": true,
+  "min_votes": 2,
+  "min_similarity": 0.85,
+  "max_keywords": 10,
+  "recursive": true
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Tag propagation completed",
+  "data": {
+    "dry_run": true,
+    "processed_images": 125,
+    "tagged_images": 0,
+    "suggestions": [
+      {
+        "image_id": 901,
+        "file_path": "/path/to/images/IMG_0901.jpg",
+        "keywords": ["mountain", "sunset"],
+        "source_neighbors": [120, 145]
+      }
+    ]
+  }
+}
+```
+
+### Similarity Operations
+
+#### Find Similar Images
+```http
+GET /api/similarity/similar?image_id=123&limit=20&min_similarity=0.80
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Found 3 similar images",
+  "data": {
+    "results": [
+      {
+        "image_id": 456,
+        "file_path": "/path/to/images/IMG_0456.jpg",
+        "similarity": 0.942311
+      }
+    ]
+  }
+}
+```
+
+#### Find Near-Duplicate Pairs
+```http
+GET /api/similarity/duplicates?threshold=0.98&limit=100
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Found 2 duplicate pairs",
+  "data": {
+    "results": [
+      {
+        "image_id_a": 1001,
+        "image_id_b": 1002,
+        "file_path_a": "/path/to/images/IMG_1001.jpg",
+        "file_path_b": "/path/to/images/IMG_1002.jpg",
+        "similarity": 0.996501
+      }
+    ]
+  }
+}
+```
+
+#### Find Visual Outliers
+```http
+GET /api/similarity/outliers?folder_path=/path/to/images&z_threshold=2.0&k=10
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Found 4 outliers",
+  "data": {
+    "results": [
+      {
+        "image_id": 777,
+        "file_path": "/path/to/images/IMG_0777.jpg",
+        "mean_knn_similarity": 0.321441,
+        "z_score": -2.41,
+        "nearest_neighbors": [
+          { "image_id": 701, "similarity": 0.441122 },
+          { "image_id": 702, "similarity": 0.438510 }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Import Operations
+
+#### Register Images from Folder (Import Without Scoring)
+```http
+POST /api/import/register
+Content-Type: application/json
+
+{
+  "folder_path": "/path/to/images",
+  "recursive": true,
+  "extensions": ["jpg", "jpeg", "png", "nef"],
+  "skip_existing": true
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Import registration completed",
+  "data": {
+    "registered": 342,
+    "skipped_existing": 118,
+    "failed": 0,
+    "folder_id": 42
+  }
+}
+```
+
 ### General Operations
 
 #### Get All Status
@@ -470,4 +610,3 @@ curl -X POST http://127.0.0.1:7860/api/scoring/stop
 - [API schema for LLMs](API_SCHEMA_LLM.md)
 - [API schema implementation notes](API_SCHEMA_IMPLEMENTATION.md)
 - [MCP debugging tools](../../technical/MCP_DEBUGGING_TOOLS.md)
-


### PR DESCRIPTION
### Motivation

- Provide concrete request/response examples for recently added API routes so integrators and LLM agents have clear contract examples to use. 
- Reduce verification friction by updating the project TODO to reflect that API docs examples were added. 

### Description

- Added request/response examples and short usage snippets to `docs/reference/api/API.md` for `POST /api/tagging/propagate`, `GET /api/similarity/similar`, `GET /api/similarity/duplicates`, `GET /api/similarity/outliers`, and `POST /api/import/register`. 
- Documented example request bodies, query strings, and sample JSON responses for the new similarity/tagging/import operations. 
- Updated the root backlog `TODO.md` to mark the task `Add request/response examples for new endpoints to API.md` as completed. 
- This change is documentation-only and does not alter runtime code paths or API implementations. 

### Testing

- Ran the project todo metrics script with `python scripts/analysis/todo_metrics.py` to validate the TODO bookkeeping and ensure the checklist counts remained consistent, and it completed successfully. 
- Performed a local diff/inspection of `docs/reference/api/API.md` and `TODO.md` to verify the new sections and the checklist update rendered as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b63ac0aca883238a9301e9ee6d3802)