### PR TITLE
Harden `_validate_file_path` root containment checks

### DIFF
--- a/modules/ui/security.py
+++ b/modules/ui/security.py
@@ -42,10 +42,20 @@ def _validate_file_path(file_path: str) -> str:
         _ALLOWED_IMAGE_ROOTS = config.get_config_value("allowed_paths", [])
         _ALLOWED_IMAGE_ROOTS.extend(config.get_default_allowed_paths())
 
-    if _ALLOWED_IMAGE_ROOTS and not any(
-        resolved.startswith(os.path.realpath(root)) for root in _ALLOWED_IMAGE_ROOTS
-    ):
-        raise HTTPException(status_code=403, detail="Access denied")
+    if _ALLOWED_IMAGE_ROOTS:
+        is_allowed = False
+        for root in _ALLOWED_IMAGE_ROOTS:
+            allowed_root = os.path.realpath(root)
+            try:
+                if os.path.commonpath([resolved, allowed_root]) == allowed_root:
+                    is_allowed = True
+                    break
+            except ValueError:
+                # Different drives (primarily on Windows) are not ancestors.
+                continue
+
+        if not is_allowed:
+            raise HTTPException(status_code=403, detail="Access denied")
 
     return resolved
 

--- a/tests/test_api_security.py
+++ b/tests/test_api_security.py
@@ -69,6 +69,63 @@ class TestPathValidation:
             _validate_file_path("D:/Photos/../../../etc/passwd")
         assert exc_info.value.status_code == 400
 
+    def test_allowed_root_exact_match(self, tmp_path, monkeypatch):
+        """Exact root path should be allowed."""
+        from modules.ui import security
+
+        root = tmp_path / "allowed"
+        root.mkdir()
+
+        monkeypatch.setattr(security, "_ALLOWED_IMAGE_ROOTS", [str(root)])
+
+        assert security._validate_file_path(str(root)) == os.path.realpath(str(root))
+
+    def test_allowed_root_nested_child(self, tmp_path, monkeypatch):
+        """Child path under allowed root should be allowed."""
+        from modules.ui import security
+
+        root = tmp_path / "allowed"
+        child = root / "nested" / "image.jpg"
+        child.parent.mkdir(parents=True)
+        child.touch()
+
+        monkeypatch.setattr(security, "_ALLOWED_IMAGE_ROOTS", [str(root)])
+
+        assert security._validate_file_path(str(child)) == os.path.realpath(str(child))
+
+    def test_shared_prefix_sibling_rejected(self, tmp_path, monkeypatch):
+        """Sibling with shared prefix (bar2) must not match root (bar)."""
+        from fastapi import HTTPException
+        from modules.ui import security
+
+        root = tmp_path / "foo" / "bar"
+        sibling = tmp_path / "foo" / "bar2" / "image.jpg"
+        root.mkdir(parents=True)
+        sibling.parent.mkdir(parents=True)
+        sibling.touch()
+
+        monkeypatch.setattr(security, "_ALLOWED_IMAGE_ROOTS", [str(root)])
+
+        with pytest.raises(HTTPException) as exc_info:
+            security._validate_file_path(str(sibling))
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.detail == "Access denied"
+
+    def test_symlink_resolved_path_allowed(self, tmp_path, monkeypatch):
+        """Symlink paths should be validated against their resolved location."""
+        from modules.ui import security
+
+        root = tmp_path / "allowed"
+        target = root / "images" / "sample.jpg"
+        link = tmp_path / "link.jpg"
+        target.parent.mkdir(parents=True)
+        target.touch()
+        link.symlink_to(target)
+
+        monkeypatch.setattr(security, "_ALLOWED_IMAGE_ROOTS", [str(root)])
+
+        assert security._validate_file_path(str(link)) == os.path.realpath(str(target))
+
 
 class TestRateLimit:
     """Test the rate limiting logic."""


### PR DESCRIPTION
### Motivation
- Prevent incorrect allow-list matches caused by simple `startswith` prefix checks that could let sibling paths like `/foo/bar2` pass when `/foo/bar` is intended as the allowed root. 
- Ensure symlinked paths are validated against their resolved locations and handle cross-drive path comparisons safely on Windows.

### Description
- Replace `startswith`-based check in `modules/ui/security.py::_validate_file_path` with normalization via `os.path.realpath` and an ancestry check using `os.path.commonpath` to verify containment. 
- Catch `ValueError` from `os.path.commonpath` (e.g., mixed drives) and treat those cases as non-ancestors. 
- Preserve existing `HTTPException(status_code=403, detail="Access denied")` behaviour for disallowed paths. 
- Add unit tests in `tests/test_api_security.py` covering exact root match, nested child acceptance, shared-prefix sibling rejection, and symlink-resolved path validation.

### Testing
- Ran `pytest -q tests/test_api_security.py`, and the suite completed with all tests passing (`12 passed`).
- Test run showed a non-blocking environment warning from the test DB setup about a missing `firebird` module, but the targeted tests still passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8356df478832395aa8f3d8fe1f2bd)