### PR TITLE
Support `stack_representative_strategy` config for clustering representative selection

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -44,7 +44,7 @@ Tags: **[Python]** = Python backend (`modules/`, FastAPI); **[Gradio]** = Gradio
 
 ### Clustering & Embeddings
 
-- [ ] **[Python]** Add `stack_representative_strategy` config option to `ClusteringEngine`
+- [x] **[Python]** Add `stack_representative_strategy` config option to `ClusteringEngine`
 - [ ] **[Python]** Implement centroid strategy (mean embedding → select closest image) in `modules/clustering.py`
 - [ ] **[Python]** 2D embedding map: add `umap-learn`, implement `modules/projections.py` (UMAP 2D coords + folder-level caching)
 - [ ] **[Electron]** **[Gradio]** Bidirectional WebSocket command channel — coordinate protocol with Electron's IPC/WebSocket bridge enhancement (see [EMBEDDING_APP_08_GRADIO_INTEGRATION_PLAN.md](docs/plans/embedding/EMBEDDING_APP_08_GRADIO_INTEGRATION_PLAN.md))

--- a/config.example.json
+++ b/config.example.json
@@ -15,6 +15,8 @@
     "clustering_batch_size": 32
   },
   "clustering": {
+    "stack_representative_strategy": "score",
+    "best_image_alpha": 0.65,
     "default_threshold": 0.15,
     "default_time_gap": 120,
     "force_rescan_default": false

--- a/docs/plans/embedding/TODO.md
+++ b/docs/plans/embedding/TODO.md
@@ -12,7 +12,7 @@ Backend tasks for embedding-based features. See [NEXT_STEPS.md](NEXT_STEPS.md) f
 
 ## Clustering & Selection
 
-- [ ] Add `stack_representative_strategy` config option to `ClusteringEngine`
+- [x] Add `stack_representative_strategy` config option to `ClusteringEngine`
 - [ ] Implement centroid strategy (mean embedding → select closest image) in `modules/clustering.py`
 
 ## 2D Embedding Map (Priority 2)

--- a/modules/clustering.py
+++ b/modules/clustering.py
@@ -85,8 +85,9 @@ class ClusteringEngine:
         """
         Select the best representative image from a stack.
 
-        Strategy is read from config key ``clustering.best_image_strategy``
-        (``score`` | ``centroid`` | ``balanced``).  Falls back to ``score``
+        Strategy is read from config key ``clustering.stack_representative_strategy``
+        (or legacy ``clustering.best_image_strategy``)
+        as ``score`` | ``centroid`` | ``balanced``. Falls back to ``score``
         when embeddings are unavailable.
 
         Args:
@@ -103,7 +104,10 @@ class ClusteringEngine:
             return img_ids[0]
 
         clustering_config = config.get_config_section('clustering')
-        strategy = clustering_config.get('best_image_strategy', 'score')
+        strategy = clustering_config.get(
+            'stack_representative_strategy',
+            clustering_config.get('best_image_strategy', 'score')
+        )
         alpha = float(clustering_config.get('best_image_alpha', 0.65))
 
         # Normalise scores to [0, 1] across the stack

--- a/tests/test_clustering_representative.py
+++ b/tests/test_clustering_representative.py
@@ -103,9 +103,9 @@ def make_engine():
 
 
 def cfg_patch(strategy="score", alpha=0.65):
-    """Patch modules.config.get_config_section for the clustering section."""
+    """Patch modules.clustering.config.get_config_section for clustering config."""
     return patch(
-        "modules.config.get_config_section",
+        "modules.clustering.config.get_config_section",
         return_value={
             "best_image_strategy": strategy,
             "best_image_alpha": alpha,
@@ -159,6 +159,27 @@ class TestSelectBestImageScore:
 # Tests: centroid strategy
 # ---------------------------------------------------------------------------
 
+
+
+    def test_prefers_stack_representative_strategy_over_legacy_key(self):
+        engine = make_engine()
+        img_ids = [1, 2, 3]
+        id_to_score = {1: 0.9, 2: 0.1, 3: 0.2}
+        id_to_feature = {
+            1: np.array([1.0, 0.0, 0.0], dtype=np.float32),
+            2: np.array([0.577, 0.577, 0.577], dtype=np.float32),
+            3: np.array([0.0, 0.0, 1.0], dtype=np.float32),
+        }
+        with patch(
+            "modules.clustering.config.get_config_section",
+            return_value={
+                "stack_representative_strategy": "centroid",
+                "best_image_strategy": "score",
+                "best_image_alpha": 0.65,
+            },
+        ):
+            result = engine._select_best_image(img_ids, id_to_score, id_to_feature)
+        assert result == 2
 class TestSelectBestImageCentroid:
     def _make_feats(self):
         """Three 3-D embeddings: id=2 is closest to the centroid direction."""
@@ -250,7 +271,7 @@ class TestSelectBestImageBalanced:
             2: np.array([0.0, 1.0], dtype=np.float32),
         }
         with patch(
-            "modules.config.get_config_section",
+            "modules.clustering.config.get_config_section",
             return_value={"best_image_strategy": "balanced"},  # no alpha key
         ):
             result = engine._select_best_image(img_ids, id_to_score, id_to_feature)


### PR DESCRIPTION
### Motivation
- Introduce a clear, explicit config key to control how a stack representative image is chosen (`score` | `centroid` | `balanced`) while preserving backward compatibility with the existing legacy key. 
- Make the new option discoverable in the example config so users can easily configure representative-selection behavior.

### Description
- Updated `ClusteringEngine._select_best_image()` to first read `clustering.stack_representative_strategy` and fall back to legacy `clustering.best_image_strategy` when missing, and still use `clustering.best_image_alpha` for the balanced strategy via `alpha = float(...)`.
- Added default entries to `config.example.json` for `stack_representative_strategy` and `best_image_alpha` so the new keys are present in the example configuration.
- Extended unit tests in `tests/test_clustering_representative.py` to patch the correct config lookup (`modules.clustering.config.get_config_section`) and added a test that verifies the new `stack_representative_strategy` key takes precedence over the legacy `best_image_strategy`.
- Marked the related TODO entries as completed in `TODO.md` and `docs/plans/embedding/TODO.md` to reflect the implemented config option.

### Testing
- Ran `pytest -q tests/test_clustering_representative.py` and all tests passed: `14 passed`.
- Test output includes a non-fatal environment warning about a missing `firebird` module during test DB setup, but the clustering representative tests executed and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b78cf0587883239435371cfb859cab)