### PR TITLE
docs: record PR #38 review blocker in offline environment

### DIFF
--- a/reviews/pr-38-review.md
+++ b/reviews/pr-38-review.md
@@ -1,0 +1,23 @@
+# Review: https://github.com/synthet/musiq-image-scoring/pull/38
+
+## Status
+
+Unable to perform a line-by-line code review in this container because outbound access to GitHub is blocked (`curl` to the PR URL fails with `CONNECT tunnel failed, response 403`).
+
+## What was attempted
+
+- Tried to fetch the pull request patch directly from GitHub:
+  - `curl -L https://github.com/synthet/musiq-image-scoring/pull/38.patch`
+- Verified repository remotes to see if PR refs were available locally:
+  - `git remote -v` (no remotes configured)
+  - `git branch -a` (only local `work` branch)
+
+## Next step to complete review
+
+Please provide one of the following so I can complete the actual code review:
+
+1. The patch/diff for PR #38
+2. A checkout of the PR branch in this environment
+3. A local remote configured with access to the repository so I can fetch `pull/38/head`
+
+Once available, I will provide a full review with actionable comments and severity tagging.


### PR DESCRIPTION
### Motivation
- Document that a requested line-by-line review of PR #38 could not be completed in this environment because outbound access to GitHub is blocked and to capture reproducible troubleshooting steps.

### Description
- Add `reviews/pr-38-review.md` which describes the access error (`CONNECT tunnel failed, response 403`), records the retrieval attempts (`curl -L https://github.com/synthet/musiq-image-scoring/pull/38.patch`, `git remote -v`, `git branch -a`), and lists concrete next steps to unblock the review.

### Testing
- Ran `curl -L https://github.com/synthet/musiq-image-scoring/pull/38.patch` which failed with `CONNECT tunnel failed, response 403`.
- Ran `git remote -v` which returned no configured remotes and completed successfully.
- Ran `git branch -a` and `git status --short && git branch --show-current && git log --oneline --decorate -n 8` which completed successfully and showed only the local `work` branch.
- Created, staged and committed `reviews/pr-38-review.md` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b80a92a23c8323b1c4eb5da42b849f)