### PR TITLE
Add configurable best image selection strategies for stacks

### DIFF
--- a/modules/clustering.py
+++ b/modules/clustering.py
@@ -81,6 +81,91 @@ class ClusteringEngine:
             return details['image_hash']
         return None
 
+    def _select_best_image(self, img_ids, id_to_score, id_to_feature=None):
+        """
+        Select the best representative image from a stack.
+
+        Strategy is read from config key ``clustering.best_image_strategy``
+        (``score`` | ``centroid`` | ``balanced``).  Falls back to ``score``
+        when embeddings are unavailable.
+
+        Args:
+            img_ids: List of image IDs in the stack.
+            id_to_score: Dict mapping image_id -> score_general (float or None).
+            id_to_feature: Optional dict mapping image_id -> 1-D numpy embedding.
+
+        Returns:
+            The image_id selected as best representative.
+        """
+        if not img_ids:
+            return None
+        if len(img_ids) == 1:
+            return img_ids[0]
+
+        clustering_config = config.get_config_section('clustering')
+        strategy = clustering_config.get('best_image_strategy', 'score')
+        alpha = float(clustering_config.get('best_image_alpha', 0.65))
+
+        # Normalise scores to [0, 1] across the stack
+        scores = np.array([float(id_to_score.get(i) or 0.0) for i in img_ids], dtype=np.float64)
+        score_range = scores.max() - scores.min()
+        if score_range > 0:
+            norm_scores = (scores - scores.min()) / score_range
+        else:
+            norm_scores = np.zeros_like(scores)
+
+        # Build embedding matrix; may be incomplete/missing
+        features_available = id_to_feature is not None
+        feat_matrix = None
+        valid_mask = None
+        if features_available:
+            feats = [id_to_feature.get(i) for i in img_ids]
+            valid_mask = [f is not None for f in feats]
+            if any(valid_mask):
+                feat_matrix = np.array(
+                    [f if f is not None else np.zeros_like(next(x for x in feats if x is not None))
+                     for f in feats],
+                    dtype=np.float64
+                )
+
+        # Fall back to score strategy if no useful embeddings
+        if strategy != 'score' and feat_matrix is None:
+            strategy = 'score'
+
+        if strategy == 'score':
+            best_idx = int(np.argmax(norm_scores))
+            return img_ids[best_idx]
+
+        # Compute centroid from valid-embedding images only
+        valid_feats = feat_matrix[[i for i, v in enumerate(valid_mask) if v]]
+        centroid = valid_feats.mean(axis=0)
+
+        # Cosine distance to centroid per image
+        norms = np.linalg.norm(feat_matrix, axis=1, keepdims=True)
+        centroid_norm = np.linalg.norm(centroid)
+        # Avoid division by zero
+        safe_norms = np.where(norms > 0, norms, 1.0)
+        safe_centroid_norm = centroid_norm if centroid_norm > 0 else 1.0
+        cosine_sim = feat_matrix.dot(centroid) / (safe_norms.squeeze() * safe_centroid_norm)
+        # Images without valid embeddings should not be preferred
+        cosine_sim[[i for i, v in enumerate(valid_mask) if not v]] = -1.0
+
+        # Normalise cosine similarity to [0, 1]
+        sim_range = cosine_sim.max() - cosine_sim.min()
+        if sim_range > 0:
+            norm_represent = (cosine_sim - cosine_sim.min()) / sim_range
+        else:
+            norm_represent = np.zeros_like(cosine_sim)
+
+        if strategy == 'centroid':
+            best_idx = int(np.argmax(norm_represent))
+            return img_ids[best_idx]
+
+        # balanced: alpha * quality + (1 - alpha) * representativeness
+        combined = alpha * norm_scores + (1.0 - alpha) * norm_represent
+        best_idx = int(np.argmax(combined))
+        return img_ids[best_idx]
+
     def load_model(self):
         if self.model is None:
             # Deferred import
@@ -478,15 +563,10 @@ class ClusteringEngine:
                     non_burst_rows.extend(group_rows)
                     continue
                 
-                # Find best image by score
+                # Find best image (no embeddings available for burst path; falls back to score)
                 img_ids = [r['id'] for r in group_rows]
-                best_id = img_ids[0]
-                max_score = -1.0
-                for r in group_rows:
-                    s = r['score_general'] if r.get('score_general') else 0
-                    if s > max_score:
-                        max_score = s
-                        best_id = r['id']
+                id_to_score_burst = {r['id']: r['score_general'] if r.get('score_general') else 0 for r in group_rows}
+                best_id = self._select_best_image(img_ids, id_to_score_burst)
                 
                 s_name = f"Burst {os.path.basename(folder)} ({len(group_rows)} shots)"
                 burst_stacks_data.append({
@@ -592,35 +672,35 @@ class ClusteringEngine:
                 )
                 labels = clustering.fit_predict(features)
                 
+                # Build id -> feature map for centroid/balanced strategies
+                id_to_feature = {}
+                for i, feat in enumerate(features):
+                    orig_idx = valid_indices[i]
+                    img_id = batch_ids[orig_idx]
+                    id_to_feature[img_id] = feat
+
                 local_clusters = {}
                 for i, lbl in enumerate(labels):
-                    orig_idx = valid_indices[i] 
+                    orig_idx = valid_indices[i]
                     img_id = batch_ids[orig_idx]
-                    
+
                     if lbl not in local_clusters:
                         local_clusters[lbl] = []
                     local_clusters[lbl].append(img_id)
-                    
+
                 # Collect stacks for this batch
                 batch_stacks_data = [] # List of dicts
-                
+
+                # Build score lookup once per batch
+                id_to_score_batch = {}
+                for r, t in batch:
+                    id_to_score_batch[r['id']] = r['score_general'] if r['score_general'] else 0
+
                 for lbl, img_ids in local_clusters.items():
                     if len(img_ids) < 2:
                         continue
-                        
-                    # Find best image
-                    # Use provided scores OR fetch? Rows have score_general
-                    id_to_score = {}
-                    for r, t in batch:
-                         id_to_score[r['id']] = r['score_general'] if r['score_general'] else 0
-                    
-                    best_id = img_ids[0]
-                    max_score = -1.0
-                    for mid in img_ids:
-                        s = id_to_score.get(mid, 0)
-                        if s > max_score:
-                            max_score = s
-                            best_id = mid
+
+                    best_id = self._select_best_image(img_ids, id_to_score_batch, id_to_feature)
                             
                     # Name based on Time? or Folder?
                     # Stack (Time)

--- a/tests/test_clustering_representative.py
+++ b/tests/test_clustering_representative.py
@@ -1,0 +1,257 @@
+"""
+Unit tests for ClusteringEngine._select_best_image().
+
+Tests cover:
+  - score strategy (default)
+  - centroid strategy
+  - balanced strategy
+  - edge cases: single image, no embeddings, missing embeddings, all-equal scores
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Stub heavy / unavailable dependencies before importing clustering
+# ---------------------------------------------------------------------------
+
+def _stub(name, **attrs):
+    """Create and register a stub module unless it already exists."""
+    if name not in sys.modules:
+        parent = name.rsplit(".", 1)[0] if "." in name else None
+        mod = types.ModuleType(name)
+        for k, v in attrs.items():
+            setattr(mod, k, v)
+        sys.modules[name] = mod
+        # Attach to parent if it exists in sys.modules
+        if parent and parent in sys.modules:
+            setattr(sys.modules[parent], name.rsplit(".", 1)[1], mod)
+    return sys.modules[name]
+
+
+# sklearn stubs (not installed in pytest environment)
+_stub("sklearn")
+_stub("sklearn.cluster", AgglomerativeClustering=MagicMock())
+
+# PIL stubs
+_stub("PIL")
+_stub("PIL.Image")
+
+# pydantic stub (needed by modules.events)
+_pydantic = _stub("pydantic")
+_pydantic.BaseModel = object
+
+class _Field:
+    def __call__(self, *a, **kw):
+        return kw.get("default", None)
+
+_pydantic.Field = _Field()
+
+# Heavy project-internal stubs (avoid DB / TF / fdb imports)
+_stub("modules.events", event_manager=MagicMock())
+_stub("modules.db")
+_stub("modules.utils")
+
+def _get_config_section(section):
+    if section == "clustering":
+        return {
+            "best_image_strategy": "score",
+            "best_image_alpha": 0.65,
+            "default_threshold": 0.15,
+            "default_time_gap": 120,
+            "force_rescan_default": False,
+            "clustering_batch_size": 32,
+        }
+    if section == "processing":
+        return {"clustering_batch_size": 32}
+    return {}
+
+_stub("modules.config", get_config_section=_get_config_section)
+_stub("modules.phases", PhaseCode=MagicMock(), PhaseStatus=MagicMock())
+_stub("modules.phases_policy",
+      explain_phase_run_decision=MagicMock(return_value={"should_run": True, "reason": ""}))
+_stub("modules.version", APP_VERSION="test")
+
+# Now safe to import
+from modules.clustering import ClusteringEngine  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_engine():
+    """Instantiate ClusteringEngine without disk I/O or model loading."""
+    with (
+        patch.object(ClusteringEngine, "_ensure_cache_dir"),
+        patch.object(ClusteringEngine, "_load_cache"),
+    ):
+        engine = ClusteringEngine.__new__(ClusteringEngine)
+        engine.feature_cache = {}
+        engine.cache_dir = "/tmp/fake_cache"
+        engine.model = None
+        engine.is_running = False
+        engine.status_message = "Idle"
+        engine.current = 0
+        engine.total = 0
+    return engine
+
+
+def cfg_patch(strategy="score", alpha=0.65):
+    """Patch modules.config.get_config_section for the clustering section."""
+    return patch(
+        "modules.config.get_config_section",
+        return_value={
+            "best_image_strategy": strategy,
+            "best_image_alpha": alpha,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: score strategy
+# ---------------------------------------------------------------------------
+
+class TestSelectBestImageScore:
+    def test_returns_highest_score(self):
+        engine = make_engine()
+        img_ids = [1, 2, 3]
+        id_to_score = {1: 0.4, 2: 0.9, 3: 0.6}
+        with cfg_patch("score"):
+            result = engine._select_best_image(img_ids, id_to_score)
+        assert result == 2
+
+    def test_single_image_returns_it(self):
+        engine = make_engine()
+        with cfg_patch("score"):
+            result = engine._select_best_image([42], {42: 0.5})
+        assert result == 42
+
+    def test_empty_returns_none(self):
+        engine = make_engine()
+        with cfg_patch("score"):
+            result = engine._select_best_image([], {})
+        assert result is None
+
+    def test_none_scores_treated_as_zero(self):
+        engine = make_engine()
+        img_ids = [1, 2, 3]
+        id_to_score = {1: None, 2: None, 3: None}
+        with cfg_patch("score"):
+            result = engine._select_best_image(img_ids, id_to_score)
+        assert result in img_ids
+
+    def test_all_equal_scores(self):
+        engine = make_engine()
+        img_ids = [10, 20, 30]
+        id_to_score = {10: 0.5, 20: 0.5, 30: 0.5}
+        with cfg_patch("score"):
+            result = engine._select_best_image(img_ids, id_to_score)
+        assert result in img_ids
+
+
+# ---------------------------------------------------------------------------
+# Tests: centroid strategy
+# ---------------------------------------------------------------------------
+
+class TestSelectBestImageCentroid:
+    def _make_feats(self):
+        """Three 3-D embeddings: id=2 is closest to the centroid direction."""
+        f1 = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+        f2 = np.array([0.577, 0.577, 0.577], dtype=np.float32)  # near centroid
+        f3 = np.array([0.0, 0.0, 1.0], dtype=np.float32)
+        return {1: f1, 2: f2, 3: f3}
+
+    def test_picks_closest_to_centroid(self):
+        engine = make_engine()
+        img_ids = [1, 2, 3]
+        id_to_score = {1: 0.9, 2: 0.5, 3: 0.7}  # id=1 has best score but is far
+        id_to_feature = self._make_feats()
+        with cfg_patch("centroid"):
+            result = engine._select_best_image(img_ids, id_to_score, id_to_feature)
+        assert result == 2
+
+    def test_fallback_to_score_when_no_embeddings(self):
+        engine = make_engine()
+        img_ids = [1, 2, 3]
+        id_to_score = {1: 0.3, 2: 0.8, 3: 0.5}
+        with cfg_patch("centroid"):
+            result = engine._select_best_image(img_ids, id_to_score, id_to_feature=None)
+        assert result == 2
+
+    def test_single_image_returns_it(self):
+        engine = make_engine()
+        feat = {99: np.array([0.5, 0.5], dtype=np.float32)}
+        with cfg_patch("centroid"):
+            result = engine._select_best_image([99], {99: 0.7}, feat)
+        assert result == 99
+
+    def test_handles_partial_embeddings(self):
+        """Only id=2 has an embedding; centroid == that embedding → id=2 wins."""
+        engine = make_engine()
+        img_ids = [1, 2, 3]
+        id_to_score = {1: 0.1, 2: 0.2, 3: 0.3}
+        id_to_feature = {2: np.array([1.0, 0.0], dtype=np.float32)}
+        with cfg_patch("centroid"):
+            result = engine._select_best_image(img_ids, id_to_score, id_to_feature)
+        assert result == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests: balanced strategy
+# ---------------------------------------------------------------------------
+
+class TestSelectBestImageBalanced:
+    def _setup(self):
+        img_ids = [1, 2, 3]
+        # id=1: best quality score, far from centroid
+        # id=2: moderate score, closest to centroid
+        id_to_score = {1: 1.0, 2: 0.5, 3: 0.0}
+        f1 = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+        f2 = np.array([0.577, 0.577, 0.577], dtype=np.float32)
+        f3 = np.array([0.0, 0.0, 1.0], dtype=np.float32)
+        id_to_feature = {1: f1, 2: f2, 3: f3}
+        return img_ids, id_to_score, id_to_feature
+
+    def test_pure_representativeness_picks_centroid_image(self):
+        engine = make_engine()
+        img_ids, id_to_score, id_to_feature = self._setup()
+        with cfg_patch("balanced", alpha=0.0):
+            result = engine._select_best_image(img_ids, id_to_score, id_to_feature)
+        assert result == 2
+
+    def test_pure_quality_picks_highest_score_image(self):
+        engine = make_engine()
+        img_ids, id_to_score, id_to_feature = self._setup()
+        with cfg_patch("balanced", alpha=1.0):
+            result = engine._select_best_image(img_ids, id_to_score, id_to_feature)
+        assert result == 1
+
+    def test_fallback_to_score_when_no_embeddings(self):
+        engine = make_engine()
+        img_ids = [1, 2, 3]
+        id_to_score = {1: 0.1, 2: 0.9, 3: 0.5}
+        with cfg_patch("balanced"):
+            result = engine._select_best_image(img_ids, id_to_score, id_to_feature=None)
+        assert result == 2
+
+    def test_default_alpha_used_when_missing_from_config(self):
+        """Missing alpha key should default to 0.65 without raising."""
+        engine = make_engine()
+        img_ids = [1, 2]
+        id_to_score = {1: 0.8, 2: 0.2}
+        id_to_feature = {
+            1: np.array([1.0, 0.0], dtype=np.float32),
+            2: np.array([0.0, 1.0], dtype=np.float32),
+        }
+        with patch(
+            "modules.config.get_config_section",
+            return_value={"best_image_strategy": "balanced"},  # no alpha key
+        ):
+            result = engine._select_best_image(img_ids, id_to_score, id_to_feature)
+        assert result in img_ids


### PR DESCRIPTION
## Summary
Implement a new `_select_best_image()` method in `ClusteringEngine` that supports multiple strategies for selecting the best representative image from a stack, replacing inline score-based selection logic throughout the codebase.

## Key Changes
- **New method `_select_best_image()`**: Centralized image selection logic supporting three strategies:
  - `score`: Selects image with highest quality score (default, backward compatible)
  - `centroid`: Selects image closest to the cluster centroid in embedding space
  - `balanced`: Weighted combination of quality score and representativeness (configurable via `best_image_alpha`)
  
- **Configuration-driven**: Strategy and alpha parameter read from `clustering` config section with sensible defaults
  
- **Graceful fallback**: Automatically falls back to score strategy when embeddings are unavailable
  
- **Refactored burst path**: Replaced inline score-based selection in burst handling with call to `_select_best_image()`
  
- **Refactored clustering path**: Replaced inline score-based selection in clustering loop with call to `_select_best_image()`, now passing embedding features for centroid/balanced strategies
  
- **Comprehensive test suite**: 257 lines of unit tests covering all three strategies, edge cases (single image, empty list, missing embeddings, equal scores), and fallback behavior

## Implementation Details
- Scores and representativeness metrics are normalized to [0, 1] range for fair comparison
- Cosine similarity used for centroid distance calculation
- Images without valid embeddings are penalized (similarity set to -1.0) in centroid/balanced strategies
- Handles partial embeddings gracefully (only uses available embeddings for centroid computation)
- Default alpha value of 0.65 provides 65% weight to quality, 35% to representativeness

https://claude.ai/code/session_01EZu1L2fJSvFLZ6CFEajVRL