### PR TITLE
feat: implement 2D embedding map (Application #05)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -46,7 +46,7 @@ Tags: **[Python]** = Python backend (`modules/`, FastAPI); **[Gradio]** = Gradio
 
 - [ ] **[Python]** Add `stack_representative_strategy` config option to `ClusteringEngine`
 - [ ] **[Python]** Implement centroid strategy (mean embedding → select closest image) in `modules/clustering.py`
-- [ ] **[Python]** 2D embedding map: add `umap-learn`, implement `modules/projections.py` (UMAP 2D coords + folder-level caching)
+- [x] **[Python]** 2D embedding map: add `umap-learn`, implement `modules/projections.py` (UMAP 2D coords + folder-level caching), `GET /api/embedding_map` endpoint
 - [ ] **[Electron]** **[Gradio]** Bidirectional WebSocket command channel — coordinate protocol with Electron's IPC/WebSocket bridge enhancement (see [EMBEDDING_APP_08_GRADIO_INTEGRATION_PLAN.md](docs/plans/embedding/EMBEDDING_APP_08_GRADIO_INTEGRATION_PLAN.md))
 - [ ] **[Electron]** **[DB]** Pipeline mode selector, headless lifecycle, `INTEGRATION_QUEUE` table
 - [ ] **[Gradio]** "Similarity Search" tab or context menu in Gradio WebUI using `similar_search.py`

--- a/config.example.json
+++ b/config.example.json
@@ -55,5 +55,12 @@
     "method": "rawpy_half",
     "max_resolution": 512,
     "jpeg_quality": 85
+  },
+  "embedding_map": {
+    "enabled": false,
+    "method": "umap",
+    "n_neighbors": 30,
+    "min_dist": 0.1,
+    "max_points": 50000
   }
 }

--- a/modules/api.py
+++ b/modules/api.py
@@ -2238,6 +2238,61 @@ def create_api_router() -> APIRouter:
             raise HTTPException(status_code=500, detail=str(exc))
 
 
+    # ========== Embedding Map Endpoint ==========
+
+    @router.get(
+        "/embedding_map",
+        response_model=ApiResponse,
+        summary="2D embedding map",
+        description="""
+        Project image embeddings to 2D coordinates for spatial visualisation.
+
+        Uses UMAP (default) or t-SNE to reduce 1280-d MobileNetV2 embeddings to
+        two dimensions.  Results are cached on disk; pass `refresh=true` to force
+        recomputation.
+
+        **Query Parameters:**
+        - folder_path: Optional.  Scope projection to one folder; omit for all images.
+        - method: `umap` (default) or `tsne`.
+        - refresh: If true, ignore the on-disk cache and recompute.
+        - sample_limit: Cap the number of images projected (default: config `embedding_map.max_points`).
+        - n_neighbors: UMAP/t-SNE neighbourhood size (default: 30).
+        - min_dist: UMAP min_dist (default: 0.1, ignored for t-SNE).
+
+        **Returns:**
+        - points: List of `{image_id, x, y, file_path, thumbnail_path, label, rating, score_general}`.
+        - meta: `{count, method, computed_at, cache_key}`.
+          When too few images are available `meta.error == "too_few_points"` and
+          `points` is empty.
+        """,
+        tags=["Similarity"],
+    )
+    def get_embedding_map(
+        folder_path: Optional[str] = Query(None, description="Scope to folder path"),
+        method: str = Query("umap", description="Projection method: umap or tsne"),
+        refresh: bool = Query(False, description="Force recomputation, ignoring cache"),
+        sample_limit: Optional[int] = Query(None, ge=1, le=50000, description="Max images to project"),
+        n_neighbors: int = Query(30, ge=2, le=200, description="UMAP/t-SNE neighbourhood size"),
+        min_dist: float = Query(0.1, ge=0.0, le=1.0, description="UMAP min_dist parameter"),
+    ):
+        """Return 2D projection of image embeddings."""
+        if method not in ("umap", "tsne"):
+            raise HTTPException(status_code=422, detail="method must be 'umap' or 'tsne'")
+        from modules import projections
+        try:
+            result = projections.compute_embedding_map(
+                folder_path=folder_path,
+                method=method,
+                refresh=refresh,
+                sample_limit=sample_limit,
+                n_neighbors=n_neighbors,
+                min_dist=min_dist,
+            )
+            return ApiResponse(success=True, message="OK", data=result)
+        except Exception as exc:
+            logger.error("Error computing embedding map: %s", exc)
+            raise HTTPException(status_code=500, detail=str(exc))
+
     # ========== Clustering Endpoints ==========
 
     @router.post(

--- a/modules/db.py
+++ b/modules/db.py
@@ -6352,6 +6352,65 @@ def get_embeddings_for_search(folder_path=None, limit=None):
         conn.close()
 
 
+def get_embeddings_with_metadata(folder_path=None, limit=None):
+    """
+    Return embedding vectors together with display metadata for each image.
+
+    Each returned dict has keys:
+        image_id, file_path, embedding (bytes), thumbnail_path,
+        label, rating, score_general
+    Optionally filter by folder_path and cap results with limit.
+    """
+    conn = get_db()
+    c = conn.cursor()
+    try:
+        if folder_path:
+            norm = os.path.normpath(folder_path)
+            c.execute("SELECT id FROM folders WHERE path = ?", (norm,))
+            frow = c.fetchone()
+            if not frow:
+                return []
+            folder_id = frow[0]
+            query = """
+                SELECT id, file_path, image_embedding,
+                       thumbnail_path, label, rating, score_general
+                FROM images
+                WHERE image_embedding IS NOT NULL AND folder_id = ?
+            """
+            params = [folder_id]
+        else:
+            query = """
+                SELECT id, file_path, image_embedding,
+                       thumbnail_path, label, rating, score_general
+                FROM images
+                WHERE image_embedding IS NOT NULL
+            """
+            params = []
+
+        if limit:
+            query += " ROWS ?"
+            params.append(limit)
+
+        c.execute(query, tuple(params))
+        results = []
+        for row in c.fetchall():
+            results.append({
+                "image_id": row[0],
+                "file_path": row[1],
+                "embedding": bytes(row[2]),
+                "thumbnail_path": row[3],
+                "label": row[4],
+                "rating": row[5],
+                "score_general": float(row[6]) if row[6] is not None else None,
+            })
+        return results
+    except Exception as e:
+        logger.error("Error loading embeddings with metadata: %s", e)
+        return []
+    finally:
+        conn.close()
+
+
 def get_images_missing_embeddings(folder_path=None, limit=None):
     """
     Return image rows with image_embedding IS NULL.

--- a/modules/projections.py
+++ b/modules/projections.py
@@ -1,0 +1,258 @@
+"""
+2D Embedding Map — Application #05
+
+Projects stored MobileNetV2 image embeddings to 2D coordinates using UMAP
+(with t-SNE as a fallback when umap-learn is not installed).  Results are
+cached on disk as JSON so repeated calls are cheap.
+
+Public API
+----------
+compute_embedding_map(folder_path, method, refresh, sample_limit, ...) -> dict
+invalidate_embedding_map_cache(folder_path) -> int   # returns files deleted
+"""
+
+import hashlib
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+
+from modules.config import BASE_DIR, get_config_value
+
+logger = logging.getLogger(__name__)
+
+_CACHE_DIR = BASE_DIR / ".cache" / "embedding_map"
+MIN_POINTS = 3  # UMAP / t-SNE require at least 3 samples
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _ensure_cache_dir():
+    _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _make_cache_key(folder_path, count, method, n_neighbors, min_dist):
+    payload = json.dumps(
+        {
+            "folder_path": folder_path,
+            "count": count,
+            "method": method,
+            "n_neighbors": n_neighbors,
+            "min_dist": min_dist,
+        },
+        sort_keys=True,
+    )
+    return hashlib.sha1(payload.encode()).hexdigest()
+
+
+def _cache_path(cache_key):
+    return _CACHE_DIR / f"{cache_key}.json"
+
+
+def _load_cache(cache_key):
+    path = _cache_path(cache_key)
+    if path.exists():
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            logger.warning("Could not read embedding map cache %s: %s", path, exc)
+    return None
+
+
+def _save_cache(cache_key, data):
+    _ensure_cache_dir()
+    path = _cache_path(cache_key)
+    try:
+        path.write_text(json.dumps(data), encoding="utf-8")
+    except Exception as exc:
+        logger.warning("Could not write embedding map cache %s: %s", path, exc)
+
+
+def _normalize(matrix):
+    """Row-wise L2 normalisation."""
+    norms = np.linalg.norm(matrix, axis=1, keepdims=True)
+    norms[norms == 0] = 1.0
+    return matrix / norms
+
+
+def _project_umap(vecs, n_neighbors, min_dist):
+    import umap  # optional dependency
+    reducer = umap.UMAP(
+        n_neighbors=n_neighbors,
+        min_dist=min_dist,
+        n_components=2,
+        metric="cosine",
+        random_state=42,
+    )
+    return reducer.fit_transform(vecs)
+
+
+def _project_tsne(vecs, n_neighbors):
+    from sklearn.manifold import TSNE
+
+    perplexity = min(n_neighbors, max(5, len(vecs) - 1))
+    reducer = TSNE(
+        n_components=2,
+        metric="cosine",
+        perplexity=perplexity,
+        random_state=42,
+        init="random",
+    )
+    return reducer.fit_transform(vecs)
+
+
+def _scale_to_unit(coords):
+    """Min-max scale both axes to [0.0, 1.0]."""
+    result = coords.astype(float).copy()
+    for axis in range(result.shape[1]):
+        col = result[:, axis]
+        lo, hi = col.min(), col.max()
+        span = hi - lo
+        result[:, axis] = (col - lo) / span if span > 0 else col * 0.0 + 0.5
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def compute_embedding_map(
+    folder_path=None,
+    method=None,
+    refresh=False,
+    sample_limit=None,
+    n_neighbors=None,
+    min_dist=None,
+):
+    """
+    Project image embeddings to 2D coordinates.
+
+    Parameters
+    ----------
+    folder_path : str or None
+        Scope to a specific folder; None means all images.
+    method : {'umap', 'tsne'} or None
+        Projection method.  Falls back to config, then 'umap'.
+    refresh : bool
+        If True, ignore cached result and recompute.
+    sample_limit : int or None
+        Maximum number of images to include; None means config default.
+    n_neighbors : int or None
+        UMAP/t-SNE neighbourhood size.  Falls back to config, then 30.
+    min_dist : float or None
+        UMAP min_dist parameter.  Falls back to config, then 0.1.
+
+    Returns
+    -------
+    dict
+        {
+            "points": [{image_id, x, y, file_path, thumbnail_path,
+                        label, rating, score_general}, ...],
+            "meta":   {count, method, computed_at, cache_key}
+        }
+        On error: "meta" contains an "error" key and "points" is [].
+    """
+    method = method or get_config_value("embedding_map.method", "umap")
+    n_neighbors = n_neighbors if n_neighbors is not None else get_config_value(
+        "embedding_map.n_neighbors", 30
+    )
+    min_dist = min_dist if min_dist is not None else get_config_value(
+        "embedding_map.min_dist", 0.1
+    )
+    max_points = sample_limit or get_config_value("embedding_map.max_points", 50000)
+
+    from modules import db
+
+    rows = db.get_embeddings_with_metadata(folder_path=folder_path, limit=max_points)
+    count = len(rows)
+
+    meta_base = {"count": count, "method": method}
+
+    if count < MIN_POINTS:
+        logger.info("Embedding map: only %d images — too few to project", count)
+        return {
+            "points": [],
+            "meta": {**meta_base, "error": "too_few_points"},
+        }
+
+    cache_key = _make_cache_key(folder_path, count, method, n_neighbors, min_dist)
+
+    if not refresh:
+        cached = _load_cache(cache_key)
+        if cached:
+            logger.debug("Embedding map: cache hit %s", cache_key)
+            return cached
+
+    # Build embedding matrix
+    vecs = np.array(
+        [np.frombuffer(r["embedding"], dtype=np.float32) for r in rows],
+        dtype=np.float32,
+    )
+    vecs = _normalize(vecs)
+
+    # Project to 2D
+    actual_method = method
+    try:
+        if method == "umap":
+            coords = _project_umap(vecs, n_neighbors, min_dist)
+        else:
+            coords = _project_tsne(vecs, n_neighbors)
+    except ImportError:
+        logger.warning("umap-learn not available, falling back to t-SNE")
+        actual_method = "tsne"
+        coords = _project_tsne(vecs, n_neighbors)
+
+    coords = _scale_to_unit(np.array(coords))
+
+    points = [
+        {
+            "image_id": r["image_id"],
+            "x": float(coords[i, 0]),
+            "y": float(coords[i, 1]),
+            "file_path": r["file_path"],
+            "thumbnail_path": r["thumbnail_path"],
+            "label": r["label"],
+            "rating": r["rating"],
+            "score_general": r["score_general"],
+        }
+        for i, r in enumerate(rows)
+    ]
+
+    result = {
+        "points": points,
+        "meta": {
+            "count": count,
+            "method": actual_method,
+            "computed_at": datetime.now(timezone.utc).isoformat(),
+            "cache_key": cache_key,
+        },
+    }
+
+    _save_cache(cache_key, result)
+    logger.info("Embedding map: projected %d images via %s", count, actual_method)
+    return result
+
+
+def invalidate_embedding_map_cache(folder_path=None):
+    """
+    Delete cached projection files.  Pass folder_path to limit scope (best-effort
+    prefix match on the cache filename is not possible; this always clears all
+    cached files when folder_path is None, or all files when folder_path is given).
+
+    Returns the number of files deleted.
+    """
+    if not _CACHE_DIR.exists():
+        return 0
+    deleted = 0
+    for f in _CACHE_DIR.glob("*.json"):
+        try:
+            f.unlink()
+            deleted += 1
+        except OSError as exc:
+            logger.warning("Could not delete cache file %s: %s", f, exc)
+    return deleted

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ exifread>=3.0.0
 imageio>=2.34.0,<3.0
 gradio>=5.0,<6.0
 scikit-learn>=1.3.0,<2.0
+umap-learn>=0.5,<1.0
 
 # MCP Server (optional - for Cursor debugging integration)
 mcp>=1.0.0,<2.0

--- a/tests/test_api_embedding_map.py
+++ b/tests/test_api_embedding_map.py
@@ -1,0 +1,185 @@
+"""
+Tests for GET /api/embedding_map endpoint.
+
+All tests are pure-unit: they mock db.get_embeddings_with_metadata and the
+projection functions so no GPU, Firebird, or umap-learn dependency is required.
+"""
+
+import numpy as np
+import pytest
+
+try:
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from modules import api
+except ImportError as e:
+    pytest.skip(f"API deps not available: {e}", allow_module_level=True)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _build_client():
+    app = FastAPI()
+    app.include_router(api.create_api_router())
+    return TestClient(app)
+
+
+def _fake_rows(n, dim=8):
+    """Return n fake embedding rows with random float32 vectors of dimension `dim`."""
+    rows = []
+    rng = np.random.default_rng(0)
+    for i in range(n):
+        vec = rng.random(dim).astype(np.float32)
+        rows.append({
+            "image_id": i + 1,
+            "file_path": f"/photos/img{i+1:04d}.jpg",
+            "embedding": vec.tobytes(),
+            "thumbnail_path": f"/thumbs/img{i+1:04d}.jpg",
+            "label": None,
+            "rating": None,
+            "score_general": round(float(rng.random()), 3),
+        })
+    return rows
+
+
+def _fake_coords(n):
+    """Return deterministic 2D coords for n points."""
+    rng = np.random.default_rng(1)
+    return rng.random((n, 2)).astype(np.float64)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_embedding_map_too_few_points(monkeypatch):
+    """Fewer than 3 images → success=True but points=[] and error key present."""
+    import modules.db as db_mod
+
+    monkeypatch.setattr(db_mod, "get_embeddings_with_metadata", lambda **kw: _fake_rows(1))
+
+    with _build_client() as client:
+        resp = client.get("/api/embedding_map")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["success"] is True
+    data = body["data"]
+    assert data["points"] == []
+    assert data["meta"]["error"] == "too_few_points"
+
+
+def test_embedding_map_returns_points(monkeypatch):
+    """With enough rows the endpoint returns a point per image."""
+    import modules.db as db_mod
+    import modules.projections as proj_mod
+
+    n = 5
+    rows = _fake_rows(n)
+    monkeypatch.setattr(db_mod, "get_embeddings_with_metadata", lambda **kw: rows)
+
+    fixed_coords = _fake_coords(n)
+
+    def _fake_project_umap(vecs, n_neighbors, min_dist):
+        return fixed_coords
+
+    monkeypatch.setattr(proj_mod, "_project_umap", _fake_project_umap)
+    # Ensure cache is bypassed
+    monkeypatch.setattr(proj_mod, "_load_cache", lambda key: None)
+    monkeypatch.setattr(proj_mod, "_save_cache", lambda key, data: None)
+
+    with _build_client() as client:
+        resp = client.get("/api/embedding_map?method=umap")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["success"] is True
+    points = body["data"]["points"]
+    assert len(points) == n
+    # All required fields present
+    for pt in points:
+        for field in ("image_id", "x", "y", "file_path", "thumbnail_path",
+                      "label", "rating", "score_general"):
+            assert field in pt, f"Missing field: {field}"
+    # x/y are in [0, 1]
+    for pt in points:
+        assert 0.0 <= pt["x"] <= 1.0
+        assert 0.0 <= pt["y"] <= 1.0
+    # meta fields present
+    meta = body["data"]["meta"]
+    assert meta["count"] == n
+    assert meta["method"] == "umap"
+    assert "computed_at" in meta
+    assert "cache_key" in meta
+
+
+def test_embedding_map_invalid_method():
+    """Unsupported method value → 422 Unprocessable Entity."""
+    with _build_client() as client:
+        resp = client.get("/api/embedding_map?method=foo")
+    assert resp.status_code == 422
+
+
+def test_embedding_map_tsne_fallback(monkeypatch):
+    """When umap raises ImportError, t-SNE is used and meta.method == 'tsne'."""
+    import modules.db as db_mod
+    import modules.projections as proj_mod
+
+    n = 5
+    rows = _fake_rows(n)
+    monkeypatch.setattr(db_mod, "get_embeddings_with_metadata", lambda **kw: rows)
+
+    def _raise_import(vecs, n_neighbors, min_dist):
+        raise ImportError("umap-learn not installed")
+
+    fixed_coords = _fake_coords(n)
+
+    def _fake_project_tsne(vecs, n_neighbors):
+        return fixed_coords
+
+    monkeypatch.setattr(proj_mod, "_project_umap", _raise_import)
+    monkeypatch.setattr(proj_mod, "_project_tsne", _fake_project_tsne)
+    monkeypatch.setattr(proj_mod, "_load_cache", lambda key: None)
+    monkeypatch.setattr(proj_mod, "_save_cache", lambda key, data: None)
+
+    with _build_client() as client:
+        resp = client.get("/api/embedding_map?method=umap")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["success"] is True
+    assert body["data"]["meta"]["method"] == "tsne"
+    assert len(body["data"]["points"]) == n
+
+
+def test_embedding_map_cache_hit(monkeypatch):
+    """When cache returns data, db and projection are not called."""
+    import modules.db as db_mod
+    import modules.projections as proj_mod
+
+    cached_data = {
+        "points": [{"image_id": 1, "x": 0.5, "y": 0.5, "file_path": "/a.jpg",
+                    "thumbnail_path": None, "label": None, "rating": None,
+                    "score_general": 0.9}],
+        "meta": {"count": 1, "method": "umap", "computed_at": "2026-01-01T00:00:00+00:00",
+                 "cache_key": "abc123"},
+    }
+
+    db_called = {"flag": False}
+
+    def _fail_db(**kw):
+        db_called["flag"] = True
+        return []
+
+    monkeypatch.setattr(db_mod, "get_embeddings_with_metadata", _fail_db)
+    monkeypatch.setattr(proj_mod, "_load_cache", lambda key: cached_data)
+
+    with _build_client() as client:
+        resp = client.get("/api/embedding_map")
+
+    assert resp.status_code == 200
+    # DB should NOT have been called — cache short-circuited
+    assert not db_called["flag"]
+    assert resp.json()["data"] == cached_data


### PR DESCRIPTION
Add UMAP/t-SNE projection of image embeddings to 2D coordinates with
disk-level caching and a REST endpoint for spatial image exploration.

- modules/projections.py: new module — compute_embedding_map() projects
  1280-d MobileNetV2 embeddings to 2D via UMAP (falls back to t-SNE when
  umap-learn is absent); results cached in .cache/embedding_map/*.json
- modules/db.py: add get_embeddings_with_metadata() — single SQL query
  that returns embedding bytes together with thumbnail_path, label,
  rating, and score_general for each image
- modules/api.py: add GET /api/embedding_map endpoint (tags: Similarity);
  supports folder_path, method, refresh, sample_limit, n_neighbors, min_dist
- requirements.txt: add umap-learn>=0.5,<1.0
- config.example.json: add embedding_map config section
- tests/test_api_embedding_map.py: 5 unit tests covering too-few-points,
  full projection, invalid method, t-SNE fallback, and cache hit
- TODO.md: mark item as done

https://claude.ai/code/session_0137Bada56B9SzQBmi3w3fr4