### PR TITLE
Preserve HTTPException status codes in /api/raw-preview

### DIFF
--- a/modules/ui/app.py
+++ b/modules/ui/app.py
@@ -203,6 +203,8 @@ def setup_server_endpoints(fastapi_app, scoring_runner=None, tagging_runner=None
                 media_type="image/jpeg",
                 headers={"Cache-Control": "public, max-age=3600"}
             )
+        except HTTPException:
+            raise
         except Exception as e:
             raise HTTPException(status_code=500, detail=str(e))
     


### PR DESCRIPTION
### Motivation
- Ensure explicit `HTTPException` instances raised inside the `raw_preview_endpoint` are not converted into generic 500 responses so intended `400`/`404`/`500` errors are preserved.

### Description
- Added an `except HTTPException: raise` clause to `raw_preview_endpoint` in `modules/ui/app.py` before the final `except Exception` handler so only unexpected exceptions are wrapped as `HTTPException(status_code=500, ...)`, and verified existing explicit `raise HTTPException(...)` branches remain unchanged.

### Testing
- Compiled the module with `python -m compileall modules/ui/app.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8356f9a3083239472d109d4d0a0cc)