### PR TITLE
Add lifecycle states and pause/resume/restart controls across pipeline backend/UI

### DIFF
--- a/modules/api.py
+++ b/modules/api.py
@@ -59,6 +59,7 @@ from modules.phases_policy import explain_phase_run_decision
 from modules.selector_resolver import resolve_selectors
 
 from modules.job_dispatcher import JobDispatcher
+from modules import db
 
 logger = logging.getLogger(__name__)
 
@@ -574,6 +575,13 @@ class PipelineBackfillRequest(BaseModel):
     input_path: str = Field(..., description="Folder path for backfill operation.")
 
 
+
+
+class LifecycleControlRequest(BaseModel):
+    """Generic lifecycle control request for workflow/stage/step runs."""
+    reason: Optional[str] = Field(None, description="Optional reason for pause/cancel/restart request.")
+
+
 class ApiResponse(BaseModel):
     """Standard API response model for operation results.
     
@@ -724,6 +732,43 @@ def create_api_router() -> APIRouter:
         }
     )
     
+
+    def _http_for_transition_error(exc: Exception):
+        msg = str(exc)
+        if "Invalid" in msg and "transition" in msg:
+            raise HTTPException(status_code=409, detail=msg)
+        raise exc
+
+    def _control_job(job_id: int, target_status: str, reason: Optional[str] = None):
+        job = db.get_job_by_id(job_id)
+        if not job:
+            raise HTTPException(status_code=404, detail="Job not found")
+        try:
+            db.update_job_status(job_id, target_status, log=reason)
+            return db.get_job_by_id(job_id)
+        except Exception as exc:
+            _http_for_transition_error(exc)
+
+    def _control_stage(job_id: int, phase_code: str, target_state: str, reason: Optional[str] = None):
+        job = db.get_job_by_id(job_id)
+        if not job:
+            raise HTTPException(status_code=404, detail="Job not found")
+        phases = db.get_job_phases(job_id)
+        if not any((p.get("phase_code") or "").strip().lower() == phase_code.strip().lower() for p in phases):
+            raise HTTPException(status_code=404, detail=f"Stage not found: {phase_code}")
+        try:
+            rows = db.set_job_phase_state(job_id, phase_code.strip().lower(), target_state, error_message=reason)
+            return rows
+        except Exception as exc:
+            _http_for_transition_error(exc)
+
+    def _control_step(image_id: int, phase_code: str, target_status: str, reason: Optional[str] = None):
+        try:
+            db.set_image_phase_status(image_id, phase_code.strip().lower(), target_status, error=reason)
+            return db.get_image_phase_statuses(image_id)
+        except Exception as exc:
+            _http_for_transition_error(exc)
+
     # Add schema endpoint for LLM agents
     @router.get(
         "/schema",
@@ -2006,6 +2051,56 @@ def create_api_router() -> APIRouter:
             raise
         except Exception as e:
             raise HTTPException(status_code=500, detail=str(e))
+
+
+
+    @router.post("/workflow-runs/{job_id}/pause", response_model=ApiResponse, summary="Pause workflow run")
+    async def pause_workflow_run(job_id: int, request: LifecycleControlRequest):
+        state = _control_job(job_id, "paused", request.reason)
+        return ApiResponse(success=True, message="Workflow paused", data={"job": state})
+
+    @router.post("/workflow-runs/{job_id}/resume", response_model=ApiResponse, summary="Resume workflow run")
+    async def resume_workflow_run(job_id: int, request: LifecycleControlRequest):
+        state = _control_job(job_id, "running", request.reason)
+        return ApiResponse(success=True, message="Workflow resumed", data={"job": state})
+
+    @router.post("/workflow-runs/{job_id}/restart", response_model=ApiResponse, summary="Restart workflow run")
+    async def restart_workflow_run(job_id: int, request: LifecycleControlRequest):
+        _control_job(job_id, "restarting", request.reason)
+        state = _control_job(job_id, "queued", request.reason)
+        return ApiResponse(success=True, message="Workflow restarting", data={"job": state})
+
+    @router.post("/stage-runs/{job_id}/{phase_code}/pause", response_model=ApiResponse, summary="Pause stage run")
+    async def pause_stage_run(job_id: int, phase_code: str, request: LifecycleControlRequest):
+        rows = _control_stage(job_id, phase_code, "paused", request.reason)
+        return ApiResponse(success=True, message="Stage paused", data={"phases": rows, "phase_code": phase_code})
+
+    @router.post("/stage-runs/{job_id}/{phase_code}/resume", response_model=ApiResponse, summary="Resume stage run")
+    async def resume_stage_run(job_id: int, phase_code: str, request: LifecycleControlRequest):
+        rows = _control_stage(job_id, phase_code, "running", request.reason)
+        return ApiResponse(success=True, message="Stage resumed", data={"phases": rows, "phase_code": phase_code})
+
+    @router.post("/stage-runs/{job_id}/{phase_code}/restart", response_model=ApiResponse, summary="Restart stage run")
+    async def restart_stage_run(job_id: int, phase_code: str, request: LifecycleControlRequest):
+        _control_stage(job_id, phase_code, "restarting", request.reason)
+        rows = _control_stage(job_id, phase_code, "queued", request.reason)
+        return ApiResponse(success=True, message="Stage restarting", data={"phases": rows, "phase_code": phase_code})
+
+    @router.post("/step-runs/{image_id}/{phase_code}/pause", response_model=ApiResponse, summary="Pause step run")
+    async def pause_step_run(image_id: int, phase_code: str, request: LifecycleControlRequest):
+        statuses = _control_step(image_id, phase_code, "paused", request.reason)
+        return ApiResponse(success=True, message="Step paused", data={"image_id": image_id, "statuses": statuses})
+
+    @router.post("/step-runs/{image_id}/{phase_code}/resume", response_model=ApiResponse, summary="Resume step run")
+    async def resume_step_run(image_id: int, phase_code: str, request: LifecycleControlRequest):
+        statuses = _control_step(image_id, phase_code, "running", request.reason)
+        return ApiResponse(success=True, message="Step resumed", data={"image_id": image_id, "statuses": statuses})
+
+    @router.post("/step-runs/{image_id}/{phase_code}/restart", response_model=ApiResponse, summary="Restart step run")
+    async def restart_step_run(image_id: int, phase_code: str, request: LifecycleControlRequest):
+        _control_step(image_id, phase_code, "restarting", request.reason)
+        statuses = _control_step(image_id, phase_code, "queued", request.reason)
+        return ApiResponse(success=True, message="Step restarting", data={"image_id": image_id, "statuses": statuses})
 
     # ========== Similar Images Endpoint ==========
 

--- a/modules/api.py
+++ b/modules/api.py
@@ -2090,12 +2090,12 @@ def create_api_router() -> APIRouter:
     @router.post("/workflow-runs/{job_id}/resume", response_model=ApiResponse, summary="Resume workflow run")
     async def resume_workflow_run(job_id: int, request: LifecycleControlRequest):
         state = _control_job(job_id, "running", request.reason)
-        return ApiResponse(success=True, message="Workflow resumed", data={"job": state})
+        return ApiResponse(success=True, message="Workflow queued for resume", data={"job": state})
 
     @router.post("/workflow-runs/{job_id}/restart", response_model=ApiResponse, summary="Restart workflow run")
     async def restart_workflow_run(job_id: int, request: LifecycleControlRequest):
         _control_job(job_id, "restarting", request.reason)
-        state = _control_job(job_id, "running", request.reason)
+        state = _control_job(job_id, "queued", request.reason)
         return ApiResponse(success=True, message="Workflow restarting", data={"job": state})
 
     @router.post("/stage-runs/{job_id}/{phase_code}/pause", response_model=ApiResponse, summary="Pause stage run")

--- a/modules/api.py
+++ b/modules/api.py
@@ -737,14 +737,42 @@ def create_api_router() -> APIRouter:
         msg = str(exc)
         if "Invalid" in msg and "transition" in msg:
             raise HTTPException(status_code=409, detail=msg)
-        raise exc
+        if isinstance(exc, HTTPException):
+            raise exc
+        raise HTTPException(status_code=500, detail=msg)
+
+    def _runner_for_job(job: Dict[str, Any]):
+        phase = (job.get("job_type") or "").strip().lower()
+        if phase in ("score", "scoring"):
+            return _scoring_runner
+        if phase in ("tag", "tagging", "keywords"):
+            return _tagging_runner
+        if phase in ("cluster", "clustering"):
+            return _clustering_runner
+        if phase in ("selection", "culling"):
+            return _selection_runner
+        return None
 
     def _control_job(job_id: int, target_status: str, reason: Optional[str] = None):
         job = db.get_job_by_id(job_id)
         if not job:
             raise HTTPException(status_code=404, detail="Job not found")
+
         try:
-            db.update_job_status(job_id, target_status, log=reason)
+            status = (target_status or "").strip().lower()
+            if status == "paused":
+                runner = _runner_for_job(job)
+                if runner and hasattr(runner, "stop"):
+                    try:
+                        runner.stop()
+                    except Exception:
+                        logger.debug("Pause request: runner stop failed for job %s", job_id, exc_info=True)
+                db.update_job_status(job_id, "paused", log=reason)
+            elif status == "running":
+                # Resume requests should return the job to dispatcher control.
+                db.update_job_status(job_id, "queued", log=reason or "resume_requested")
+            else:
+                db.update_job_status(job_id, status, log=reason)
             return db.get_job_by_id(job_id)
         except Exception as exc:
             _http_for_transition_error(exc)
@@ -2067,7 +2095,7 @@ def create_api_router() -> APIRouter:
     @router.post("/workflow-runs/{job_id}/restart", response_model=ApiResponse, summary="Restart workflow run")
     async def restart_workflow_run(job_id: int, request: LifecycleControlRequest):
         _control_job(job_id, "restarting", request.reason)
-        state = _control_job(job_id, "queued", request.reason)
+        state = _control_job(job_id, "running", request.reason)
         return ApiResponse(success=True, message="Workflow restarting", data={"job": state})
 
     @router.post("/stage-runs/{job_id}/{phase_code}/pause", response_model=ApiResponse, summary="Pause stage run")

--- a/modules/db.py
+++ b/modules/db.py
@@ -3637,13 +3637,13 @@ def set_job_phase_state(job_id, phase_code, state, error_message=None):
         "pending": {"queued", "running", "skipped", "canceled"},
         "queued": {"running", "paused", "cancel_requested", "canceled"},
         "running": {"paused", "completed", "failed", "cancel_requested", "restarting", "canceled"},
-        "paused": {"running", "restarting", "cancel_requested", "canceled"},
-        "cancel_requested": {"canceled", "failed"},
+        "paused": {"queued", "running", "restarting", "cancel_requested", "canceled"},
+        "cancel_requested": {"canceled", "failed", "restarting"},
         "restarting": {"queued", "running", "failed"},
-        "completed": set(),
-        "failed": set(),
-        "skipped": set(),
-        "canceled": set(),
+        "completed": {"restarting", "queued"},
+        "failed": {"restarting", "queued"},
+        "skipped": {"restarting", "queued", "running"},
+        "canceled": {"restarting", "queued"},
     }
     conn = get_db()
     c = conn.cursor()

--- a/modules/db.py
+++ b/modules/db.py
@@ -23,14 +23,19 @@ logger = logging.getLogger(__name__)
 DEBUG_DB_CONNECTION = os.environ.get("DEBUG_DB_CONNECTION", "").lower() in ("1", "true", "yes")
 
 
-JOB_TERMINAL_STATES = {"completed", "failed", "canceled", "interrupted"}
+JOB_TERMINAL_STATES = {"completed", "failed", "canceled", "cancelled", "interrupted"}
 JOB_ALLOWED_TRANSITIONS = {
-    "pending": {"running", "canceled", "interrupted"},
-    "running": {"completed", "failed", "canceled", "interrupted"},
-    "interrupted": {"running", "canceled"},
+    "pending": {"queued", "running", "canceled", "cancelled", "interrupted"},
+    "queued": {"running", "paused", "cancel_requested", "canceled", "cancelled", "interrupted", "restarting"},
+    "running": {"paused", "completed", "failed", "cancel_requested", "canceled", "cancelled", "interrupted", "restarting"},
+    "paused": {"queued", "running", "cancel_requested", "canceled", "cancelled", "interrupted", "restarting"},
+    "cancel_requested": {"canceled", "cancelled", "failed", "interrupted"},
+    "restarting": {"queued", "running", "failed", "interrupted"},
+    "interrupted": {"queued", "running", "canceled", "cancelled", "restarting"},
     "completed": set(),
     "failed": set(),
     "canceled": set(),
+    "cancelled": set(),
 }
 
 
@@ -3395,12 +3400,20 @@ def update_job_status(job_id, status, log=None, current_phase=None, next_phase_i
                 phase_code = get_next_running_job_phase(job_id)
 
         if phase_code:
-            phase_state = "running"
-            if status == "completed":
-                phase_state = "completed"
-            elif status == "failed":
-                phase_state = "failed"
-            set_job_phase_state(job_id, phase_code, phase_state, error_message=log if status == "failed" else None)
+            phase_state_map = {
+                "queued": "queued",
+                "running": "running",
+                "paused": "paused",
+                "cancel_requested": "cancel_requested",
+                "restarting": "restarting",
+                "completed": "completed",
+                "failed": "failed",
+                "canceled": "canceled",
+                "cancelled": "canceled",
+                "interrupted": "failed",
+            }
+            phase_state = phase_state_map.get(new_status, "running")
+            set_job_phase_state(job_id, phase_code, phase_state, error_message=log if new_status in {"failed", "interrupted"} else None)
     except Exception as e:
         logger.debug("update_job_status: failed to sync job_phases for job %s: %s", job_id, e)
 
@@ -3620,11 +3633,23 @@ def create_job_phases(job_id, phase_codes):
 
 def set_job_phase_state(job_id, phase_code, state, error_message=None):
     """Update state metadata for one phase of a job and auto-advance next pending phase."""
+    allowed = {
+        "pending": {"queued", "running", "skipped", "canceled"},
+        "queued": {"running", "paused", "cancel_requested", "canceled"},
+        "running": {"paused", "completed", "failed", "cancel_requested", "restarting", "canceled"},
+        "paused": {"running", "restarting", "cancel_requested", "canceled"},
+        "cancel_requested": {"canceled", "failed"},
+        "restarting": {"queued", "running", "failed"},
+        "completed": set(),
+        "failed": set(),
+        "skipped": set(),
+        "canceled": set(),
+    }
     conn = get_db()
     c = conn.cursor()
     now = datetime.datetime.now()
     c.execute(
-        "SELECT id FROM job_phases WHERE job_id = ? AND phase_code = ?",
+        "SELECT id, state FROM job_phases WHERE job_id = ? AND phase_code = ?",
         (job_id, phase_code),
     )
     row = c.fetchone()
@@ -3633,6 +3658,11 @@ def set_job_phase_state(job_id, phase_code, state, error_message=None):
         return None
 
     phase_id = row[0]
+    old_state = (row[1] or "pending").strip().lower()
+    new_state = (state or "").strip().lower()
+    if old_state != new_state and new_state not in allowed.get(old_state, set()):
+        conn.close()
+        raise ValueError(f"Invalid job phase transition: {old_state} -> {new_state} (job_id={job_id}, phase={phase_code})")
     fields = ["state = ?"]
     params = [state]
     if state == "running":
@@ -6589,6 +6619,14 @@ def set_image_phase_status(image_id, phase_code, status,
                 )
                 return
 
+            old_enum = PhaseStatus(old_status) if old_status in {x.value for x in PhaseStatus} else None
+            new_enum = PhaseStatus(status) if status in {x.value for x in PhaseStatus} else None
+            if old_enum and new_enum and old_enum != new_enum:
+                from modules.phases import ALLOWED_TRANSITIONS
+                allowed = ALLOWED_TRANSITIONS.get(old_enum, set())
+                if new_enum not in allowed:
+                    raise ValueError(f"Invalid image phase transition: {old_status} -> {status} (img={image_id}, phase={phase_code})")
+
             # Increment attempt on rerun transitions
             if status == PhaseStatus.RUNNING and old_status in (
                 PhaseStatus.DONE, PhaseStatus.FAILED, PhaseStatus.SKIPPED
@@ -6802,6 +6840,10 @@ def get_folder_phase_summary(folder_path, force_refresh=False):
                 COALESCE(SUM(CASE WHEN ips.status = 'done' THEN 1 ELSE 0 END), 0) as done_count,
                 COALESCE(SUM(CASE WHEN ips.status = 'failed' THEN 1 ELSE 0 END), 0) as failed_count,
                 COALESCE(SUM(CASE WHEN ips.status = 'running' THEN 1 ELSE 0 END), 0) as running_count,
+                COALESCE(SUM(CASE WHEN ips.status = 'queued' THEN 1 ELSE 0 END), 0) as queued_count,
+                COALESCE(SUM(CASE WHEN ips.status = 'paused' THEN 1 ELSE 0 END), 0) as paused_count,
+                COALESCE(SUM(CASE WHEN ips.status = 'cancel_requested' THEN 1 ELSE 0 END), 0) as cancel_requested_count,
+                COALESCE(SUM(CASE WHEN ips.status = 'restarting' THEN 1 ELSE 0 END), 0) as restarting_count,
                 COALESCE(SUM(CASE WHEN ips.status = 'skipped' THEN 1 ELSE 0 END), 0) as skipped_count,
                 pp.optional
             FROM pipeline_phases pp
@@ -6831,8 +6873,12 @@ def get_folder_phase_summary(folder_path, force_refresh=False):
             done = row[4] or 0
             failed = row[5] or 0
             running = row[6] or 0
-            skipped = row[7] or 0
-            is_optional = bool(row[8])
+            queued = row[7] or 0
+            paused = row[8] or 0
+            cancel_requested = row[9] or 0
+            restarting = row[10] or 0
+            skipped = row[11] or 0
+            is_optional = bool(row[12])
 
             advance_ready = done + skipped if is_optional else done
             if total == 0:
@@ -6844,7 +6890,15 @@ def get_folder_phase_summary(folder_path, force_refresh=False):
             elif advance_ready == total and is_optional:
                 status = "done"
             elif running > 0:
-                status = "partial"
+                status = "running"
+            elif paused > 0:
+                status = "paused"
+            elif queued > 0:
+                status = "queued"
+            elif restarting > 0:
+                status = "restarting"
+            elif cancel_requested > 0:
+                status = "cancel_requested"
             elif done > 0 or skipped > 0:
                 status = "partial"
             elif failed > 0:
@@ -6863,6 +6917,10 @@ def get_folder_phase_summary(folder_path, force_refresh=False):
                 "done_count": done,
                 "failed_count": failed,
                 "running_count": running,
+                "queued_count": queued,
+                "paused_count": paused,
+                "cancel_requested_count": cancel_requested,
+                "restarting_count": restarting,
                 "skipped_count": skipped,
                 "total_count": total,
                 "optional": is_optional,

--- a/modules/phases.py
+++ b/modules/phases.py
@@ -72,18 +72,26 @@ def normalize_phase_codes(phase_codes: Optional[List[Any]]) -> List[PhaseCode]:
 
 class PhaseStatus(str, Enum):
     NOT_STARTED = "not_started"
+    QUEUED      = "queued"
     RUNNING     = "running"
+    PAUSED      = "paused"
+    CANCEL_REQUESTED = "cancel_requested"
+    RESTARTING  = "restarting"
     DONE        = "done"
     SKIPPED     = "skipped"
     FAILED      = "failed"
 
 # Allowed transitions: from_status -> set of to_statuses
 ALLOWED_TRANSITIONS = {
-    PhaseStatus.NOT_STARTED: {PhaseStatus.RUNNING},
-    PhaseStatus.RUNNING:     {PhaseStatus.DONE, PhaseStatus.FAILED, PhaseStatus.SKIPPED},
-    PhaseStatus.DONE:        {PhaseStatus.RUNNING},      # rerun
-    PhaseStatus.FAILED:      {PhaseStatus.RUNNING},      # retry
-    PhaseStatus.SKIPPED:     {PhaseStatus.RUNNING},      # explicit rerun
+    PhaseStatus.NOT_STARTED: {PhaseStatus.QUEUED, PhaseStatus.RUNNING},
+    PhaseStatus.QUEUED:      {PhaseStatus.RUNNING, PhaseStatus.CANCEL_REQUESTED, PhaseStatus.SKIPPED},
+    PhaseStatus.RUNNING:     {PhaseStatus.PAUSED, PhaseStatus.DONE, PhaseStatus.FAILED, PhaseStatus.SKIPPED, PhaseStatus.CANCEL_REQUESTED, PhaseStatus.RESTARTING},
+    PhaseStatus.PAUSED:      {PhaseStatus.RUNNING, PhaseStatus.CANCEL_REQUESTED, PhaseStatus.RESTARTING},
+    PhaseStatus.CANCEL_REQUESTED: {PhaseStatus.SKIPPED, PhaseStatus.FAILED, PhaseStatus.NOT_STARTED},
+    PhaseStatus.RESTARTING:  {PhaseStatus.QUEUED, PhaseStatus.RUNNING, PhaseStatus.FAILED},
+    PhaseStatus.DONE:        {PhaseStatus.RESTARTING, PhaseStatus.RUNNING},      # rerun
+    PhaseStatus.FAILED:      {PhaseStatus.RESTARTING, PhaseStatus.RUNNING},      # retry
+    PhaseStatus.SKIPPED:     {PhaseStatus.RESTARTING, PhaseStatus.RUNNING},      # explicit rerun
 }
 
 

--- a/modules/ui/tabs/pipeline.py
+++ b/modules/ui/tabs/pipeline.py
@@ -106,6 +106,11 @@ def create_tab(app_config, scoring_runner, tagging_runner, selection_runner, orc
                             components["stop_all_btn"] = gr.Button("Stop All", variant="stop", elem_classes=["danger-btn"])
                             components["repair_index_meta_btn"] = gr.Button("Repair Index/Meta", variant="secondary", elem_classes=["secondary-btn"])
                             components["run_metadata_btn"] = gr.Button("Run Metadata", variant="secondary", elem_classes=["secondary-btn"])
+                        with gr.Row(elem_classes=["pipeline-actions"]):
+                            components["pause_workflow_btn"] = gr.Button("Pause", elem_classes=["secondary-btn"])
+                            components["resume_workflow_btn"] = gr.Button("Resume", elem_classes=["secondary-btn"])
+                            components["restart_workflow_btn"] = gr.Button("Restart", elem_classes=["danger-btn"])
+                        components["lifecycle_status"] = gr.Markdown("", elem_classes=["section-microcopy"])
                         gr.HTML(
                             "<p class='section-microcopy'>"
                             "<strong>Run All Pending</strong> \u2014 starts Scoring, Culling, and Keywords for images not yet processed. "
@@ -337,6 +342,32 @@ def create_tab(app_config, scoring_runner, tagging_runner, selection_runner, orc
         elif phase_code == "keywords":
             _run_tagging(path, overwrite=False, captions=False)
 
+    def _find_latest_workflow_job(path):
+        jobs = db.get_jobs(limit=200)
+        for job in jobs:
+            status = (job.get("status") or "").strip().lower()
+            if path and (job.get("input_path") or "") != path:
+                continue
+            if status in {"queued", "running", "paused", "restarting", "cancel_requested"}:
+                return job
+        return jobs[0] if jobs else None
+
+    def _control_workflow(path, action):
+        job = _find_latest_workflow_job(path)
+        if not job:
+            return "⚠️ No workflow job found for this folder."
+        target_by_action = {"pause": "paused", "resume": "running", "restart": "restarting"}
+        target = target_by_action[action]
+        try:
+            db.update_job_status(job["id"], target, log=f"ui_{action}_requested")
+            if action == "restart":
+                db.update_job_status(job["id"], "queued", log="ui_restart_queued")
+            return f"✅ {action.title()} requested for job #{job['id']} (optimistic)."
+        except ValueError as exc:
+            return f"⚠️ Conflict: {exc}"
+        except Exception as exc:
+            return f"❌ {action.title()} failed: {exc}"
+
     def _run_all_pending(path):
         if not path:
             return
@@ -471,6 +502,22 @@ def create_tab(app_config, scoring_runner, tagging_runner, selection_runner, orc
         fn=lambda p: _retry_phase(p, "keywords"),
         inputs=[components["selected_path"]],
         outputs=[]
+    )
+
+    components["pause_workflow_btn"].click(
+        fn=lambda p: _control_workflow(p, "pause"),
+        inputs=[components["selected_path"]],
+        outputs=[components["lifecycle_status"]],
+    )
+    components["resume_workflow_btn"].click(
+        fn=lambda p: _control_workflow(p, "resume"),
+        inputs=[components["selected_path"]],
+        outputs=[components["lifecycle_status"]],
+    )
+    components["restart_workflow_btn"].click(
+        fn=lambda p: _control_workflow(p, "restart"),
+        inputs=[components["selected_path"]],
+        outputs=[components["lifecycle_status"]],
     )
 
     return components
@@ -712,6 +759,10 @@ _STATUS_LABELS = {
     "not_started": "Not Started",
     "failed": "Failed",
     "running": "Running",
+    "queued": "Queued",
+    "paused": "Paused",
+    "cancel_requested": "Cancel Requested",
+    "restarting": "Restarting",
     "skipped": "Skipped",
 }
 
@@ -720,6 +771,10 @@ _STATUS_BADGE_CLASS = {
     "done": "success",
     "partial": "info",
     "running": "info",
+    "queued": "info",
+    "paused": "warning",
+    "cancel_requested": "warning",
+    "restarting": "info",
     "failed": "error",
     "skipped": "warning",
     "not_started": "",

--- a/modules/ui/tabs/pipeline.py
+++ b/modules/ui/tabs/pipeline.py
@@ -356,11 +356,22 @@ def create_tab(app_config, scoring_runner, tagging_runner, selection_runner, orc
         job = _find_latest_workflow_job(path)
         if not job:
             return "⚠️ No workflow job found for this folder."
-        target_by_action = {"pause": "paused", "resume": "running", "restart": "restarting"}
-        target = target_by_action[action]
+
+        phase = (job.get("job_type") or "").strip().lower()
         try:
-            db.update_job_status(job["id"], target, log=f"ui_{action}_requested")
-            if action == "restart":
+            if action == "pause":
+                # Best-effort stop so paused status reflects real execution state.
+                if phase in ("score", "scoring") and scoring_runner:
+                    scoring_runner.stop()
+                elif phase in ("selection", "culling") and selection_runner:
+                    selection_runner.stop()
+                elif phase in ("tag", "tagging", "keywords") and tagging_runner:
+                    tagging_runner.stop()
+                db.update_job_status(job["id"], "paused", log="ui_pause_requested")
+            elif action == "resume":
+                db.update_job_status(job["id"], "queued", log="ui_resume_requested")
+            else:  # restart
+                db.update_job_status(job["id"], "restarting", log="ui_restart_requested")
                 db.update_job_status(job["id"], "queued", log="ui_restart_queued")
             return f"✅ {action.title()} requested for job #{job['id']} (optimistic)."
         except ValueError as exc:

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -421,8 +421,10 @@ def test_all_status_returns_all_keys(monkeypatch):
 
 def test_pause_workflow_run_returns_conflict(monkeypatch):
     monkeypatch.setattr(db, "get_job_by_id", lambda job_id: {"id": job_id, "status": "completed"})
+
     def _raise(*args, **kwargs):
         raise ValueError("Invalid job status transition: completed -> paused")
+
     monkeypatch.setattr(db, "update_job_status", _raise)
     with _build_client() as client:
         response = client.post("/api/workflow-runs/1/pause", json={})
@@ -432,7 +434,11 @@ def test_pause_workflow_run_returns_conflict(monkeypatch):
 def test_resume_stage_run_success(monkeypatch):
     monkeypatch.setattr(db, "get_job_by_id", lambda job_id: {"id": job_id, "status": "paused"})
     monkeypatch.setattr(db, "get_job_phases", lambda job_id: [{"phase_code": "scoring", "state": "paused"}])
-    monkeypatch.setattr(db, "set_job_phase_state", lambda *args, **kwargs: [{"phase_code": "scoring", "state": "running"}])
+    monkeypatch.setattr(
+        db,
+        "set_job_phase_state",
+        lambda *args, **kwargs: [{"phase_code": "scoring", "state": "running"}],
+    )
     with _build_client() as client:
         response = client.post("/api/stage-runs/1/scoring/resume", json={})
     assert response.status_code == 200
@@ -441,7 +447,12 @@ def test_resume_stage_run_success(monkeypatch):
 
 def test_restart_step_run_success(monkeypatch):
     calls = []
-    monkeypatch.setattr(db, "set_image_phase_status", lambda image_id, phase_code, status, error=None: calls.append(status))
+
+    monkeypatch.setattr(
+        db,
+        "set_image_phase_status",
+        lambda image_id, phase_code, status, error=None: calls.append(status),
+    )
     monkeypatch.setattr(db, "get_image_phase_statuses", lambda image_id: {"scoring": {"status": "queued"}})
     with _build_client() as client:
         response = client.post("/api/step-runs/99/scoring/restart", json={})

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -458,3 +458,36 @@ def test_restart_step_run_success(monkeypatch):
         response = client.post("/api/step-runs/99/scoring/restart", json={})
     assert response.status_code == 200
     assert calls == ["restarting", "queued"]
+
+
+def test_resume_workflow_run_queues_for_dispatch(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(db, "get_job_by_id", lambda job_id: {"id": job_id, "status": "paused", "job_type": "scoring"})
+
+    def _update(job_id, status, log=None, **kwargs):
+        calls.append(status)
+
+    monkeypatch.setattr(db, "update_job_status", _update)
+    with _build_client() as client:
+        response = client.post("/api/workflow-runs/1/resume", json={})
+    assert response.status_code == 200
+    assert calls == ["queued"]
+
+
+def test_pause_workflow_run_stops_runner_best_effort(monkeypatch):
+    class _StopRunner:
+        def __init__(self):
+            self.stopped = False
+
+        def stop(self):
+            self.stopped = True
+
+    runner = _StopRunner()
+    monkeypatch.setattr(api, "_scoring_runner", runner)
+    monkeypatch.setattr(db, "get_job_by_id", lambda job_id: {"id": job_id, "status": "running", "job_type": "scoring"})
+    monkeypatch.setattr(db, "update_job_status", lambda *args, **kwargs: None)
+    with _build_client() as client:
+        response = client.post("/api/workflow-runs/1/pause", json={})
+    assert response.status_code == 200
+    assert runner.stopped is True

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -417,3 +417,33 @@ def test_all_status_returns_all_keys(monkeypatch):
     data = response.json()
     assert "scoring" in data
     assert "tagging" in data
+
+
+def test_pause_workflow_run_returns_conflict(monkeypatch):
+    monkeypatch.setattr(db, "get_job_by_id", lambda job_id: {"id": job_id, "status": "completed"})
+    def _raise(*args, **kwargs):
+        raise ValueError("Invalid job status transition: completed -> paused")
+    monkeypatch.setattr(db, "update_job_status", _raise)
+    with _build_client() as client:
+        response = client.post("/api/workflow-runs/1/pause", json={})
+    assert response.status_code == 409
+
+
+def test_resume_stage_run_success(monkeypatch):
+    monkeypatch.setattr(db, "get_job_by_id", lambda job_id: {"id": job_id, "status": "paused"})
+    monkeypatch.setattr(db, "get_job_phases", lambda job_id: [{"phase_code": "scoring", "state": "paused"}])
+    monkeypatch.setattr(db, "set_job_phase_state", lambda *args, **kwargs: [{"phase_code": "scoring", "state": "running"}])
+    with _build_client() as client:
+        response = client.post("/api/stage-runs/1/scoring/resume", json={})
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+
+
+def test_restart_step_run_success(monkeypatch):
+    calls = []
+    monkeypatch.setattr(db, "set_image_phase_status", lambda image_id, phase_code, status, error=None: calls.append(status))
+    monkeypatch.setattr(db, "get_image_phase_statuses", lambda image_id: {"scoring": {"status": "queued"}})
+    with _build_client() as client:
+        response = client.post("/api/step-runs/99/scoring/restart", json={})
+    assert response.status_code == 200
+    assert calls == ["restarting", "queued"]

--- a/tests/test_db_core.py
+++ b/tests/test_db_core.py
@@ -138,6 +138,15 @@ def test_update_job_status_changes_status(test_db):
     assert row[0].strip() == "running"
 
 
+
+
+def test_update_job_status_rejects_invalid_transition(test_db):
+    job_id = db.create_job("/test/job_invalid/path")
+    db.update_job_status(job_id, "completed")
+    with pytest.raises(ValueError):
+        db.update_job_status(job_id, "paused")
+
+
 def test_request_cancel_job_returns_not_found_for_missing(test_db):
     result = db.request_cancel_job(999999)
     assert result.get("success") is False

--- a/tests/test_db_core.py
+++ b/tests/test_db_core.py
@@ -138,15 +138,6 @@ def test_update_job_status_changes_status(test_db):
     assert row[0].strip() == "running"
 
 
-
-
-def test_update_job_status_rejects_invalid_transition(test_db):
-    job_id = db.create_job("/test/job_invalid/path")
-    db.update_job_status(job_id, "completed")
-    with pytest.raises(ValueError):
-        db.update_job_status(job_id, "paused")
-
-
 def test_request_cancel_job_returns_not_found_for_missing(test_db):
     result = db.request_cancel_job(999999)
     assert result.get("success") is False
@@ -268,3 +259,10 @@ def test_get_all_folders_returns_list(test_db):
     folders = db.get_all_folders()
     assert isinstance(folders, list)
     assert len(folders) >= 1
+
+
+def test_update_job_status_rejects_invalid_transition(test_db):
+    job_id = db.create_job("/test/job_invalid/path")
+    db.update_job_status(job_id, "completed")
+    with pytest.raises(ValueError):
+        db.update_job_status(job_id, "paused")


### PR DESCRIPTION
### Motivation

- Introduce richer lifecycle states (`queued`, `paused`, `cancel_requested`, `restarting`) so jobs/phases/steps can be paused, restarted, and queued with durable semantics. 
- Enforce transition guards in the DB and surface lifecycle controls in the HTTP API and UI so users can request pause/resume/restart and get conflict feedback when transitions are invalid.

### Description

- Expanded `PhaseStatus` in `modules/phases.py` to include `queued`, `paused`, `cancel_requested`, and `restarting` and extended `ALLOWED_TRANSITIONS` accordingly.
- Tightened job/phase transition logic in `modules/db.py`: extended `JOB_ALLOWED_TRANSITIONS`, enforced allowed transitions in `update_job_status`, mapped job status → `job_phases` states, added allowed-state checks in `set_job_phase_state`, and added image-level transition validation in `set_image_phase_status`.
- Updated folder summary derivation in `modules/db.py` to count and expose `queued`, `paused`, `cancel_requested`, and `restarting` image-phase counts and to surface those states in the folder-phase summary payload.
- Added lifecycle control surfaces in `modules/api.py`: `LifecycleControlRequest` model, helper controllers (`_control_job`, `_control_stage`, `_control_step`) and endpoints for WorkflowRun, StageRun, and StepRun (`/api/workflow-runs/{job_id}/...`, `/api/stage-runs/{job_id}/{phase_code}/...`, `/api/step-runs/{image_id}/{phase_code}/...`) with invalid-transition → HTTP 409 mapping.
- Reflected controls in the UI in `modules/ui/tabs/pipeline.py`: added Pause/Resume/Restart workflow buttons, optimistic UI messages, and extended `_STATUS_LABELS`/`_STATUS_BADGE_CLASS` to show new lifecycle states and count fields in the phase cards.
- Added/updated unit tests to cover lifecycle endpoints and a DB transition test (`tests/test_api_endpoints.py`, `tests/test_db_core.py`).

### Testing

- Ran static compilation: `python -m py_compile modules/phases.py modules/db.py modules/api.py modules/ui/tabs/pipeline.py` succeeded.
- Exercised new API lifecycle endpoint tests: `pytest -q tests/test_api_endpoints.py::test_pause_workflow_run_returns_conflict tests/test_api_endpoints.py::test_resume_stage_run_success tests/test_api_endpoints.py::test_restart_step_run_success` — these targeted tests passed (3 passed, multiple warnings unrelated to the change were emitted).
- Ran DB transition unit test `pytest -q tests/test_db_core.py::test_update_job_status_rejects_invalid_transition` in this environment: it was not executed against a live Firebird instance here (test fixture requires Firebird), so the environment skipped/failed DB-suite collection; the change implements the expected `ValueError` guard in `update_job_status`.
- Attempted a UI/WebUI screenshot via Playwright, but the WebUI was not serving in this environment (`ERR_EMPTY_RESPONSE`), so no browser validation was captured.

Notes: broader integration tests that require a Firebird test DB or full WebUI/runner processes may fail or be skipped in this CI-like environment; core changes include transition guards and API surfaces ready for integration testing in an environment with the DB and runners available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7948f6a8c8323b33ec858debe4aba)