### PR TITLE
Add Electron IPC → FastAPI bridge endpoint

### DIFF
--- a/modules/api.py
+++ b/modules/api.py
@@ -574,6 +574,26 @@ class PipelineBackfillRequest(BaseModel):
     input_path: str = Field(..., description="Folder path for backfill operation.")
 
 
+class IpcBridgeRequest(BaseModel):
+    """Generic IPC-style message wrapper for Electron -> FastAPI bridging."""
+    channel: str = Field(
+        ...,
+        description="IPC channel name (e.g. 'pipeline:submit', 'tasks:active').",
+        example="pipeline:submit",
+    )
+    payload: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Channel-specific payload; mirrors the endpoint body/query shape.",
+    )
+
+
+class IpcBridgeResponse(BaseModel):
+    """Response envelope for IPC bridge requests."""
+    channel: str = Field(..., description="Echoed IPC channel")
+    ok: bool = Field(..., description="True when handler succeeded")
+    data: Optional[Any] = Field(None, description="Handler result payload")
+
+
 class ApiResponse(BaseModel):
     """Standard API response model for operation results.
     
@@ -3249,4 +3269,77 @@ def create_api_router() -> APIRouter:
             data={"updated_images": updated}
         )
 
+
+
+    @router.post(
+        "/ipc/bridge",
+        response_model=IpcBridgeResponse,
+        summary="Electron IPC -> FastAPI bridge",
+        description="""
+        Bridges Electron-style IPC messages into FastAPI handlers so the desktop
+        main process can forward a single contract to Python.
+
+        Supported channels:
+        - `pipeline:submit` -> POST /api/pipeline/submit
+        - `pipeline:phase:skip` -> POST /api/pipeline/phase/skip
+        - `pipeline:phase:retry` -> POST /api/pipeline/phase/retry
+        - `tasks:active` -> GET /api/tasks/active
+        - `jobs:queue` -> GET /api/jobs/queue
+        - `folders:tree` -> GET /api/folders/tree
+        - `folders:phase-status` -> GET /api/folders/phase-status
+        """
+    )
+    async def ipc_bridge(request: IpcBridgeRequest):
+        channel = (request.channel or "").strip()
+        payload = request.payload or {}
+
+        if channel == "pipeline:submit":
+            result = await submit_pipeline(PipelineSubmitRequest(**payload))
+            return IpcBridgeResponse(channel=channel, ok=True, data=result.model_dump())
+
+        if channel == "pipeline:phase:skip":
+            result = await skip_pipeline_phase(PipelinePhaseControlRequest(**payload))
+            return IpcBridgeResponse(channel=channel, ok=True, data=result.model_dump())
+
+        if channel == "pipeline:phase:retry":
+            result = await retry_pipeline_phase(PipelinePhaseControlRequest(**payload))
+            return IpcBridgeResponse(channel=channel, ok=True, data=result.model_dump())
+
+        if channel == "tasks:active":
+            limit = int(payload.get("limit", 200) or 200)
+            result = await get_tasks_active(limit=limit)
+            return IpcBridgeResponse(channel=channel, ok=True, data=result)
+
+        if channel == "jobs:queue":
+            limit = int(payload.get("limit", 200) or 200)
+            result = await get_jobs_queue(limit=limit)
+            return IpcBridgeResponse(channel=channel, ok=True, data=result)
+
+        if channel == "folders:tree":
+            result = await get_folder_tree()
+            return IpcBridgeResponse(channel=channel, ok=True, data=result)
+
+        if channel == "folders:phase-status":
+            path = (payload.get("path") or payload.get("input_path") or "").strip()
+            if not path:
+                raise HTTPException(status_code=400, detail="payload.path is required for folders:phase-status")
+            force_refresh = bool(payload.get("force_refresh", False))
+            result = await get_folder_phase_status(path=path, force_refresh=force_refresh)
+            return IpcBridgeResponse(channel=channel, ok=True, data=result)
+
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "message": f"Unsupported IPC channel: {channel}",
+                "supported_channels": [
+                    "pipeline:submit",
+                    "pipeline:phase:skip",
+                    "pipeline:phase:retry",
+                    "tasks:active",
+                    "jobs:queue",
+                    "folders:tree",
+                    "folders:phase-status",
+                ],
+            },
+        )
     return router

--- a/tests/test_api_queue.py
+++ b/tests/test_api_queue.py
@@ -662,3 +662,78 @@ class _FakeConn:
 
     def close(self):
         return None
+
+
+def test_ipc_bridge_routes_pipeline_submit(monkeypatch, tmp_path):
+    monkeypatch.setattr(ui_security, "_check_rate_limit", lambda endpoint: None)
+    monkeypatch.setattr(api, "_scoring_runner", _RunnerStub())
+
+    monkeypatch.setattr(db, "enqueue_job", lambda *a, **kw: (900, 4))
+    monkeypatch.setattr(db, "create_job_phases", lambda job_id, phase_codes: [])
+
+    with _build_client() as client:
+        response = client.post(
+            "/api/ipc/bridge",
+            json={
+                "channel": "pipeline:submit",
+                "payload": {
+                    "input_path": str(tmp_path),
+                    "operations": ["score"],
+                    "skip_existing": True,
+                },
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["channel"] == "pipeline:submit"
+    assert payload["ok"] is True
+    assert payload["data"]["success"] is True
+    assert payload["data"]["data"]["job_id"] == 900
+
+
+def test_ipc_bridge_routes_tasks_active(monkeypatch):
+    monkeypatch.setattr(api._job_dispatcher, "get_state", lambda: {
+        "queue": [],
+        "queue_size": 0,
+        "active_runner": None,
+        "is_dispatcher_running": True,
+    })
+    monkeypatch.setattr(db, "get_queued_jobs", lambda limit=200: [])
+    monkeypatch.setattr(db, "get_jobs", lambda limit=20: [])
+    monkeypatch.setattr(db, "get_job_by_id", lambda job_id: None)
+
+    with _build_client() as client:
+        response = client.post(
+            "/api/ipc/bridge",
+            json={"channel": "tasks:active", "payload": {"limit": 11}},
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["channel"] == "tasks:active"
+    assert payload["ok"] is True
+    assert "dispatcher" in payload["data"]
+
+
+def test_ipc_bridge_rejects_unknown_channel():
+    with _build_client() as client:
+        response = client.post(
+            "/api/ipc/bridge",
+            json={"channel": "unknown:channel", "payload": {}},
+        )
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert "Unsupported IPC channel" in detail["message"]
+
+
+def test_ipc_bridge_folders_phase_status_requires_path():
+    with _build_client() as client:
+        response = client.post(
+            "/api/ipc/bridge",
+            json={"channel": "folders:phase-status", "payload": {}},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "payload.path is required for folders:phase-status"


### PR DESCRIPTION
## Summary
- add a new `/api/ipc/bridge` endpoint that accepts Electron-style channel messages and dispatches to existing FastAPI handlers
- introduce `IpcBridgeRequest` and `IpcBridgeResponse` models for a normalized bridge contract
- support these channels:
  - `pipeline:submit`
  - `pipeline:phase:skip`
  - `pipeline:phase:retry`
  - `tasks:active`
  - `jobs:queue`
  - `folders:tree`
  - `folders:phase-status`
- return consistent bridge envelopes and explicit error details for unsupported channels

## Testing
- `pytest -q tests/test_api_queue.py -k "ipc_bridge or tasks_active or pipeline_submit"`
  - passes for selected tests
  - environment warns about missing `firebird` when creating test DB, but tests still pass with stubs/mocks

## Notes
- bridge implementation intentionally reuses existing endpoint handlers so business logic remains centralized and behavior stays aligned across direct REST and bridged IPC calls.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b809cc10948323bf0a2a359e814a1b)