### PR TITLE
Add telemetry panel and in-memory pipeline event stream

### DIFF
--- a/modules/db.py
+++ b/modules/db.py
@@ -4,6 +4,8 @@ import os
 import datetime
 import logging
 import time
+import threading
+from collections import deque
 from pathlib import Path
 import traceback
 
@@ -32,6 +34,52 @@ JOB_ALLOWED_TRANSITIONS = {
     "failed": set(),
     "canceled": set(),
 }
+
+
+_PIPELINE_TELEMETRY_LOCK = threading.Lock()
+_PIPELINE_TELEMETRY_SEQ = 0
+_PIPELINE_TELEMETRY_EVENTS = deque(maxlen=3000)
+
+
+def record_pipeline_event(event_type, message, *, workflow_run=None, stage_run=None,
+                          step_run=None, category=None, severity="info",
+                          metadata=None, critical=False, noisy=False, source="db"):
+    """Append a normalized pipeline telemetry event to an in-memory ring buffer."""
+    global _PIPELINE_TELEMETRY_SEQ
+    event = {
+        "timestamp": datetime.datetime.now().isoformat(timespec="seconds"),
+        "event_type": event_type or "log",
+        "message": message or "",
+        "workflow_run": workflow_run,
+        "stage_run": stage_run,
+        "step_run": step_run,
+        "category": category or "pipeline",
+        "severity": severity or "info",
+        "metadata": metadata or {},
+        "critical": bool(critical),
+        "noisy": bool(noisy),
+        "source": source,
+    }
+    with _PIPELINE_TELEMETRY_LOCK:
+        _PIPELINE_TELEMETRY_SEQ += 1
+        event["seq"] = _PIPELINE_TELEMETRY_SEQ
+        _PIPELINE_TELEMETRY_EVENTS.append(event)
+    return event["seq"]
+
+
+def get_pipeline_events(since_seq=0, limit=250):
+    """Return pipeline telemetry events with sequence greater than `since_seq`."""
+    try:
+        since = int(since_seq or 0)
+    except (TypeError, ValueError):
+        since = 0
+    lim = max(1, min(int(limit or 250), 1000))
+    with _PIPELINE_TELEMETRY_LOCK:
+        rows = [evt.copy() for evt in _PIPELINE_TELEMETRY_EVENTS if evt.get("seq", 0) > since]
+        if len(rows) > lim:
+            rows = rows[-lim:]
+        latest_seq = _PIPELINE_TELEMETRY_SEQ
+    return {"events": rows, "latest_seq": latest_seq}
 
 
 def generate_image_uuid(metadata: dict | None) -> str:
@@ -3310,6 +3358,17 @@ def create_job(input_path, phase_code=None, job_type=None, status="pending", cur
     job_id = row[0] if row else None
     conn.commit()
     conn.close()
+
+    record_pipeline_event(
+        "state-change",
+        f"Job #{job_id} created ({status})",
+        workflow_run=job_id,
+        stage_run=phase_code or job_type or "pipeline",
+        step_run="job:create",
+        category="job",
+        metadata={"status": status, "input_path": input_path, "job_type": job_type, "phase_code": phase_code},
+        source="db.create_job",
+    )
     return job_id
 
 
@@ -3332,6 +3391,17 @@ def set_job_execution_cursor(job_id, current_phase=None, next_phase_index=None, 
     )
     conn.commit()
     conn.close()
+
+    record_pipeline_event(
+        "state-change",
+        f"Job #{job_id} cursor updated",
+        workflow_run=job_id,
+        stage_run=current_phase or "pipeline",
+        step_run="job:cursor",
+        category="phase-transition",
+        metadata={"current_phase": current_phase, "next_phase_index": next_phase_index, "runner_state": runner_state},
+        source="db.set_job_execution_cursor",
+    )
 
 
 def update_job_status(job_id, status, log=None, current_phase=None, next_phase_index=None, runner_state=None):
@@ -3406,6 +3476,34 @@ def update_job_status(job_id, status, log=None, current_phase=None, next_phase_i
 
     conn.commit()
     conn.close()
+
+    event_type = "state-change"
+    severity = "info"
+    if new_status == "failed":
+        event_type = "error"
+        severity = "error"
+    elif new_status in ("completed", "canceled"):
+        event_type = "recovery"
+        severity = "warning" if new_status == "canceled" else "info"
+
+    record_pipeline_event(
+        event_type,
+        f"Job #{job_id} status: {old_status} → {new_status}",
+        workflow_run=job_id,
+        stage_run=final_phase or "pipeline",
+        step_run="job:status",
+        category="job",
+        severity=severity,
+        metadata={
+            "old_status": old_status,
+            "status": new_status,
+            "current_phase": final_phase,
+            "next_phase_index": final_next_idx,
+            "runner_state": final_runner_state,
+        },
+        critical=new_status in ("failed", "interrupted"),
+        source="db.update_job_status",
+    )
 
     # Broadcast job status update
     try:
@@ -6667,6 +6765,23 @@ def set_image_phase_status(image_id, phase_code, status,
             pass
     finally:
         conn.close()
+
+    phase_text = phase_code.value if hasattr(phase_code, "value") else str(phase_code)
+    event_type = "progress" if status == PhaseStatus.RUNNING else "state-change"
+    severity = "error" if status == PhaseStatus.FAILED else ("warning" if status == PhaseStatus.SKIPPED else "info")
+    record_pipeline_event(
+        "error" if status == PhaseStatus.FAILED else event_type,
+        f"Image #{image_id} phase {phase_text}: {status}",
+        workflow_run=job_id,
+        stage_run=phase_text,
+        step_run=f"image:{image_id}",
+        category="phase",
+        severity=severity,
+        metadata={"image_id": image_id, "phase": phase_text, "status": status, "error": error, "skip_reason": skip_reason},
+        critical=status == PhaseStatus.FAILED,
+        noisy=True,
+        source="db.set_image_phase_status",
+    )
 
     if folder_id:
         invalidate_folder_phase_aggregates(folder_id=folder_id)

--- a/modules/ui/app.py
+++ b/modules/ui/app.py
@@ -95,9 +95,18 @@ def create_ui():
             settings_components = settings_tab.create_tab(app_config)
             
         # Monitor Loop
-        def monitor_status_wrapper(selected_folder):
+        def monitor_status_wrapper(selected_folder, telemetry_state, collapse_noisy, pin_critical):
             # Pass the currently selected folder from the Pipeline tree to update cards
-            res = pipeline.get_status_update(runner, tagging_runner, selection_runner, orchestrator, selected_folder)
+            res = pipeline.get_status_update(
+                runner,
+                tagging_runner,
+                selection_runner,
+                orchestrator,
+                selected_folder,
+                telemetry_state,
+                collapse_noisy,
+                pin_critical,
+            )
             return list(res)
 
         monitor_outputs = [
@@ -115,11 +124,18 @@ def create_ui():
             pipeline_components["repair_index_meta_btn"],
             pipeline_components["run_metadata_btn"],
             pipeline_components["quick_start_html"],
+            pipeline_components["telemetry_html"],
+            pipeline_components["telemetry_state"],
         ]
 
         status_timer.tick(
             fn=monitor_status_wrapper,
-            inputs=[pipeline_components.get("selected_path")],
+            inputs=[
+                pipeline_components.get("selected_path"),
+                pipeline_components.get("telemetry_state"),
+                pipeline_components.get("telemetry_collapse_noisy"),
+                pipeline_components.get("telemetry_pin_critical"),
+            ],
             outputs=monitor_outputs
         )
 

--- a/modules/ui/assets.py
+++ b/modules/ui/assets.py
@@ -1281,6 +1281,29 @@ button.media-button.svelte-ao1xvt {
   box-shadow: none !important;
 }
 
+.telemetry-list {
+  display: flex !important;
+  flex-direction: column !important;
+  gap: 8px !important;
+  max-height: 320px !important;
+  overflow-y: auto !important;
+}
+
+.telemetry-item {
+  border: 1px solid var(--border-color) !important;
+  border-radius: var(--radius-sm) !important;
+  padding: 8px !important;
+  background: rgba(255,255,255,0.02) !important;
+}
+
+.telemetry-item.telemetry-warning {
+  border-color: var(--accent-warning) !important;
+}
+
+.telemetry-item.telemetry-error {
+  border-color: var(--accent-danger) !important;
+}
+
 .section-divider {
   border-top: 1px solid var(--border-color) !important;
   margin: 15px 0 !important;

--- a/modules/ui/tabs/pipeline.py
+++ b/modules/ui/tabs/pipeline.py
@@ -195,6 +195,15 @@ def create_tab(app_config, scoring_runner, tagging_runner, selection_runner, orc
                             lines=12, label="", max_lines=12, interactive=False, elem_classes=["console-code"]
                         )
 
+                # PANEL: Telemetry
+                with gr.Group(elem_classes=["panel", "telemetry-card"]):
+                    gr.HTML("<div class='panel-header'><h2 class='panel-title'>Telemetry</h2></div>")
+                    with gr.Row(elem_classes=["pipeline-actions"]):
+                        components["telemetry_collapse_noisy"] = gr.Checkbox(label="Collapse noisy per-image logs", value=True)
+                        components["telemetry_pin_critical"] = gr.Checkbox(label="Pin critical failures", value=True)
+                    components["telemetry_html"] = gr.HTML(_build_telemetry_html([], collapse_noisy=True, pin_critical=True))
+                    components["telemetry_state"] = gr.State({"last_seq": 0, "last_runner_log": "", "last_running": False, "events": []})
+
     # Wire up folder selection to update HTML rendering (force_refresh to avoid stale cache)
     components["selected_path"].change(
         fn=lambda p: _update_folder_selection(p, force_refresh=True)[:6],
@@ -509,7 +518,7 @@ def _update_folder_selection(folder_path: str, force_refresh=False, is_running=F
     )
 
 
-def get_status_update(scoring_runner, tagging_runner, selection_runner, orchestrator, selected_folder):
+def get_status_update(scoring_runner, tagging_runner, selection_runner, orchestrator, selected_folder, telemetry_state, collapse_noisy, pin_critical):
     """Called regularly by the main app timer to update components."""
     # Process Orchestrator tick
     orchestrator.on_tick()
@@ -519,6 +528,78 @@ def get_status_update(scoring_runner, tagging_runner, selection_runner, orchestr
     )
 
     queued_jobs = db.get_queued_jobs(limit=5)
+
+    telemetry_state = telemetry_state or {}
+    telemetry_events = list(telemetry_state.get("events", []))
+
+    # Poll persisted telemetry from DB/runners broadcast points
+    last_seq = telemetry_state.get("last_seq", 0)
+    event_batch = db.get_pipeline_events(since_seq=last_seq, limit=300)
+    telemetry_events.extend(event_batch.get("events", []))
+    telemetry_state["last_seq"] = event_batch.get("latest_seq", last_seq)
+
+    # Ingest runner status stream into telemetry events (progress/log)
+    log_text = console_out or ""
+    prev_log = telemetry_state.get("last_runner_log", "")
+    if log_text != prev_log:
+        new_lines = [ln for ln in log_text[len(prev_log):].splitlines() if ln.strip()] if log_text.startswith(prev_log) else [ln for ln in log_text.splitlines() if ln.strip()]
+        for line in new_lines[-80:]:
+            sev = "error" if "error" in line.lower() else ("warning" if "warn" in line.lower() else "info")
+            telemetry_events.append({
+                "event_type": "log" if sev == "info" else ("error" if sev == "error" else "log"),
+                "message": line,
+                "severity": sev,
+                "workflow_run": None,
+                "stage_run": mon_name.lower() if mon_name else None,
+                "step_run": "runner:log",
+                "category": "runner-log",
+                "critical": sev == "error",
+                "noisy": True,
+                "source": "runner.get_status",
+                "timestamp": "",
+                "seq": 0,
+            })
+    telemetry_state["last_runner_log"] = log_text
+
+    # State transitions from runner polling
+    if telemetry_state.get("last_running") != is_running:
+        telemetry_events.append({
+            "event_type": "state-change",
+            "message": "Pipeline run started" if is_running else "Pipeline run became idle",
+            "severity": "info",
+            "workflow_run": None,
+            "stage_run": mon_name.lower() if mon_name else "pipeline",
+            "step_run": "runner:state",
+            "category": "phase-transition",
+            "critical": False,
+            "noisy": False,
+            "source": "runner.get_status",
+            "timestamp": "",
+            "seq": 0,
+        })
+    telemetry_state["last_running"] = is_running
+
+    # Throughput counter from monitor values
+    if is_running and mon_tot > 0:
+        telemetry_events.append({
+            "event_type": "progress",
+            "message": f"{mon_name}: {mon_cur}/{mon_tot}",
+            "severity": "info",
+            "workflow_run": None,
+            "stage_run": mon_name.lower() if mon_name else None,
+            "step_run": "runner:throughput",
+            "category": "throughput",
+            "critical": False,
+            "noisy": True,
+            "source": "get_status_update",
+            "timestamp": "",
+            "seq": 0,
+        })
+
+    if len(telemetry_events) > 600:
+        telemetry_events = telemetry_events[-600:]
+    telemetry_state["events"] = telemetry_events
+    telemetry_html = _build_telemetry_html(telemetry_events, collapse_noisy=bool(collapse_noisy), pin_critical=bool(pin_critical))
 
     # Rebuild stepper/cards from current folder state (force_refresh when running for real-time updates)
     res_summary, res_stepper, res_sc, res_cu, res_kw, res_qs, folder_total = _update_folder_selection(
@@ -557,12 +638,14 @@ def get_status_update(scoring_runner, tagging_runner, selection_runner, orchestr
         gr.update(interactive=not_running),  # repair_index_meta
         gr.update(interactive=not_running),  # run_metadata
         res_qs,                              # quick_start
+        telemetry_html,
+        telemetry_state,
     )
 
     # Skip SSE push if nothing changed since last tick
-    cache_key = (res_stepper, res_sc, res_cu, res_kw, monitor_html, console_out, is_running)
+    cache_key = (res_stepper, res_sc, res_cu, res_kw, monitor_html, console_out, is_running, telemetry_html)
     if cache_key == _last_status_cache["state"]:
-        return tuple(gr.skip() for _ in range(14))
+        return tuple(gr.skip() for _ in range(16))
     _last_status_cache["state"] = cache_key
 
     return result
@@ -704,6 +787,51 @@ def _build_monitor_html(name, msg, current, total, queued_jobs=None, folder_tota
       {_render_queue_html(queued_jobs)}
     </div>
     """
+
+
+def _build_telemetry_html(events, collapse_noisy=True, pin_critical=True):
+    events = events or []
+    if not events:
+        return "<div class='panel-body'><p class='section-microcopy'>No telemetry events yet.</p></div>"
+
+    critical = [e for e in events if e.get("critical")]
+    normal = [e for e in events if not e.get("critical")]
+    noisy_count = 0
+    if collapse_noisy:
+        filtered = []
+        for ev in normal:
+            if ev.get("noisy") and ev.get("category") in ("runner-log", "phase", "throughput"):
+                noisy_count += 1
+                continue
+            filtered.append(ev)
+        normal = filtered
+
+    ordered = (critical + normal) if pin_critical else events
+    ordered = ordered[-120:]
+
+    lines = ["<div class='panel-body'><div class='telemetry-list'>"]
+    if noisy_count:
+        lines.append(f"<p class='section-microcopy'>Collapsed {noisy_count} noisy event(s).</p>")
+
+    for ev in ordered:
+        etype = (ev.get("event_type") or "log").strip()
+        severity = (ev.get("severity") or "info").strip()
+        cls = f"telemetry-item telemetry-{severity}"
+        run = " / ".join(x for x in [str(ev.get("workflow_run") or ""), str(ev.get("stage_run") or ""), str(ev.get("step_run") or "")] if x)
+        run_html = f"<div class='section-microcopy'>{run}</div>" if run else ""
+        stamp = ev.get("timestamp") or ""
+        badge = "<span class='status-badge error'>PIN</span>" if ev.get("critical") else ""
+        lines.append(
+            f"<div class='{cls}'>"
+            f"<div><strong>[{etype}]</strong> {ev.get('message','')}</div>"
+            f"{run_html}"
+            f"<div class='section-microcopy'>{stamp} · {ev.get('source','')}</div>"
+            f"{badge}"
+            f"</div>"
+        )
+
+    lines.append("</div></div>")
+    return "".join(lines)
 
 
 _STATUS_LABELS = {


### PR DESCRIPTION
### Motivation
- Provide a live telemetry view that groups and streams pipeline events by WorkflowRun / StageRun / StepRun and surfaces state changes, progress, logs, errors, recoveries, and throughput counters. 
- Ingest events from existing broadcast points and runner status so operators can collapse noisy per-image logs and pin critical failures for quicker diagnosis.

### Description
- Added an in-memory, sequence-indexed telemetry buffer in `modules/db.py` with `record_pipeline_event` and `get_pipeline_events` to normalize and expose telemetry events (type, severity, workflow/stage/step, metadata, noisy/critical flags). 
- Wired telemetry emission into DB execution points used by the pipeline: `create_job`, `set_job_execution_cursor`, `update_job_status`, and `set_image_phase_status` so job lifecycle and per-image phase updates produce telemetry events. 
- Extended the Pipeline UI (`modules/ui/tabs/pipeline.py` + `modules/ui/app.py`) with a Telemetry panel and controls to collapse noisy per-image logs and pin critical failures, plus `_build_telemetry_html` to render grouped events; `get_status_update` now polls `db.get_pipeline_events` and also ingests runner log/progress/state transitions into the panel. 
- Added styling for telemetry list/items in `modules/ui/assets.py`, adjusted timer wiring to pass telemetry state/filters, and included telemetry output in the regular SSE/timer cache key to avoid unnecessary pushes.

### Testing
- Ran `python -m py_compile modules/db.py modules/ui/tabs/pipeline.py modules/ui/app.py modules/ui/assets.py` which completed successfully. 
- Attempted a Playwright-based UI screenshot against `http://127.0.0.1:7860`, but the local WebUI server did not respond in this environment so the screenshot/run failed. 
- No new unit tests were added in this change set; the implementation is intentionally backed by an in-memory ring buffer for low-risk rollout and can be extended to persistent storage later.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b794a6a4a08323a563c1a63721b098)