### PR TITLE
Add Pipeline Target Composer UI and selector-to-payload mapping for pipeline submit

### DIFF
--- a/modules/api.py
+++ b/modules/api.py
@@ -57,6 +57,11 @@ import logging
 from pathlib import Path
 from modules.phases_policy import explain_phase_run_decision
 from modules.selector_resolver import resolve_selectors
+from modules.pipeline_selector_composer import (
+    compose_selector_request,
+    validate_and_preview,
+    serialize_queue_payload,
+)
 
 from modules.job_dispatcher import JobDispatcher
 
@@ -513,7 +518,7 @@ class ImportRegisterRequest(BaseModel):
     })
 
 
-class PipelineSubmitRequest(BaseModel):
+class PipelineSubmitRequest(SelectorRequest):
     """Request model for submitting images/folders to the processing pipeline.
 
     Chains requested operations sequentially (score -> tag -> cluster).
@@ -523,8 +528,8 @@ class PipelineSubmitRequest(BaseModel):
         operations: List of operations to run in order. Valid: "score", "tag", "cluster".
         options: Optional per-operation options.
     """
-    input_path: str = Field(
-        ...,
+    input_path: Optional[str] = Field(
+        None,
         description="File or directory path to process.",
         example="D:/Photos/2024"
     )
@@ -558,6 +563,10 @@ class PipelineSubmitRequest(BaseModel):
     clustering_force_rescan: bool = Field(
         False,
         description="If True, force re-clustering even when folder was already clustered."
+    )
+    exclude_image_paths: Optional[List[str]] = Field(
+        None,
+        description="Optional image paths to exclude from resolved selector targets."
     )
 
 
@@ -2672,10 +2681,29 @@ def create_api_router() -> APIRouter:
         from modules.ui.security import _check_rate_limit
         _check_rate_limit("pipeline_submit")
 
-        if not request.input_path or not request.input_path.strip():
-            raise HTTPException(status_code=400, detail="input_path is required")
-        if not os.path.exists(request.input_path):
-            raise HTTPException(status_code=400, detail=f"Path not found: {request.input_path}")
+        has_selector = any([
+            request.input_path,
+            request.image_ids,
+            request.image_paths,
+            request.folder_ids,
+            request.folder_paths,
+        ])
+        if not has_selector:
+            raise HTTPException(status_code=400, detail="Provide input_path or at least one selector")
+
+        selector_request = compose_selector_request(
+            input_path=request.input_path,
+            image_ids_raw=",".join(str(i) for i in (request.image_ids or [])),
+            image_paths_raw=",".join(request.image_paths or []),
+            folder_ids_raw=",".join(str(i) for i in (request.folder_ids or [])),
+            folder_paths_raw=",".join(request.folder_paths or []),
+            exclude_image_paths_raw=",".join(request.exclude_image_paths or []),
+            recursive=request.recursive,
+        )
+        preview = validate_and_preview(selector_request)
+        resolved_count = int(preview.get("preview_count") or 0)
+        if resolved_count <= 0:
+            raise HTTPException(status_code=400, detail="No images matched selectors")
 
         valid_ops = {"indexing", "metadata", "score", "tag", "cluster"}
         invalid_ops = [op for op in request.operations if op not in valid_ops]
@@ -2684,7 +2712,7 @@ def create_api_router() -> APIRouter:
         if not request.operations:
             raise HTTPException(status_code=400, detail="At least one operation is required")
 
-        is_file = os.path.isfile(request.input_path)
+        is_file = bool(request.input_path and os.path.isfile(request.input_path))
         if is_file and "cluster" in request.operations:
             raise HTTPException(status_code=400, detail="Clustering requires a folder path, not a single file")
 
@@ -2755,11 +2783,14 @@ def create_api_router() -> APIRouter:
                 request.input_path,
                 phase_code=op_to_phase_code[first_op],
                 job_type="scoring", # Scoring runner handles indexing/metadata/scoring
-                queue_payload={
-                    "input_path": request.input_path, 
-                    "skip_existing": request.skip_existing,
-                    "target_phases": target_phases
-                },
+                queue_payload=serialize_queue_payload(
+                    {
+                        "input_path": request.input_path,
+                        "skip_existing": request.skip_existing,
+                        "target_phases": target_phases,
+                    },
+                    preview,
+                ),
             )
         elif first_op == "tag":
             if _tagging_runner is None:
@@ -2768,12 +2799,15 @@ def create_api_router() -> APIRouter:
                 request.input_path,
                 phase_code="keywords",
                 job_type="tagging",
-                queue_payload={
-                    "input_path": request.input_path,
-                    "custom_keywords": request.custom_keywords,
-                    "overwrite": not request.skip_existing,
-                    "generate_captions": request.generate_captions,
-                },
+                queue_payload=serialize_queue_payload(
+                    {
+                        "input_path": request.input_path,
+                        "custom_keywords": request.custom_keywords,
+                        "overwrite": not request.skip_existing,
+                        "generate_captions": request.generate_captions,
+                    },
+                    preview,
+                ),
             )
         else:
             if _clustering_runner is None:
@@ -2782,12 +2816,15 @@ def create_api_router() -> APIRouter:
                 request.input_path,
                 phase_code="culling",
                 job_type="clustering",
-                queue_payload={
-                    "input_path": request.input_path,
-                    "threshold": request.clustering_threshold,
-                    "time_gap": request.clustering_time_gap,
-                    "force_rescan": request.clustering_force_rescan,
-                },
+                queue_payload=serialize_queue_payload(
+                    {
+                        "input_path": request.input_path,
+                        "threshold": request.clustering_threshold,
+                        "time_gap": request.clustering_time_gap,
+                        "force_rescan": request.clustering_force_rescan,
+                    },
+                    preview,
+                ),
             )
 
         if job_id is None:
@@ -2805,6 +2842,8 @@ def create_api_router() -> APIRouter:
                 "queue_position": queue_position,
                 "phase_plan": phase_rows,
                 "remaining_operations": request.operations[1:],
+                "resolved_count": resolved_count,
+                "warnings": preview.get("warnings") or [],
             },
         )
 

--- a/modules/api.py
+++ b/modules/api.py
@@ -2693,11 +2693,11 @@ def create_api_router() -> APIRouter:
 
         selector_request = compose_selector_request(
             input_path=request.input_path,
-            image_ids_raw=",".join(str(i) for i in (request.image_ids or [])),
-            image_paths_raw=",".join(request.image_paths or []),
-            folder_ids_raw=",".join(str(i) for i in (request.folder_ids or [])),
-            folder_paths_raw=",".join(request.folder_paths or []),
-            exclude_image_paths_raw=",".join(request.exclude_image_paths or []),
+            image_ids_raw=request.image_ids,
+            image_paths_raw=request.image_paths,
+            folder_ids_raw=request.folder_ids,
+            folder_paths_raw=request.folder_paths,
+            exclude_image_paths_raw=request.exclude_image_paths,
             recursive=request.recursive,
         )
         preview = validate_and_preview(selector_request)
@@ -2715,6 +2715,10 @@ def create_api_router() -> APIRouter:
         is_file = bool(request.input_path and os.path.isfile(request.input_path))
         if is_file and "cluster" in request.operations:
             raise HTTPException(status_code=400, detail="Clustering requires a folder path, not a single file")
+        if "cluster" in request.operations and not any([request.input_path, request.folder_ids, request.folder_paths]):
+            raise HTTPException(status_code=400, detail="Clustering requires a folder selector")
+
+        queue_input_path = request.input_path or "SELECTOR_PIPELINE"
 
         from modules import db
         first_op = request.operations[0]
@@ -2780,7 +2784,7 @@ def create_api_router() -> APIRouter:
             target_phases = [op_to_phase_code.get(op) for op in request.operations if op in ["indexing", "metadata", "score"]]
             
             job_id, queue_position = db.enqueue_job(
-                request.input_path,
+                queue_input_path,
                 phase_code=op_to_phase_code[first_op],
                 job_type="scoring", # Scoring runner handles indexing/metadata/scoring
                 queue_payload=serialize_queue_payload(
@@ -2796,7 +2800,7 @@ def create_api_router() -> APIRouter:
             if _tagging_runner is None:
                 raise HTTPException(status_code=503, detail="Tagging runner not available")
             job_id, queue_position = db.enqueue_job(
-                request.input_path,
+                queue_input_path,
                 phase_code="keywords",
                 job_type="tagging",
                 queue_payload=serialize_queue_payload(
@@ -2813,7 +2817,7 @@ def create_api_router() -> APIRouter:
             if _clustering_runner is None:
                 raise HTTPException(status_code=503, detail="Clustering runner not available")
             job_id, queue_position = db.enqueue_job(
-                request.input_path,
+                queue_input_path,
                 phase_code="culling",
                 job_type="clustering",
                 queue_payload=serialize_queue_payload(
@@ -2838,6 +2842,7 @@ def create_api_router() -> APIRouter:
             data={
                 "job_id": job_id,
                 "input_path": request.input_path,
+                "selector_source": queue_input_path,
                 "current_operation": first_op,
                 "queue_position": queue_position,
                 "phase_plan": phase_rows,

--- a/modules/pipeline_selector_composer.py
+++ b/modules/pipeline_selector_composer.py
@@ -12,18 +12,25 @@ from modules.selector_resolver import resolve_selectors
 PRESET_FILE = os.path.join("tmp", "pipeline_selector_presets.json")
 
 
-def _split_csv_lines(raw: str | None) -> list[str]:
-    if not raw:
+def _coerce_items(raw: Any) -> list[str]:
+    if raw is None:
         return []
+    if isinstance(raw, (list, tuple, set)):
+        return [str(item) for item in raw]
+    return [str(raw)]
+
+
+def _split_csv_lines(raw: Any) -> list[str]:
     out: list[str] = []
-    for line in str(raw).replace("\n", ",").split(","):
-        val = line.strip()
-        if val:
-            out.append(val)
+    for chunk in _coerce_items(raw):
+        for line in chunk.replace("\n", ",").split(","):
+            val = line.strip()
+            if val:
+                out.append(val)
     return out
 
 
-def _to_ints(values: Iterable[str]) -> list[int]:
+def _to_ints(values: Iterable[Any]) -> list[int]:
     out: list[int] = []
     for value in values:
         try:
@@ -35,11 +42,11 @@ def _to_ints(values: Iterable[str]) -> list[int]:
 
 def compose_selector_request(
     input_path: str | None = None,
-    image_ids_raw: str | None = None,
-    image_paths_raw: str | None = None,
-    folder_ids_raw: str | None = None,
-    folder_paths_raw: str | None = None,
-    exclude_image_paths_raw: str | None = None,
+    image_ids_raw: Any = None,
+    image_paths_raw: Any = None,
+    folder_ids_raw: Any = None,
+    folder_paths_raw: Any = None,
+    exclude_image_paths_raw: Any = None,
     recursive: bool = True,
 ) -> dict[str, Any]:
     image_ids = _to_ints(_split_csv_lines(image_ids_raw))
@@ -48,16 +55,15 @@ def compose_selector_request(
     folder_paths = _split_csv_lines(folder_paths_raw)
     exclude_image_paths = _split_csv_lines(exclude_image_paths_raw)
 
-    if input_path:
-        normalized = input_path.strip()
-        if normalized:
-            if os.path.isdir(normalized):
-                folder_paths.append(normalized)
-            else:
-                image_paths.append(normalized)
+    normalized_input_path = input_path.strip() if isinstance(input_path, str) and input_path.strip() else None
+    if normalized_input_path:
+        if os.path.isdir(normalized_input_path):
+            folder_paths.append(normalized_input_path)
+        else:
+            image_paths.append(normalized_input_path)
 
     return {
-        "input_path": input_path.strip() if input_path else None,
+        "input_path": normalized_input_path,
         "image_ids": image_ids or None,
         "image_paths": image_paths or None,
         "folder_ids": folder_ids or None,
@@ -89,10 +95,17 @@ def validate_and_preview(request: dict[str, Any]) -> dict[str, Any]:
         excluded_ids = list(exclusion_result.get("resolved_image_ids") or [])
         missing_excluded_paths = list(exclusion_result.get("missing_image_paths") or [])
 
+    raw_selector_entries = []
+    raw_selector_entries.extend(_to_ints(request.get("image_ids") or []))
+    raw_selector_entries.extend(_split_csv_lines(request.get("image_paths") or []))
+    raw_selector_entries.extend(_to_ints(request.get("folder_ids") or []))
+    raw_selector_entries.extend(_split_csv_lines(request.get("folder_paths") or []))
+    duplicate_inclusion_count = max(0, len(raw_selector_entries) - len(set(raw_selector_entries)))
+
     resolved_ids = list(selector_result.get("resolved_image_ids") or [])
-    duplicate_inclusion_count = max(0, len(resolved_ids) - len(set(resolved_ids)))
     before_exclusion_count = len(set(resolved_ids))
-    resolved_ids = [image_id for image_id in resolved_ids if image_id not in set(excluded_ids)]
+    excluded_id_set = set(excluded_ids)
+    resolved_ids = [image_id for image_id in resolved_ids if image_id not in excluded_id_set]
 
     warnings: list[str] = []
     missing_paths = list(selector_result.get("missing_image_paths") or []) + list(selector_result.get("missing_folder_paths") or [])

--- a/modules/pipeline_selector_composer.py
+++ b/modules/pipeline_selector_composer.py
@@ -1,0 +1,148 @@
+"""Selector composition helpers for Pipeline UI and API pipeline submission."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Iterable
+
+from modules.selector_resolver import resolve_selectors
+
+
+PRESET_FILE = os.path.join("tmp", "pipeline_selector_presets.json")
+
+
+def _split_csv_lines(raw: str | None) -> list[str]:
+    if not raw:
+        return []
+    out: list[str] = []
+    for line in str(raw).replace("\n", ",").split(","):
+        val = line.strip()
+        if val:
+            out.append(val)
+    return out
+
+
+def _to_ints(values: Iterable[str]) -> list[int]:
+    out: list[int] = []
+    for value in values:
+        try:
+            out.append(int(value))
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
+def compose_selector_request(
+    input_path: str | None = None,
+    image_ids_raw: str | None = None,
+    image_paths_raw: str | None = None,
+    folder_ids_raw: str | None = None,
+    folder_paths_raw: str | None = None,
+    exclude_image_paths_raw: str | None = None,
+    recursive: bool = True,
+) -> dict[str, Any]:
+    image_ids = _to_ints(_split_csv_lines(image_ids_raw))
+    image_paths = _split_csv_lines(image_paths_raw)
+    folder_ids = _to_ints(_split_csv_lines(folder_ids_raw))
+    folder_paths = _split_csv_lines(folder_paths_raw)
+    exclude_image_paths = _split_csv_lines(exclude_image_paths_raw)
+
+    if input_path:
+        normalized = input_path.strip()
+        if normalized:
+            if os.path.isdir(normalized):
+                folder_paths.append(normalized)
+            else:
+                image_paths.append(normalized)
+
+    return {
+        "input_path": input_path.strip() if input_path else None,
+        "image_ids": image_ids or None,
+        "image_paths": image_paths or None,
+        "folder_ids": folder_ids or None,
+        "folder_paths": folder_paths or None,
+        "exclude_image_paths": exclude_image_paths or None,
+        "recursive": bool(recursive),
+    }
+
+
+def validate_and_preview(request: dict[str, Any]) -> dict[str, Any]:
+    selector_result = resolve_selectors(
+        image_ids=request.get("image_ids"),
+        image_paths=request.get("image_paths"),
+        folder_ids=request.get("folder_ids"),
+        folder_paths=request.get("folder_paths"),
+        recursive=bool(request.get("recursive", True)),
+        index_missing=True,
+    )
+
+    excluded_ids: list[int] = []
+    missing_excluded_paths: list[str] = []
+    exclude_paths = request.get("exclude_image_paths") or []
+    if exclude_paths:
+        exclusion_result = resolve_selectors(
+            image_paths=exclude_paths,
+            recursive=False,
+            index_missing=False,
+        )
+        excluded_ids = list(exclusion_result.get("resolved_image_ids") or [])
+        missing_excluded_paths = list(exclusion_result.get("missing_image_paths") or [])
+
+    resolved_ids = list(selector_result.get("resolved_image_ids") or [])
+    duplicate_inclusion_count = max(0, len(resolved_ids) - len(set(resolved_ids)))
+    before_exclusion_count = len(set(resolved_ids))
+    resolved_ids = [image_id for image_id in resolved_ids if image_id not in set(excluded_ids)]
+
+    warnings: list[str] = []
+    missing_paths = list(selector_result.get("missing_image_paths") or []) + list(selector_result.get("missing_folder_paths") or [])
+    if missing_paths:
+        warnings.append(f"Missing paths: {len(missing_paths)}")
+    if duplicate_inclusion_count:
+        warnings.append(f"Duplicate inclusion entries detected: {duplicate_inclusion_count}")
+    if exclude_paths:
+        warnings.append(f"Excluded files removed: {max(0, before_exclusion_count - len(resolved_ids))}")
+    if missing_excluded_paths:
+        warnings.append(f"Excluded paths not found: {len(missing_excluded_paths)}")
+
+    return {
+        "selector_result": selector_result,
+        "resolved_image_ids": resolved_ids,
+        "preview_count": len(resolved_ids),
+        "missing_paths": missing_paths,
+        "missing_excluded_paths": missing_excluded_paths,
+        "warnings": warnings,
+    }
+
+
+def serialize_queue_payload(base_payload: dict[str, Any], preview: dict[str, Any]) -> dict[str, Any]:
+    payload = dict(base_payload)
+    payload["resolved_image_ids"] = list(preview.get("resolved_image_ids") or [])
+    payload["selector_preview_count"] = int(preview.get("preview_count") or 0)
+    payload["missing_paths"] = list(preview.get("missing_paths") or [])
+    return payload
+
+
+def load_presets() -> dict[str, Any]:
+    if not os.path.exists(PRESET_FILE):
+        return {}
+    try:
+        with open(PRESET_FILE, "r", encoding="utf-8") as handle:
+            data = json.load(handle)
+            if isinstance(data, dict):
+                return data
+    except Exception:
+        return {}
+    return {}
+
+
+def save_preset(name: str, request: dict[str, Any]) -> dict[str, Any]:
+    clean_name = (name or "").strip()
+    if not clean_name:
+        raise ValueError("Preset name is required")
+    os.makedirs(os.path.dirname(PRESET_FILE), exist_ok=True)
+    presets = load_presets()
+    presets[clean_name] = request
+    with open(PRESET_FILE, "w", encoding="utf-8") as handle:
+        json.dump(presets, handle, indent=2)
+    return presets

--- a/modules/ui/tabs/pipeline.py
+++ b/modules/ui/tabs/pipeline.py
@@ -222,6 +222,9 @@ def create_tab(app_config, scoring_runner, tagging_runner, selection_runner, orc
                             lines=12, label="", max_lines=12, interactive=False, elem_classes=["console-code"]
                         )
 
+    def _sync_composer_path(path):
+        return path or ""
+
     # Wire up folder selection to update HTML rendering (force_refresh to avoid stale cache)
     components["selected_path"].change(
         fn=lambda p: _update_folder_selection(p, force_refresh=True)[:6],
@@ -234,6 +237,10 @@ def create_tab(app_config, scoring_runner, tagging_runner, selection_runner, orc
             components["keywords_card_html"],
             components["quick_start_html"],
         ]
+    ).then(
+        fn=_sync_composer_path,
+        inputs=[components["selected_path"]],
+        outputs=[components["composer_input_path"]],
     )
 
     def _on_refresh_click(selected_path):
@@ -264,6 +271,10 @@ def create_tab(app_config, scoring_runner, tagging_runner, selection_runner, orc
             components["keywords_card_html"],
             components["quick_start_html"],
         ],
+    ).then(
+        fn=_sync_composer_path,
+        inputs=[components["selected_path"]],
+        outputs=[components["composer_input_path"]],
     )
 
     components["refresh_btn"].click(
@@ -278,6 +289,10 @@ def create_tab(app_config, scoring_runner, tagging_runner, selection_runner, orc
             components["keywords_card_html"],
             components["quick_start_html"],
         ],
+    ).then(
+        fn=_sync_composer_path,
+        inputs=[components["selected_path"]],
+        outputs=[components["composer_input_path"]],
     )
 
     def _compose_request(input_path, image_ids, image_paths, folder_ids, folder_paths, exclude_paths, recursive):

--- a/modules/ui/tabs/pipeline.py
+++ b/modules/ui/tabs/pipeline.py
@@ -1,6 +1,7 @@
 import gradio as gr
 from modules import db
 from modules import ui_tree
+from modules.pipeline_selector_composer import compose_selector_request, validate_and_preview, save_preset, load_presets
 
 # Cache for timer-based status updates to avoid unnecessary SSE pushes
 _last_status_cache = {"state": None}
@@ -79,6 +80,32 @@ def create_tab(app_config, scoring_runner, tagging_runner, selection_runner, orc
                     _build_quick_start_html(None),
                     elem_classes=["animate-in"],
                 )
+
+
+                # PANEL: Target Composer
+                with gr.Group(elem_classes=["panel"]):
+                    gr.HTML("<div class='panel-header'><h2 class='panel-title'>Target Composer</h2></div>")
+                    with gr.Column(elem_classes=["panel-body"]):
+                        components["composer_modes"] = gr.CheckboxGroup(
+                            choices=["image", "file", "folder", "subtree", "list"],
+                            value=["folder"],
+                            label="Selector chips",
+                        )
+                        components["composer_input_path"] = gr.Textbox(label="Path (image or folder)", value="")
+                        with gr.Row():
+                            components["composer_image_ids"] = gr.Textbox(label="Image IDs (csv)", value="")
+                            components["composer_folder_ids"] = gr.Textbox(label="Folder IDs (csv)", value="")
+                        components["composer_image_paths"] = gr.Textbox(label="Image paths (csv/newline)", lines=2, value="")
+                        components["composer_folder_paths"] = gr.Textbox(label="Folder paths (csv/newline)", lines=2, value="")
+                        components["composer_exclude_paths"] = gr.Textbox(label="Exclude image paths (csv/newline)", lines=2, value="")
+                        components["composer_recursive"] = gr.Checkbox(label="Include subfolders", value=True)
+                        with gr.Row():
+                            components["composer_preset_name"] = gr.Textbox(label="Save preset as", value="")
+                            components["composer_preset_select"] = gr.Dropdown(label="Saved presets", choices=sorted(load_presets().keys()), value=None)
+                        with gr.Row():
+                            components["composer_preview_btn"] = gr.Button("Validate + Preview", elem_classes=["secondary-btn"])
+                            components["composer_save_preset_btn"] = gr.Button("Save Preset", elem_classes=["secondary-btn"])
+                        components["composer_preview_html"] = gr.HTML("<p class='section-microcopy'>Compose selectors and preview count before submit.</p>")
 
                 # PANEL: Pipeline Progress
                 with gr.Group(elem_classes=["panel"]):
@@ -252,6 +279,48 @@ def create_tab(app_config, scoring_runner, tagging_runner, selection_runner, orc
             components["quick_start_html"],
         ],
     )
+
+    def _compose_request(input_path, image_ids, image_paths, folder_ids, folder_paths, exclude_paths, recursive):
+        return compose_selector_request(
+            input_path=input_path,
+            image_ids_raw=image_ids,
+            image_paths_raw=image_paths,
+            folder_ids_raw=folder_ids,
+            folder_paths_raw=folder_paths,
+            exclude_image_paths_raw=exclude_paths,
+            recursive=recursive,
+        )
+
+    def _preview_composer(input_path, image_ids, image_paths, folder_ids, folder_paths, exclude_paths, recursive):
+        request = _compose_request(input_path, image_ids, image_paths, folder_ids, folder_paths, exclude_paths, recursive)
+        preview = validate_and_preview(request)
+        warning_items = ''.join(f"<li>{w}</li>" for w in (preview.get("warnings") or [])) or "<li>None</li>"
+        return (
+            "<div class='section-microcopy'>"
+            f"<p><strong>Preview count:</strong> {preview.get('preview_count', 0)}</p>"
+            "<p><strong>Conflict warnings</strong></p>"
+            f"<ul>{warning_items}</ul>"
+            "</div>"
+        )
+
+    def _save_composer_preset(name, input_path, image_ids, image_paths, folder_ids, folder_paths, exclude_paths, recursive):
+        request = _compose_request(input_path, image_ids, image_paths, folder_ids, folder_paths, exclude_paths, recursive)
+        presets = save_preset(name, request)
+        return gr.update(choices=sorted(presets.keys()), value=name.strip() if name else None)
+
+    def _load_composer_preset(name):
+        presets = load_presets()
+        request = presets.get(name or "", {})
+        return (
+            request.get("input_path") or "",
+            ",".join(str(v) for v in (request.get("image_ids") or [])),
+            "\n".join(request.get("image_paths") or []),
+            ",".join(str(v) for v in (request.get("folder_ids") or [])),
+            "\n".join(request.get("folder_paths") or []),
+            "\n".join(request.get("exclude_image_paths") or []),
+            bool(request.get("recursive", True)),
+        )
+
 
     # --- Run button handlers ---
     # All runners use start_batch(input_path, job_id, **kwargs)
@@ -471,6 +540,48 @@ def create_tab(app_config, scoring_runner, tagging_runner, selection_runner, orc
         fn=lambda p: _retry_phase(p, "keywords"),
         inputs=[components["selected_path"]],
         outputs=[]
+    )
+
+
+    components["composer_preview_btn"].click(
+        fn=_preview_composer,
+        inputs=[
+            components["composer_input_path"],
+            components["composer_image_ids"],
+            components["composer_image_paths"],
+            components["composer_folder_ids"],
+            components["composer_folder_paths"],
+            components["composer_exclude_paths"],
+            components["composer_recursive"],
+        ],
+        outputs=[components["composer_preview_html"]],
+    )
+    components["composer_save_preset_btn"].click(
+        fn=_save_composer_preset,
+        inputs=[
+            components["composer_preset_name"],
+            components["composer_input_path"],
+            components["composer_image_ids"],
+            components["composer_image_paths"],
+            components["composer_folder_ids"],
+            components["composer_folder_paths"],
+            components["composer_exclude_paths"],
+            components["composer_recursive"],
+        ],
+        outputs=[components["composer_preset_select"]],
+    )
+    components["composer_preset_select"].change(
+        fn=_load_composer_preset,
+        inputs=[components["composer_preset_select"]],
+        outputs=[
+            components["composer_input_path"],
+            components["composer_image_ids"],
+            components["composer_image_paths"],
+            components["composer_folder_ids"],
+            components["composer_folder_paths"],
+            components["composer_exclude_paths"],
+            components["composer_recursive"],
+        ],
     )
 
     return components

--- a/tests/test_api_queue.py
+++ b/tests/test_api_queue.py
@@ -84,6 +84,11 @@ def test_jobs_queue_endpoint_refreshes_from_db_with_limit_zero(monkeypatch):
 def test_pipeline_submit_cluster_enqueues_full_payload(monkeypatch, tmp_path):
     monkeypatch.setattr(ui_security, "_check_rate_limit", lambda endpoint: None)
     monkeypatch.setattr(api, "_clustering_runner", _RunnerStub())
+    monkeypatch.setattr(
+        api,
+        "validate_and_preview",
+        lambda request: {"preview_count": 2, "resolved_image_ids": [11, 12], "missing_paths": [], "warnings": []},
+    )
 
     captured = {}
 
@@ -131,6 +136,9 @@ def test_pipeline_submit_cluster_enqueues_full_payload(monkeypatch, tmp_path):
         "threshold": 0.2,
         "time_gap": 12,
         "force_rescan": True,
+        "resolved_image_ids": [11, 12],
+        "selector_preview_count": 2,
+        "missing_paths": [],
     }
     assert created_phase_codes["job_id"] == 321
     assert created_phase_codes["phase_codes"] == ["culling"]
@@ -139,6 +147,11 @@ def test_pipeline_submit_cluster_enqueues_full_payload(monkeypatch, tmp_path):
 def test_pipeline_submit_metadata_enqueues_scoring_runner_with_target_phases(monkeypatch, tmp_path):
     monkeypatch.setattr(ui_security, "_check_rate_limit", lambda endpoint: None)
     monkeypatch.setattr(api, "_scoring_runner", _RunnerStub())
+    monkeypatch.setattr(
+        api,
+        "validate_and_preview",
+        lambda request: {"preview_count": 2, "resolved_image_ids": [11, 12], "missing_paths": [], "warnings": []},
+    )
 
     captured = {}
 
@@ -182,6 +195,9 @@ def test_pipeline_submit_metadata_enqueues_scoring_runner_with_target_phases(mon
             "input_path": str(tmp_path),
             "skip_existing": False,
             "target_phases": ["indexing", "metadata"],
+            "resolved_image_ids": [11, 12],
+            "selector_preview_count": 2,
+            "missing_paths": [],
         },
     }
 
@@ -189,6 +205,11 @@ def test_pipeline_submit_metadata_enqueues_scoring_runner_with_target_phases(mon
 def test_pipeline_submit_mixed_operations_only_targets_scoring_side(monkeypatch, tmp_path):
     monkeypatch.setattr(ui_security, "_check_rate_limit", lambda endpoint: None)
     monkeypatch.setattr(api, "_scoring_runner", _RunnerStub())
+    monkeypatch.setattr(
+        api,
+        "validate_and_preview",
+        lambda request: {"preview_count": 2, "resolved_image_ids": [11, 12], "missing_paths": [], "warnings": []},
+    )
 
     captured = {}
 
@@ -220,6 +241,9 @@ def test_pipeline_submit_mixed_operations_only_targets_scoring_side(monkeypatch,
             "input_path": str(tmp_path),
             "skip_existing": True,
             "target_phases": ["scoring"],
+            "resolved_image_ids": [11, 12],
+            "selector_preview_count": 2,
+            "missing_paths": [],
         },
     }
 
@@ -227,6 +251,11 @@ def test_pipeline_submit_mixed_operations_only_targets_scoring_side(monkeypatch,
 def test_pipeline_submit_metadata_requires_scoring_runner(monkeypatch, tmp_path):
     monkeypatch.setattr(ui_security, "_check_rate_limit", lambda endpoint: None)
     monkeypatch.setattr(api, "_scoring_runner", None)
+    monkeypatch.setattr(
+        api,
+        "validate_and_preview",
+        lambda request: {"preview_count": 2, "resolved_image_ids": [11, 12], "missing_paths": [], "warnings": []},
+    )
 
     with _build_client() as client:
         response = client.post(
@@ -416,6 +445,11 @@ def test_pipeline_phase_backfill_returns_400_for_missing_path(monkeypatch):
 def test_scoring_start_returns_500_when_enqueue_fails(monkeypatch, tmp_path):
     monkeypatch.setattr(ui_security, "_check_rate_limit", lambda endpoint: None)
     monkeypatch.setattr(api, "_scoring_runner", _RunnerStub())
+    monkeypatch.setattr(
+        api,
+        "resolve_selectors",
+        lambda **kwargs: {"resolved_image_ids": [11], "missing_image_paths": [], "missing_folder_paths": []},
+    )
     monkeypatch.setattr(db, "enqueue_job", lambda *args, **kwargs: (None, 0))
 
     with _build_client() as client:
@@ -428,6 +462,11 @@ def test_scoring_start_returns_500_when_enqueue_fails(monkeypatch, tmp_path):
 def test_tagging_start_returns_500_when_enqueue_fails(monkeypatch, tmp_path):
     monkeypatch.setattr(ui_security, "_check_rate_limit", lambda endpoint: None)
     monkeypatch.setattr(api, "_tagging_runner", _RunnerStub())
+    monkeypatch.setattr(
+        api,
+        "resolve_selectors",
+        lambda **kwargs: {"resolved_image_ids": [11], "missing_image_paths": [], "missing_folder_paths": []},
+    )
     monkeypatch.setattr(db, "enqueue_job", lambda *args, **kwargs: (None, 0))
 
     with _build_client() as client:
@@ -440,6 +479,11 @@ def test_tagging_start_returns_500_when_enqueue_fails(monkeypatch, tmp_path):
 def test_clustering_start_returns_500_when_enqueue_fails(monkeypatch, tmp_path):
     monkeypatch.setattr(ui_security, "_check_rate_limit", lambda endpoint: None)
     monkeypatch.setattr(api, "_clustering_runner", _RunnerStub())
+    monkeypatch.setattr(
+        api,
+        "resolve_selectors",
+        lambda **kwargs: {"resolved_image_ids": [11], "missing_image_paths": [], "missing_folder_paths": []},
+    )
     monkeypatch.setattr(db, "enqueue_job", lambda *args, **kwargs: (None, 0))
 
     with _build_client() as client:
@@ -452,6 +496,11 @@ def test_clustering_start_returns_500_when_enqueue_fails(monkeypatch, tmp_path):
 def test_pipeline_submit_returns_500_when_enqueue_fails(monkeypatch, tmp_path):
     monkeypatch.setattr(ui_security, "_check_rate_limit", lambda endpoint: None)
     monkeypatch.setattr(api, "_clustering_runner", _RunnerStub())
+    monkeypatch.setattr(
+        api,
+        "validate_and_preview",
+        lambda request: {"preview_count": 2, "resolved_image_ids": [11, 12], "missing_paths": [], "warnings": []},
+    )
     monkeypatch.setattr(db, "enqueue_job", lambda *args, **kwargs: (None, 0))
 
     body = {
@@ -472,7 +521,8 @@ def test_pipeline_submit_requires_input_path(monkeypatch):
     with _build_client() as client:
         response = client.post("/api/pipeline/submit", json={"operations": ["score"]})
 
-    assert response.status_code == 422
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Provide input_path or at least one selector"
 
 
 def test_outliers_endpoint_returns_detector_payload(monkeypatch):

--- a/tests/test_pipeline_selector_composer.py
+++ b/tests/test_pipeline_selector_composer.py
@@ -1,0 +1,47 @@
+from modules import pipeline_selector_composer as composer
+
+
+def test_compose_selector_request_accepts_native_lists(tmp_path):
+    folder = str(tmp_path)
+    payload = composer.compose_selector_request(
+        input_path=folder,
+        image_ids_raw=["1", 2],
+        image_paths_raw=["a.jpg", "b.jpg"],
+        folder_ids_raw=["3"],
+        folder_paths_raw=["/x", "/y"],
+        exclude_image_paths_raw=["e.jpg"],
+        recursive=False,
+    )
+
+    assert payload["input_path"] == folder
+    assert payload["image_ids"] == [1, 2]
+    assert payload["folder_ids"] == [3]
+    assert payload["folder_paths"][-1] == folder
+    assert payload["exclude_image_paths"] == ["e.jpg"]
+    assert payload["recursive"] is False
+
+
+def test_validate_and_preview_reports_duplicate_entries(monkeypatch):
+    monkeypatch.setattr(
+        composer,
+        "resolve_selectors",
+        lambda **kwargs: {
+            "resolved_image_ids": [10, 11],
+            "missing_image_paths": [],
+            "missing_folder_paths": [],
+        },
+    )
+
+    preview = composer.validate_and_preview(
+        {
+            "image_ids": [1, 1],
+            "image_paths": ["x.jpg", "x.jpg"],
+            "folder_ids": [2],
+            "folder_paths": ["/a"],
+            "exclude_image_paths": [],
+            "recursive": True,
+        }
+    )
+
+    assert preview["preview_count"] == 2
+    assert any("Duplicate inclusion entries detected" in warning for warning in preview["warnings"])


### PR DESCRIPTION
### Motivation
- Provide a composer UI for building mixed selectors (image/file/folder/subtree/list) so users can validate and preview target counts before submitting pipeline jobs.
- Surface conflict warnings (missing paths, duplicates, excluded files) and let users save/load selector presets to speed repeated workflows.
- Map composed selectors to the API `SelectorRequest`/queue payloads so queued jobs carry resolved image IDs and preview metadata for reliable, deduplicated execution.

### Description
- Added a reusable selector composer module `modules/pipeline_selector_composer.py` that parses CSV/newline inputs, composes a selector request, calls `resolve_selectors` to validate and preview resolved image IDs, computes conflict warnings, serializes selector-aware queue payloads, and persists presets.
- Extended the API `PipelineSubmitRequest` to inherit `SelectorRequest` and added `exclude_image_paths`, then updated `POST /api/pipeline/submit` to compose selectors from incoming fields, call `validate_and_preview`, reject empty selector results, and enqueue `queue_payload` using `serialize_queue_payload` (which includes `resolved_image_ids`, `selector_preview_count`, and `missing_paths`).
- Added a Target Composer panel to the Pipeline UI (`modules/ui/tabs/pipeline.py`) with selector chips, input fields for IDs/paths/folders, exclude field, recursive option, Validate+Preview action showing preview count and warnings, and Save/Load preset controls wired to the new composer helpers.
- Updated pipeline-related tests (`tests/test_api_queue.py`) to mock preview/selector resolution where appropriate and to assert the serialized selector-aware `queue_payload` contents and the new validation behavior.

### Testing
- Performed a syntax check with `python -m py_compile modules/api.py modules/ui/tabs/pipeline.py modules/pipeline_selector_composer.py tests/test_api_queue.py` which succeeded.
- Ran API queue tests with `python -m pytest tests/test_api_queue.py -q` and observed success: the test run completed with all tests passing (`26 passed`).
- Attempted a UI screenshot via Playwright (`page.goto('http://127.0.0.1:7860')`) but the local WebUI was not reachable in this environment (screenshot attempt failed with `ERR_EMPTY_RESPONSE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b794ab77e48323b98607274fcc16ad)