### PR TITLE
Add Workflow Runs navigation shell with run/stage deep links

### DIFF
--- a/modules/ui/app.py
+++ b/modules/ui/app.py
@@ -13,6 +13,8 @@ instances for external use (e.g., MCP server integration).
 """
 import os
 import platform
+import json
+from datetime import datetime
 import gradio as gr
 from pathlib import Path
 from modules import scoring, db, tagging, config, clustering, thumbnails, utils, culling, pipeline_orchestrator
@@ -29,6 +31,173 @@ from modules import phase_executors
 IS_WINDOWS = platform.system() == "Windows"
 
 
+def _safe_parse_json(raw_value):
+    if not raw_value:
+        return {}
+    if isinstance(raw_value, dict):
+        return raw_value
+    try:
+        return json.loads(raw_value)
+    except Exception:
+        return {}
+
+
+def _format_timestamp(value):
+    if not value:
+        return "—"
+    if isinstance(value, datetime):
+        return value.strftime("%Y-%m-%d %H:%M:%S")
+    return str(value)
+
+
+def _format_duration_seconds(started_at, ended_at):
+    if not started_at:
+        return "—"
+    end_value = ended_at or datetime.now()
+    if isinstance(started_at, str) or isinstance(end_value, str):
+        return "—"
+    delta = max(0, int((end_value - started_at).total_seconds()))
+    hours, remainder = divmod(delta, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    if hours:
+        return f"{hours:02d}:{minutes:02d}:{seconds:02d}"
+    return f"{minutes:02d}:{seconds:02d}"
+
+
+def _normalize_run_status(status, failed_stages):
+    status_value = (status or "unknown").lower()
+    if status_value == "failed":
+        return "Failed"
+    if status_value in {"interrupted", "cancelled"}:
+        return "Needs Attention"
+    if status_value == "running":
+        return "Running"
+    if status_value == "queued":
+        return "Queued"
+    if status_value == "blocked":
+        return "Blocked"
+    if failed_stages > 0:
+        return "Needs Attention"
+    if status_value in {"completed", "done"}:
+        return "Completed"
+    return status_value.title()
+
+
+def _compute_progress(completed_stages, total_stages):
+    if not total_stages:
+        return "0%"
+    pct = int((completed_stages / total_stages) * 100)
+    return f"{pct}% ({completed_stages}/{total_stages})"
+
+
+
+
+
+def _build_stage_graph_html(phases):
+    if not phases:
+        return "<div class='text-secondary'>No StageRun data.</div>"
+    nodes = []
+    for phase in phases:
+        state = (phase.get("state") or "pending").lower()
+        phase_code = phase.get("phase_code") or "unknown"
+        stage_id = phase.get("id")
+        deep_link = f"/app?stage_id={stage_id}" if stage_id else "#"
+        nodes.append(
+            f"<div style='padding:8px;border:1px solid #ddd;border-radius:6px;'>"
+            f"<strong>{phase_code}</strong>"
+            f"<div>Status: {state.title()}</div>"
+            f"<div><a href='{deep_link}'>Stage link</a></div>"
+            f"</div>"
+        )
+    return "<div style='display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:8px;'>" + "".join(nodes) + "</div>"
+
+
+def _build_step_timeline_html(phases):
+    if not phases:
+        return "<div class='text-secondary'>No StepRun timeline data.</div>"
+    rows = ["<ol style='margin:0;padding-left:20px;'>"]
+    for phase in phases:
+        state = (phase.get("state") or "pending").title()
+        started = _format_timestamp(phase.get("started_at"))
+        done = _format_timestamp(phase.get("completed_at"))
+        rows.append(
+            f"<li><strong>{phase.get('phase_code')}</strong> — {state} "
+            f"<span style='color:#666'>(start: {started}, end: {done})</span></li>"
+        )
+    rows.append("</ol>")
+    return "".join(rows)
+
+
+def _build_navigation_left_html(run_rows):
+    targets = {}
+    for run in run_rows:
+        target_type = run.get("target_type") or "unknown"
+        targets[target_type] = targets.get(target_type, 0) + 1
+    target_items = "".join([f"<li>{k}: {v}</li>" for k, v in sorted(targets.items())]) or "<li>No targets</li>"
+    return (
+        "<div><h4>Targets</h4><ul>" + target_items + "</ul>"
+        "<h4>Saved Filters</h4><ul>"
+        "<li><a href='/app?wf_filter=Running'>Running</a></li>"
+        "<li><a href='/app?wf_filter=Queued'>Queued</a></li>"
+        "<li><a href='/app?wf_filter=Blocked'>Blocked</a></li>"
+        "<li><a href='/app?wf_filter=Failed'>Failed</a></li>"
+        "<li><a href='/app?wf_filter=Needs%20Attention'>Needs Attention</a></li>"
+        "<li><a href='/app?wf_filter=Completed'>Completed</a></li>"
+        "</ul><h4>Workflow Templates</h4><ul>"
+        "<li>Full Pipeline (index → metadata → scoring → culling → keywords)</li>"
+        "<li>Metadata + Scoring</li>"
+        "<li>Culling + Keywords</li>"
+        "</ul></div>"
+    )
+
+
+def _load_workflow_runs(filter_value="All", limit=200):
+    jobs = db.get_jobs(limit=limit) or []
+    normalized = []
+    for row in jobs:
+        payload = _safe_parse_json(row.get("queue_payload"))
+        phase_rows = db.get_job_phases(row.get("id")) or []
+        total = len(phase_rows)
+        completed = len([p for p in phase_rows if (p.get("state") or "").lower() == "completed"])
+        failed = len([p for p in phase_rows if (p.get("state") or "").lower() == "failed"])
+        display_status = _normalize_run_status(row.get("status"), failed)
+        run = {
+            "id": row.get("id"),
+            "status": display_status,
+            "status_raw": row.get("status"),
+            "queued_time": _format_timestamp(row.get("enqueued_at") or row.get("created_at")),
+            "duration": _format_duration_seconds(row.get("started_at"), row.get("finished_at") or row.get("completed_at")),
+            "target_type": (payload.get("target_type") if isinstance(payload, dict) else None) or row.get("job_type") or "unknown",
+            "progress": _compute_progress(completed, total),
+            "owner": (payload.get("actor") if isinstance(payload, dict) else None) or "system",
+            "run_link": f"/app?run_id={row.get('id')}",
+            "phases": phase_rows,
+        }
+        normalized.append(run)
+
+    if filter_value and filter_value != "All":
+        normalized = [r for r in normalized if r["status"] == filter_value]
+
+    table_data = [[
+        r["id"], r["status"], r["queued_time"], r["duration"], r["target_type"], r["progress"], r["owner"], r["run_link"]
+    ] for r in normalized]
+    return normalized, table_data
+
+
+def _build_run_details_html(run):
+    if not run:
+        return "<div>Select a run to view StageRun graph and StepRun timeline.</div>"
+    phases = run.get("phases") or []
+    stage_graph = _build_stage_graph_html(phases)
+    timeline = _build_step_timeline_html(phases)
+    return (
+        f"<div><h3>Run #{run.get('id')}</h3>"
+        f"<p><strong>Status:</strong> {run.get('status')} | <strong>Target:</strong> {run.get('target_type')} | "
+        f"<strong>Owner/Actor:</strong> {run.get('owner')}</p>"
+        f"<p><a href='{run.get('run_link')}'>Deep link to run</a></p>"
+        "<h4>StageRun Graph</h4>" + stage_graph +
+        "<h4 style='margin-top:10px;'>StepRun Timeline</h4>" + timeline + "</div>"
+    )
 
 def create_ui():
     """Main function to build the WebUI."""
@@ -87,6 +256,66 @@ def create_ui():
                 selection_runner=selection_runner,
                 orchestrator=orchestrator
             )
+
+            with gr.Tab("Workflow Runs"):
+                workflow_runs_state = gr.State([])
+                selected_run_id_state = gr.State(None)
+                with gr.Row():
+                    with gr.Column(scale=2):
+                        workflow_nav_html = gr.HTML("<div>Loading navigation shell...</div>")
+                    with gr.Column(scale=6):
+                        with gr.Row():
+                            quick_filters = ["Running", "Queued", "Blocked", "Failed", "Needs Attention", "Completed"]
+                            filter_buttons = [gr.Button(label, size="sm") for label in quick_filters]
+                            clear_filter_btn = gr.Button("All", size="sm")
+                        runs_table = gr.Dataframe(
+                            headers=["Run ID", "Status", "Queued Time", "Duration", "Target Type", "Progress", "Owner/Actor", "Deep Link"],
+                            datatype=["number", "str", "str", "str", "str", "str", "str", "str"],
+                            interactive=False,
+                            wrap=True,
+                            row_count=12,
+                            col_count=(8, "fixed"),
+                            label="WorkflowRuns"
+                        )
+                    with gr.Column(scale=4):
+                        run_details_html = gr.HTML("<div>Select a run to view details.</div>")
+
+                def refresh_shell(filter_value="All"):
+                    run_rows, table_rows = _load_workflow_runs(filter_value=filter_value)
+                    nav_html = _build_navigation_left_html(run_rows)
+                    return run_rows, table_rows, nav_html, "<div>Select a run to view StageRun graph and StepRun timeline.</div>", None
+
+                def choose_run(table_data, run_rows, evt: gr.SelectData):
+                    if evt is None or not evt.index:
+                        return "<div>Select a run to view details.</div>", None
+                    row_index = evt.index[0]
+                    if row_index is None or row_index >= len(table_data):
+                        return "<div>Select a run to view details.</div>", None
+                    run_id = table_data[row_index][0]
+                    selected = next((r for r in run_rows if r.get("id") == run_id), None)
+                    return _build_run_details_html(selected), run_id
+
+                demo.load(
+                    fn=refresh_shell,
+                    outputs=[workflow_runs_state, runs_table, workflow_nav_html, run_details_html, selected_run_id_state],
+                )
+
+                for idx, btn in enumerate(filter_buttons):
+                    btn.click(
+                        fn=lambda i=idx: refresh_shell(quick_filters[i]),
+                        outputs=[workflow_runs_state, runs_table, workflow_nav_html, run_details_html, selected_run_id_state],
+                    )
+
+                clear_filter_btn.click(
+                    fn=lambda: refresh_shell("All"),
+                    outputs=[workflow_runs_state, runs_table, workflow_nav_html, run_details_html, selected_run_id_state],
+                )
+
+                runs_table.select(
+                    fn=choose_run,
+                    inputs=[runs_table, workflow_runs_state],
+                    outputs=[run_details_html, selected_run_id_state],
+                )
             
             # 2. Gallery Tab
             gallery_components = gallery.create_tab(shared_state, current_folder_state, current_stack_state, runner, tagging_runner, app_config)


### PR DESCRIPTION
### Motivation
- Provide a dedicated UI for inspecting pipeline/job history and status so operators can quickly find running/queued/failed runs and inspect their stages.
- Surface run-level and phase-level deep links using stable IDs from `jobs` and `job_phases` to enable direct navigation and diagnostics.
- Offer quick filters and a three-pane layout to improve observability and troubleshooting of WorkflowRuns.

### Description
- Added helper utilities to `modules/ui/app.py`: `_safe_parse_json`, `_format_timestamp`, `_format_duration_seconds`, `_normalize_run_status`, and `_compute_progress` to parse payloads, format times/durations, normalize statuses, and render progress.
- Implemented HTML builders: `_build_stage_graph_html`, `_build_step_timeline_html`, `_build_navigation_left_html`, `_build_run_details_html`, and `_load_workflow_runs` to render the left rail, StageRun graph, StepRun timeline, and center run table sourcing data from `db.get_jobs()` and `db.get_job_phases()`.
- Integrated a new `Workflow Runs` Gradio tab inside `create_ui()` that creates a three-pane shell (left: Targets/saved filters/templates, center: `WorkflowRuns` `Dataframe`, right: run details) and wires `demo.load`, quick-filter buttons, `Dataframe.select`, and refresh handlers.
- Deep links are generated as `/app?run_id=<job.id>` for runs and `/app?stage_id=<job_phases.id>` for stages so external navigation can target specific runs or stages.

### Testing
- Ran `python -m py_compile modules/ui/app.py` to validate syntax and byte-compile the modified module, and it succeeded.
- Attempted to capture a UI screenshot via a Playwright script against `http://127.0.0.1:7860`, but the local WebUI server did not respond (`ERR_EMPTY_RESPONSE`), so a runtime UI render test could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7947ec66083239a30372124f04080)