### PR TITLE
Add optional Gradio-native fallback Pipeline tab and conditional UI initialization

### DIFF
--- a/modules/ui/app.py
+++ b/modules/ui/app.py
@@ -19,6 +19,7 @@ from modules import scoring, db, tagging, config, clustering, thumbnails, utils,
 from modules.ui import assets, navigation, common
 from modules.ui.tabs import (
     pipeline,
+    pipeline_fallback,
     gallery,
     settings as settings_tab
 )
@@ -48,6 +49,9 @@ def create_ui():
     )
     recovery_info = orchestrator.recover_interrupted_jobs()
     app_config["job_recovery"] = recovery_info
+    ui_config = app_config.get("ui", {})
+    use_fallback_pipeline_ui = bool(ui_config.get("use_gradio_fallback", False) or os.getenv("GRADIO_FALLBACK_UI") == "1")
+    pipeline_tab = pipeline_fallback if use_fallback_pipeline_ui else pipeline
 
     # Register phase executors (binds phase codes to runner logic)
     phase_executors.register_all(
@@ -63,7 +67,12 @@ def create_ui():
     favicon_links = """
 <link rel="icon" href="/favicon.ico" sizes="any">
 """
-    with gr.Blocks(title="Image Scoring WebUI", css=custom_css, head=tree_js + favicon_links) as demo:
+    if use_fallback_pipeline_ui:
+        demo = gr.Blocks(title="Image Scoring WebUI", head=favicon_links)
+    else:
+        demo = gr.Blocks(title="Image Scoring WebUI", css=custom_css, head=tree_js + favicon_links)
+
+    with demo:
         gr.Markdown("# Image Scoring WebUI")
         
         # Shared States
@@ -80,7 +89,7 @@ def create_ui():
         
         with gr.Tabs() as main_tabs:
             # 1. Pipeline Tab
-            pipeline_components = pipeline.create_tab(
+            pipeline_components = pipeline_tab.create_tab(
                 app_config,
                 scoring_runner=runner,
                 tagging_runner=tagging_runner,
@@ -97,7 +106,7 @@ def create_ui():
         # Monitor Loop
         def monitor_status_wrapper(selected_folder):
             # Pass the currently selected folder from the Pipeline tree to update cards
-            res = pipeline.get_status_update(runner, tagging_runner, selection_runner, orchestrator, selected_folder)
+            res = pipeline_tab.get_status_update(runner, tagging_runner, selection_runner, orchestrator, selected_folder)
             return list(res)
 
         monitor_outputs = [

--- a/modules/ui/tabs/pipeline.py
+++ b/modules/ui/tabs/pipeline.py
@@ -509,6 +509,11 @@ def _update_folder_selection(folder_path: str, force_refresh=False, is_running=F
     )
 
 
+def get_folder_selection_view(folder_path: str, force_refresh=False, is_running=False):
+    """Public wrapper for folder-scoped pipeline summary rendering."""
+    return _update_folder_selection(folder_path, force_refresh=force_refresh, is_running=is_running)
+
+
 def get_status_update(scoring_runner, tagging_runner, selection_runner, orchestrator, selected_folder):
     """Called regularly by the main app timer to update components."""
     # Process Orchestrator tick

--- a/modules/ui/tabs/pipeline_fallback.py
+++ b/modules/ui/tabs/pipeline_fallback.py
@@ -1,0 +1,190 @@
+import gradio as gr
+
+from modules import config, db
+from modules.ui.tabs import pipeline as pipeline_full
+
+
+def create_tab(app_config, scoring_runner, tagging_runner, selection_runner, orchestrator) -> dict:
+    """Minimal, native-Gradio fallback Pipeline tab."""
+    components = {}
+
+    def _folder_choices():
+        folders = db.get_all_folders() or []
+        return sorted({f for f in folders if f})
+
+    def _save_selected_folder(path: str):
+        path = (path or "").strip()
+        config.save_config_value("ui.last_selected_folder", path)
+        return path
+
+    def _refresh_and_render(path: str):
+        path = (path or "").strip()
+        choices = _folder_choices()
+        if path and path not in choices:
+            choices = [path] + choices
+        updates = pipeline_full._update_folder_selection(path, force_refresh=True)
+        return (
+            gr.update(choices=choices, value=path),
+            path,
+            updates[0],
+            updates[1],
+            updates[2],
+            updates[3],
+            updates[4],
+            updates[5],
+        )
+
+    with gr.Tab("Pipeline", id="pipeline"):
+        gr.Markdown("## Pipeline (Fallback UI)")
+
+        last_folder = app_config.get("ui", {}).get("last_selected_folder", "") or ""
+
+        with gr.Row():
+            components["folder_dropdown"] = gr.Dropdown(
+                choices=_folder_choices(),
+                value=last_folder,
+                label="Folder",
+                allow_custom_value=True,
+            )
+            components["refresh_btn"] = gr.Button("Refresh")
+
+        components["selected_path"] = gr.Textbox(value=last_folder, label="Selected folder")
+
+        initial_updates = pipeline_full._update_folder_selection(last_folder, force_refresh=False)
+        components["folder_summary_html"] = gr.Markdown(initial_updates[0])
+        components["quick_start_html"] = gr.Markdown(initial_updates[5])
+        components["stepper_html"] = gr.Markdown(initial_updates[1])
+
+        with gr.Row():
+            components["run_all_btn"] = gr.Button("Run All Pending", variant="primary")
+            components["stop_all_btn"] = gr.Button("Stop All", variant="stop")
+            components["repair_index_meta_btn"] = gr.Button("Repair Index/Meta")
+            components["run_metadata_btn"] = gr.Button("Run Metadata")
+
+        with gr.Accordion("Scoring", open=True):
+            components["scoring_card_html"] = gr.Markdown(initial_updates[2])
+            components["scoring_force"] = gr.Checkbox(label="Force Re-score", value=False)
+            components["scoring_run_btn"] = gr.Button("Start Scoring")
+
+        with gr.Accordion("Culling", open=False):
+            components["culling_card_html"] = gr.Markdown(initial_updates[3])
+            components["culling_force"] = gr.Checkbox(label="Force Re-run", value=False)
+            components["culling_run_btn"] = gr.Button("Start Culling")
+
+        with gr.Accordion("Keywords", open=False):
+            components["keywords_card_html"] = gr.Markdown(initial_updates[4])
+            components["keywords_overwrite"] = gr.Checkbox(label="Overwrite Existing", value=False)
+            components["keywords_captions"] = gr.Checkbox(label="Generate Captions", value=False)
+            components["keywords_run_btn"] = gr.Button("Start Keywords")
+
+        components["monitor_html"] = gr.Markdown(
+            pipeline_full._build_idle_html(recovery_info=app_config.get("job_recovery"), queued_jobs=[])
+        )
+        components["console_output"] = gr.Textbox(lines=12, label="Console Output", interactive=False)
+
+    def _run_scoring(path, force):
+        if not path:
+            return
+        db.enqueue_job(
+            path,
+            phase_code="scoring",
+            job_type="scoring",
+            queue_payload={"input_path": path, "skip_existing": not force},
+        )
+
+    def _run_metadata(path):
+        if not path:
+            return
+        db.enqueue_job(
+            path,
+            phase_code="scoring",
+            job_type="scoring",
+            queue_payload={
+                "input_path": path,
+                "skip_existing": False,
+                "target_phases": ["indexing", "metadata"],
+            },
+        )
+
+    def _run_culling(path, force):
+        if not path:
+            return
+        db.enqueue_job(
+            path,
+            phase_code="culling",
+            job_type="selection",
+            queue_payload={"input_path": path, "force_rescan": force},
+        )
+
+    def _run_tagging(path, overwrite, captions):
+        if not path:
+            return
+        db.enqueue_job(
+            path,
+            phase_code="keywords",
+            job_type="tagging",
+            queue_payload={"input_path": path, "overwrite": overwrite, "generate_captions": captions},
+        )
+
+    def _run_all_pending(path):
+        if not path:
+            return
+        orchestrator.start(path)
+
+    def _stop_all():
+        orchestrator.stop()
+        scoring_runner.stop()
+        selection_runner.stop()
+        tagging_runner.stop()
+
+    def _repair_index_meta(path):
+        if not path:
+            return
+        db.backfill_index_meta_for_folder(path)
+
+    components["folder_dropdown"].change(
+        fn=lambda p: _refresh_and_render(_save_selected_folder(p)),
+        inputs=[components["folder_dropdown"]],
+        outputs=[
+            components["folder_dropdown"],
+            components["selected_path"],
+            components["folder_summary_html"],
+            components["stepper_html"],
+            components["scoring_card_html"],
+            components["culling_card_html"],
+            components["keywords_card_html"],
+            components["quick_start_html"],
+        ],
+    )
+
+    components["refresh_btn"].click(
+        fn=_refresh_and_render,
+        inputs=[components["selected_path"]],
+        outputs=[
+            components["folder_dropdown"],
+            components["selected_path"],
+            components["folder_summary_html"],
+            components["stepper_html"],
+            components["scoring_card_html"],
+            components["culling_card_html"],
+            components["keywords_card_html"],
+            components["quick_start_html"],
+        ],
+    )
+
+    components["scoring_run_btn"].click(fn=_run_scoring, inputs=[components["selected_path"], components["scoring_force"]], outputs=[])
+    components["culling_run_btn"].click(fn=_run_culling, inputs=[components["selected_path"], components["culling_force"]], outputs=[])
+    components["keywords_run_btn"].click(fn=_run_tagging, inputs=[components["selected_path"], components["keywords_overwrite"], components["keywords_captions"]], outputs=[])
+    components["run_all_btn"].click(fn=_run_all_pending, inputs=[components["selected_path"]], outputs=[])
+    components["run_metadata_btn"].click(fn=_run_metadata, inputs=[components["selected_path"]], outputs=[])
+    components["repair_index_meta_btn"].click(fn=_repair_index_meta, inputs=[components["selected_path"]], outputs=[])
+    components["stop_all_btn"].click(fn=_stop_all, inputs=[], outputs=[])
+
+
+
+    return components
+
+
+def get_status_update(scoring_runner, tagging_runner, selection_runner, orchestrator, selected_folder):
+    """Reuse standard status update logic for fallback tab."""
+    return pipeline_full.get_status_update(scoring_runner, tagging_runner, selection_runner, orchestrator, selected_folder)

--- a/modules/ui/tabs/pipeline_fallback.py
+++ b/modules/ui/tabs/pipeline_fallback.py
@@ -22,7 +22,7 @@ def create_tab(app_config, scoring_runner, tagging_runner, selection_runner, orc
         choices = _folder_choices()
         if path and path not in choices:
             choices = [path] + choices
-        updates = pipeline_full._update_folder_selection(path, force_refresh=True)
+        updates = pipeline_full.get_folder_selection_view(path, force_refresh=True)
         return (
             gr.update(choices=choices, value=path),
             path,
@@ -50,7 +50,7 @@ def create_tab(app_config, scoring_runner, tagging_runner, selection_runner, orc
 
         components["selected_path"] = gr.Textbox(value=last_folder, label="Selected folder")
 
-        initial_updates = pipeline_full._update_folder_selection(last_folder, force_refresh=False)
+        initial_updates = pipeline_full.get_folder_selection_view(last_folder, force_refresh=False)
         components["folder_summary_html"] = gr.Markdown(initial_updates[0])
         components["quick_start_html"] = gr.Markdown(initial_updates[5])
         components["stepper_html"] = gr.Markdown(initial_updates[1])
@@ -77,9 +77,7 @@ def create_tab(app_config, scoring_runner, tagging_runner, selection_runner, orc
             components["keywords_captions"] = gr.Checkbox(label="Generate Captions", value=False)
             components["keywords_run_btn"] = gr.Button("Start Keywords")
 
-        components["monitor_html"] = gr.Markdown(
-            pipeline_full._build_idle_html(recovery_info=app_config.get("job_recovery"), queued_jobs=[])
-        )
+        components["monitor_html"] = gr.Markdown("No active jobs in the pipeline.")
         components["console_output"] = gr.Textbox(lines=12, label="Console Output", interactive=False)
 
     def _run_scoring(path, force):


### PR DESCRIPTION
### Motivation

- Provide a minimal, native-Gradio fallback for the Pipeline tab to support environments where the full custom UI assets or JS cannot be used. 
- Allow switching to the fallback UI via config (`ui.use_gradio_fallback`) or the environment variable `GRADIO_FALLBACK_UI`.

### Description

- Add a new `modules/ui/tabs/pipeline_fallback.py` implementing a simplified Pipeline tab that reuses core pipeline logic from `modules.ui.tabs.pipeline` and enqueues jobs via `db` and `orchestrator` functions. 
- Make `create_ui()` choose between the full `pipeline` tab and the new `pipeline_fallback` tab based on `app_config["ui"].use_gradio_fallback` or `GRADIO_FALLBACK_UI`, and assign it to `pipeline_tab`. 
- Initialize `gr.Blocks` conditionally to omit custom CSS/JS when the fallback UI is used. 
- Update status monitoring and tab wiring to call `pipeline_tab.get_status_update` and to use `pipeline_tab.create_tab` so both implementations integrate identically with the rest of the UI.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7994ec1208323ad0c5e631bbc461c)