### PR TITLE
Rate limiting: per-endpoint+client buckets

### DIFF
--- a/docs/technical/API_CONTRACT.md
+++ b/docs/technical/API_CONTRACT.md
@@ -317,4 +317,5 @@ Now includes `clustering` runner state:
 - **Data query endpoints** delegate to existing `db.py` functions; no new DB code.
 - **Stats endpoint** reuses `get_database_stats()` from the MCP server module.
 - All endpoints follow existing patterns: Pydantic models, `ApiResponse` wrapper, rate limiting, path validation.
+- **Rate limiting semantics:** protected mutating endpoints use in-memory buckets keyed by `(endpoint, client)` with a default limit of `10 requests / 60 seconds` per client per endpoint. Client identity is derived from `X-Forwarded-For` (first hop), then `X-Real-IP`, then FastAPI `request.client.host`, and falls back to `"anonymous"` if unavailable.
 - **Path conversion:** When the backend runs on Linux (WSL), Windows paths are converted to WSL via `utils.convert_path_to_wsl`. When the backend runs natively on Windows, paths are kept as-is.

--- a/modules/api.py
+++ b/modules/api.py
@@ -45,7 +45,7 @@ Endpoints:
         GET /api/health - Health check endpoint
 """
 
-from fastapi import APIRouter, HTTPException, Body, Query
+from fastapi import APIRouter, HTTPException, Body, Query, Request
 from fastapi.responses import FileResponse, StreamingResponse
 import json
 
@@ -61,6 +61,24 @@ from modules.selector_resolver import resolve_selectors
 from modules.job_dispatcher import JobDispatcher
 
 logger = logging.getLogger(__name__)
+
+
+def _get_client_rate_limit_key(request: Request) -> str:
+    """Build a stable caller key for per-client rate limiting buckets."""
+    forwarded_for = request.headers.get("x-forwarded-for", "").strip()
+    if forwarded_for:
+        first_hop = forwarded_for.split(",", 1)[0].strip()
+        if first_hop:
+            return f"ip:{first_hop}"
+
+    real_ip = request.headers.get("x-real-ip", "").strip()
+    if real_ip:
+        return f"ip:{real_ip}"
+
+    if request.client and request.client.host:
+        return f"ip:{request.client.host}"
+
+    return "anonymous"
 
 # Request/Response Models with comprehensive descriptions for LLM agents
 
@@ -1051,7 +1069,7 @@ def create_api_router() -> APIRouter:
             503: {"description": "Scoring runner not available"}
         }
     )
-    async def start_scoring(request: ScoringStartRequest):
+    async def start_scoring(request: ScoringStartRequest, http_request: Request):
         """
         Start a batch scoring job.
 
@@ -1062,7 +1080,7 @@ def create_api_router() -> APIRouter:
             ApiResponse with success status and job_id if started
         """
         from modules.ui.security import _check_rate_limit
-        _check_rate_limit("scoring_start")
+        _check_rate_limit("scoring_start", _get_client_rate_limit_key(http_request))
 
         if _scoring_runner is None:
             raise HTTPException(status_code=503, detail="Scoring runner not available")
@@ -1299,10 +1317,10 @@ def create_api_router() -> APIRouter:
         """,
         response_description="Tagging job start confirmation"
     )
-    async def start_tagging(request: TaggingStartRequest):
+    async def start_tagging(request: TaggingStartRequest, http_request: Request):
         """Start a batch tagging job."""
         from modules.ui.security import _check_rate_limit
-        _check_rate_limit("tagging_start")
+        _check_rate_limit("tagging_start", _get_client_rate_limit_key(http_request))
 
         if _tagging_runner is None:
             raise HTTPException(status_code=503, detail="Tagging runner not available")
@@ -2253,10 +2271,10 @@ def create_api_router() -> APIRouter:
         The job runs asynchronously. Use GET /api/clustering/status to monitor progress.
         """
     )
-    async def start_clustering(request: ClusteringStartRequest):
+    async def start_clustering(request: ClusteringStartRequest, http_request: Request):
         """Start a batch clustering job."""
         from modules.ui.security import _check_rate_limit
-        _check_rate_limit("clustering_start")
+        _check_rate_limit("clustering_start", _get_client_rate_limit_key(http_request))
 
         if _clustering_runner is None:
             raise HTTPException(status_code=503, detail="Clustering runner not available")
@@ -2539,7 +2557,7 @@ def create_api_router() -> APIRouter:
         providing real-time progress updates during the folder scan and registration process.
         """
     )
-    async def import_register_stream(request: ImportRegisterRequest):
+    async def import_register_stream(request: ImportRegisterRequest, http_request: Request):
         """Streaming version of image registration."""
         from modules.ui.security import _check_rate_limit
         from modules import db, utils
@@ -2547,7 +2565,7 @@ def create_api_router() -> APIRouter:
         from modules.phases import PhaseCode, PhaseStatus
         from modules.version import APP_VERSION
 
-        _check_rate_limit("import_register")
+        _check_rate_limit("import_register", _get_client_rate_limit_key(http_request))
 
         folder_path = request.folder_path
         try:
@@ -2667,10 +2685,10 @@ def create_api_router() -> APIRouter:
         'cluster' requires a folder path.
         """
     )
-    async def submit_pipeline(request: PipelineSubmitRequest):
+    async def submit_pipeline(request: PipelineSubmitRequest, http_request: Request):
         """Submit image/folder to the processing pipeline."""
         from modules.ui.security import _check_rate_limit
-        _check_rate_limit("pipeline_submit")
+        _check_rate_limit("pipeline_submit", _get_client_rate_limit_key(http_request))
 
         if not request.input_path or not request.input_path.strip():
             raise HTTPException(status_code=400, detail="input_path is required")
@@ -2855,10 +2873,10 @@ def create_api_router() -> APIRouter:
         summary="Skip a pipeline phase",
         description="Marks all images in a folder phase as skipped, storing reason and actor."
     )
-    async def skip_pipeline_phase(request: PipelinePhaseControlRequest):
+    async def skip_pipeline_phase(request: PipelinePhaseControlRequest, http_request: Request):
         from modules.ui.security import _check_rate_limit
         from modules import db
-        _check_rate_limit("pipeline_phase_skip")
+        _check_rate_limit("pipeline_phase_skip", _get_client_rate_limit_key(http_request))
 
         if not os.path.exists(request.input_path):
             raise HTTPException(status_code=400, detail=f"Path not found: {request.input_path}")
@@ -2882,10 +2900,10 @@ def create_api_router() -> APIRouter:
         summary="Retry a skipped pipeline phase",
         description="Converts skipped statuses to running and starts the selected phase runner."
     )
-    async def retry_pipeline_phase(request: PipelinePhaseControlRequest):
+    async def retry_pipeline_phase(request: PipelinePhaseControlRequest, http_request: Request):
         from modules.ui.security import _check_rate_limit
         from modules import db
-        _check_rate_limit("pipeline_phase_retry")
+        _check_rate_limit("pipeline_phase_retry", _get_client_rate_limit_key(http_request))
 
         if not os.path.exists(request.input_path):
             raise HTTPException(status_code=400, detail=f"Path not found: {request.input_path}")
@@ -3009,10 +3027,10 @@ def create_api_router() -> APIRouter:
         without also updating `electron/db.ts`.
         """
     )
-    async def update_image(image_id: int, request: ImageUpdateRequest):
+    async def update_image(image_id: int, request: ImageUpdateRequest, http_request: Request):
         from modules import db
         from modules.ui.security import _check_rate_limit
-        _check_rate_limit("image_update")
+        _check_rate_limit("image_update", _get_client_rate_limit_key(http_request))
 
         conn = db.get_db()
         try:
@@ -3071,10 +3089,10 @@ def create_api_router() -> APIRouter:
         from disk. Use with caution — this is irreversible.
         """
     )
-    async def delete_image(image_id: int, delete_file: bool = Query(False, description="Also delete image file from disk.")):
+    async def delete_image(image_id: int, http_request: Request, delete_file: bool = Query(False, description="Also delete image file from disk.")):
         from modules import db
         from modules.ui.security import _check_rate_limit
-        _check_rate_limit("image_delete")
+        _check_rate_limit("image_delete", _get_client_rate_limit_key(http_request))
 
         conn = db.get_db()
         try:
@@ -3126,11 +3144,11 @@ def create_api_router() -> APIRouter:
         as an attachment.
         """
     )
-    async def export_gallery(request: ExportRequest):
+    async def export_gallery(request: ExportRequest, http_request: Request):
         from modules import db
         from modules.ui.security import _check_rate_limit
         import datetime
-        _check_rate_limit("gallery_export")
+        _check_rate_limit("gallery_export", _get_client_rate_limit_key(http_request))
 
         fmt = (request.format or "json").lower()
         if fmt not in ("json", "csv", "xlsx"):
@@ -3215,10 +3233,10 @@ def create_api_router() -> APIRouter:
         for a specific section.
         """
     )
-    async def save_config(section: str, body: Dict[str, Any] = Body(...)):
+    async def save_config(section: str, http_request: Request, body: Dict[str, Any] = Body(...)):
         from modules.config import save_config_section
         from modules.ui.security import _check_rate_limit
-        _check_rate_limit("config_save")
+        _check_rate_limit("config_save", _get_client_rate_limit_key(http_request))
         valid_sections = {"scoring", "processing", "culling", "ui", "tagging"}
         if section not in valid_sections:
             raise HTTPException(status_code=400, detail=f"Unknown config section: {section!r}. Valid: {sorted(valid_sections)}")
@@ -3564,10 +3582,10 @@ def create_api_router() -> APIRouter:
         summary="Backfill Index/Meta phase status",
         description="Sets INDEXING=DONE and METADATA=DONE for images that have SCORING=DONE but lack these statuses (repairs legacy or new-image backfill gap)."
     )
-    async def backfill_index_meta(request: PipelineBackfillRequest):
+    async def backfill_index_meta(request: PipelineBackfillRequest, http_request: Request):
         from modules.ui.security import _check_rate_limit
         from modules import db
-        _check_rate_limit("pipeline_backfill")
+        _check_rate_limit("pipeline_backfill", _get_client_rate_limit_key(http_request))
 
         if not os.path.exists(request.input_path):
             raise HTTPException(status_code=400, detail=f"Path not found: {request.input_path}")

--- a/modules/ui/security.py
+++ b/modules/ui/security.py
@@ -15,14 +15,22 @@ _RATE_LIMIT_WINDOW = 60  # seconds
 _RATE_LIMIT_MAX_REQUESTS = 10
 
 
-def _check_rate_limit(endpoint: str):
-    """Simple in-memory rate limiter per endpoint."""
+def _check_rate_limit(endpoint: str, client_key: str = "anonymous"):
+    """Simple in-memory rate limiter per endpoint+client bucket.
+
+    Args:
+        endpoint: Logical endpoint name for the protected action.
+        client_key: Stable caller identifier (IP, session id, token hash).
+            Falls back to ``"anonymous"`` when unavailable.
+    """
     from fastapi import HTTPException
+
+    bucket_key = (endpoint, client_key or "anonymous")
     now = time.time()
-    _rate_limits[endpoint] = [t for t in _rate_limits[endpoint] if now - t < _RATE_LIMIT_WINDOW]
-    if len(_rate_limits[endpoint]) >= _RATE_LIMIT_MAX_REQUESTS:
+    _rate_limits[bucket_key] = [t for t in _rate_limits[bucket_key] if now - t < _RATE_LIMIT_WINDOW]
+    if len(_rate_limits[bucket_key]) >= _RATE_LIMIT_MAX_REQUESTS:
         raise HTTPException(status_code=429, detail="Rate limit exceeded")
-    _rate_limits[endpoint].append(now)
+    _rate_limits[bucket_key].append(now)
 
 # --- Path validation ---
 _ALLOWED_IMAGE_ROOTS = None

--- a/tests/test_api_queue.py
+++ b/tests/test_api_queue.py
@@ -82,7 +82,7 @@ def test_jobs_queue_endpoint_refreshes_from_db_with_limit_zero(monkeypatch):
 
 
 def test_pipeline_submit_cluster_enqueues_full_payload(monkeypatch, tmp_path):
-    monkeypatch.setattr(ui_security, "_check_rate_limit", lambda endpoint: None)
+    monkeypatch.setattr(ui_security, "_check_rate_limit", lambda *args, **kwargs: None)
     monkeypatch.setattr(api, "_clustering_runner", _RunnerStub())
 
     captured = {}
@@ -137,7 +137,7 @@ def test_pipeline_submit_cluster_enqueues_full_payload(monkeypatch, tmp_path):
 
 
 def test_pipeline_submit_metadata_enqueues_scoring_runner_with_target_phases(monkeypatch, tmp_path):
-    monkeypatch.setattr(ui_security, "_check_rate_limit", lambda endpoint: None)
+    monkeypatch.setattr(ui_security, "_check_rate_limit", lambda *args, **kwargs: None)
     monkeypatch.setattr(api, "_scoring_runner", _RunnerStub())
 
     captured = {}
@@ -187,7 +187,7 @@ def test_pipeline_submit_metadata_enqueues_scoring_runner_with_target_phases(mon
 
 
 def test_pipeline_submit_mixed_operations_only_targets_scoring_side(monkeypatch, tmp_path):
-    monkeypatch.setattr(ui_security, "_check_rate_limit", lambda endpoint: None)
+    monkeypatch.setattr(ui_security, "_check_rate_limit", lambda *args, **kwargs: None)
     monkeypatch.setattr(api, "_scoring_runner", _RunnerStub())
 
     captured = {}
@@ -225,7 +225,7 @@ def test_pipeline_submit_mixed_operations_only_targets_scoring_side(monkeypatch,
 
 
 def test_pipeline_submit_metadata_requires_scoring_runner(monkeypatch, tmp_path):
-    monkeypatch.setattr(ui_security, "_check_rate_limit", lambda endpoint: None)
+    monkeypatch.setattr(ui_security, "_check_rate_limit", lambda *args, **kwargs: None)
     monkeypatch.setattr(api, "_scoring_runner", None)
 
     with _build_client() as client:
@@ -239,7 +239,7 @@ def test_pipeline_submit_metadata_requires_scoring_runner(monkeypatch, tmp_path)
 
 
 def test_pipeline_phase_skip_calls_db_with_defaults(monkeypatch, tmp_path):
-    monkeypatch.setattr(ui_security, "_check_rate_limit", lambda endpoint: None)
+    monkeypatch.setattr(ui_security, "_check_rate_limit", lambda *args, **kwargs: None)
     captured = {}
 
     def fake_set_folder_phase_status(**kwargs):
@@ -270,7 +270,7 @@ def test_pipeline_phase_skip_calls_db_with_defaults(monkeypatch, tmp_path):
 
 
 def test_pipeline_phase_skip_returns_400_for_missing_path(monkeypatch):
-    monkeypatch.setattr(ui_security, "_check_rate_limit", lambda endpoint: None)
+    monkeypatch.setattr(ui_security, "_check_rate_limit", lambda *args, **kwargs: None)
 
     with _build_client() as client:
         response = client.post(
@@ -283,7 +283,7 @@ def test_pipeline_phase_skip_returns_400_for_missing_path(monkeypatch):
 
 
 def test_pipeline_phase_retry_scoring_starts_runner(monkeypatch, tmp_path):
-    monkeypatch.setattr(ui_security, "_check_rate_limit", lambda endpoint: None)
+    monkeypatch.setattr(ui_security, "_check_rate_limit", lambda *args, **kwargs: None)
     runner = _BatchRunnerStub()
     monkeypatch.setattr(api, "_scoring_runner", runner)
 
@@ -314,7 +314,7 @@ def test_pipeline_phase_retry_scoring_starts_runner(monkeypatch, tmp_path):
 
 
 def test_pipeline_phase_retry_keywords_starts_runner(monkeypatch, tmp_path):
-    monkeypatch.setattr(ui_security, "_check_rate_limit", lambda endpoint: None)
+    monkeypatch.setattr(ui_security, "_check_rate_limit", lambda *args, **kwargs: None)
     runner = _BatchRunnerStub()
     monkeypatch.setattr(api, "_tagging_runner", runner)
     monkeypatch.setattr(db, "set_folder_phase_status", lambda **kwargs: 4)
@@ -334,7 +334,7 @@ def test_pipeline_phase_retry_keywords_starts_runner(monkeypatch, tmp_path):
 
 
 def test_pipeline_phase_retry_culling_starts_runner(monkeypatch, tmp_path):
-    monkeypatch.setattr(ui_security, "_check_rate_limit", lambda endpoint: None)
+    monkeypatch.setattr(ui_security, "_check_rate_limit", lambda *args, **kwargs: None)
     runner = _BatchRunnerStub()
     monkeypatch.setattr(api, "_clustering_runner", runner)
     monkeypatch.setattr(db, "set_folder_phase_status", lambda **kwargs: 6)
@@ -354,7 +354,7 @@ def test_pipeline_phase_retry_culling_starts_runner(monkeypatch, tmp_path):
 
 
 def test_pipeline_phase_retry_returns_503_when_runner_missing(monkeypatch, tmp_path):
-    monkeypatch.setattr(ui_security, "_check_rate_limit", lambda endpoint: None)
+    monkeypatch.setattr(ui_security, "_check_rate_limit", lambda *args, **kwargs: None)
     monkeypatch.setattr(api, "_tagging_runner", None)
     monkeypatch.setattr(db, "set_folder_phase_status", lambda **kwargs: 1)
 
@@ -369,7 +369,7 @@ def test_pipeline_phase_retry_returns_503_when_runner_missing(monkeypatch, tmp_p
 
 
 def test_pipeline_phase_retry_rejects_unsupported_phase(monkeypatch, tmp_path):
-    monkeypatch.setattr(ui_security, "_check_rate_limit", lambda endpoint: None)
+    monkeypatch.setattr(ui_security, "_check_rate_limit", lambda *args, **kwargs: None)
     monkeypatch.setattr(db, "set_folder_phase_status", lambda **kwargs: 3)
 
     with _build_client() as client:
@@ -383,7 +383,7 @@ def test_pipeline_phase_retry_rejects_unsupported_phase(monkeypatch, tmp_path):
 
 
 def test_pipeline_phase_backfill_returns_count(monkeypatch, tmp_path):
-    monkeypatch.setattr(ui_security, "_check_rate_limit", lambda endpoint: None)
+    monkeypatch.setattr(ui_security, "_check_rate_limit", lambda *args, **kwargs: None)
     monkeypatch.setattr(db, "backfill_index_meta_for_folder", lambda folder_path: 9)
 
     with _build_client() as client:
@@ -401,7 +401,7 @@ def test_pipeline_phase_backfill_returns_count(monkeypatch, tmp_path):
 
 
 def test_pipeline_phase_backfill_returns_400_for_missing_path(monkeypatch):
-    monkeypatch.setattr(ui_security, "_check_rate_limit", lambda endpoint: None)
+    monkeypatch.setattr(ui_security, "_check_rate_limit", lambda *args, **kwargs: None)
 
     with _build_client() as client:
         response = client.post(
@@ -414,7 +414,7 @@ def test_pipeline_phase_backfill_returns_400_for_missing_path(monkeypatch):
 
 
 def test_scoring_start_returns_500_when_enqueue_fails(monkeypatch, tmp_path):
-    monkeypatch.setattr(ui_security, "_check_rate_limit", lambda endpoint: None)
+    monkeypatch.setattr(ui_security, "_check_rate_limit", lambda *args, **kwargs: None)
     monkeypatch.setattr(api, "_scoring_runner", _RunnerStub())
     monkeypatch.setattr(db, "enqueue_job", lambda *args, **kwargs: (None, 0))
 
@@ -426,7 +426,7 @@ def test_scoring_start_returns_500_when_enqueue_fails(monkeypatch, tmp_path):
 
 
 def test_tagging_start_returns_500_when_enqueue_fails(monkeypatch, tmp_path):
-    monkeypatch.setattr(ui_security, "_check_rate_limit", lambda endpoint: None)
+    monkeypatch.setattr(ui_security, "_check_rate_limit", lambda *args, **kwargs: None)
     monkeypatch.setattr(api, "_tagging_runner", _RunnerStub())
     monkeypatch.setattr(db, "enqueue_job", lambda *args, **kwargs: (None, 0))
 
@@ -438,7 +438,7 @@ def test_tagging_start_returns_500_when_enqueue_fails(monkeypatch, tmp_path):
 
 
 def test_clustering_start_returns_500_when_enqueue_fails(monkeypatch, tmp_path):
-    monkeypatch.setattr(ui_security, "_check_rate_limit", lambda endpoint: None)
+    monkeypatch.setattr(ui_security, "_check_rate_limit", lambda *args, **kwargs: None)
     monkeypatch.setattr(api, "_clustering_runner", _RunnerStub())
     monkeypatch.setattr(db, "enqueue_job", lambda *args, **kwargs: (None, 0))
 
@@ -450,7 +450,7 @@ def test_clustering_start_returns_500_when_enqueue_fails(monkeypatch, tmp_path):
 
 
 def test_pipeline_submit_returns_500_when_enqueue_fails(monkeypatch, tmp_path):
-    monkeypatch.setattr(ui_security, "_check_rate_limit", lambda endpoint: None)
+    monkeypatch.setattr(ui_security, "_check_rate_limit", lambda *args, **kwargs: None)
     monkeypatch.setattr(api, "_clustering_runner", _RunnerStub())
     monkeypatch.setattr(db, "enqueue_job", lambda *args, **kwargs: (None, 0))
 
@@ -467,7 +467,7 @@ def test_pipeline_submit_returns_500_when_enqueue_fails(monkeypatch, tmp_path):
 
 
 def test_pipeline_submit_requires_input_path(monkeypatch):
-    monkeypatch.setattr(ui_security, "_check_rate_limit", lambda endpoint: None)
+    monkeypatch.setattr(ui_security, "_check_rate_limit", lambda *args, **kwargs: None)
 
     with _build_client() as client:
         response = client.post("/api/pipeline/submit", json={"operations": ["score"]})

--- a/tests/test_api_security.py
+++ b/tests/test_api_security.py
@@ -96,3 +96,16 @@ class TestRateLimit:
         with pytest.raises(HTTPException) as exc_info:
             _check_rate_limit("test_endpoint_flood")
         assert exc_info.value.status_code == 429
+
+    def test_rate_limit_isolated_per_client_key(self):
+        """Requests from different callers should use separate buckets."""
+        from modules.ui.security import _check_rate_limit, _rate_limits, _RATE_LIMIT_MAX_REQUESTS
+
+        _rate_limits.clear()
+
+        for _ in range(_RATE_LIMIT_MAX_REQUESTS):
+            _check_rate_limit("test_endpoint_shared", client_key="client-a")
+
+        # Different client key should still be allowed.
+        _check_rate_limit("test_endpoint_shared", client_key="client-b")
+

--- a/tests/test_api_v2_reorg.py
+++ b/tests/test_api_v2_reorg.py
@@ -79,12 +79,12 @@ def test_import_register_stream(monkeypatch):
     monkeypatch.setattr(os.path, "isfile", lambda x: True)
     
     monkeypatch.setattr(db, "get_or_create_folder", lambda x: 1)
-    monkeypatch.setattr(db, "find_image_id_by_path", lambda x: None)
+    monkeypatch.setattr(db, "find_image_id_by_path", lambda *args, **kwargs: None)
     monkeypatch.setattr(db, "register_image_for_import", lambda *args: (123, True))
     monkeypatch.setattr(db, "set_image_phase_status", lambda *args, **kwargs: None)
     
     # Mock rate limit and version if needed
-    monkeypatch.setattr("modules.ui.security._check_rate_limit", lambda x: None)
+    monkeypatch.setattr("modules.ui.security._check_rate_limit", lambda *args, **kwargs: None)
     
     # Mock extract_exif to avoid external dependencies
     monkeypatch.setattr("modules.exif_extractor.extract_exif", lambda x: {})
@@ -116,10 +116,10 @@ def test_import_register_legacy(monkeypatch):
     monkeypatch.setattr(os, "listdir", lambda x: ["img1.jpg"])
     monkeypatch.setattr(os.path, "isfile", lambda x: True)
     monkeypatch.setattr(db, "get_or_create_folder", lambda x: 1)
-    monkeypatch.setattr(db, "find_image_id_by_path", lambda x: None)
+    monkeypatch.setattr(db, "find_image_id_by_path", lambda *args, **kwargs: None)
     monkeypatch.setattr(db, "register_image_for_import", lambda *args: (123, True))
     monkeypatch.setattr(db, "set_image_phase_status", lambda *args, **kwargs: None)
-    monkeypatch.setattr("modules.ui.security._check_rate_limit", lambda x: None)
+    monkeypatch.setattr("modules.ui.security._check_rate_limit", lambda *args, **kwargs: None)
     monkeypatch.setattr("modules.exif_extractor.extract_exif", lambda x: {})
 
     with _build_client() as client:


### PR DESCRIPTION
### Motivation
- Reduce cross-client interference by scoping in-memory rate-limit buckets to both the endpoint and the caller identity so one noisy client cannot exhaust an endpoint-wide bucket.
- Keep behavior backward-compatible when no caller identity is available by falling back to a stable `"anonymous"` bucket.

### Description
- Updated `_check_rate_limit` to accept an optional `client_key` and to use bucket keys of the form `(endpoint, client_key)` with `"anonymous"` as fallback.
- Added `_get_client_rate_limit_key(request)` in `modules/api.py` which derives a stable caller key from `X-Forwarded-For` (first hop), then `X-Real-IP`, then `request.client.host`.
- Updated all `_check_rate_limit(...)` call sites in `modules/api.py` to pass the per-request client key where available, preserving the previous semantics when no request identity exists.
- Documented the per-client throttling semantics and default limits in `docs/technical/API_CONTRACT.md` and added a unit test for client-isolated buckets.

### Testing
- Ran unit tests for security helpers with `python -m pytest tests/test_api_security.py -q` which passed (9 passed). 
- Performed a syntax/compile check with `python -m py_compile modules/ui/security.py modules/api.py` which succeeded.
- Ran broader integration-style test groups with `python -m pytest tests/test_api_security.py tests/test_api_queue.py tests/test_api_v2_reorg.py` which produced failures in this environment due to a missing external dependency (`ImportError: firebird-driver not installed`), not related to the rate-limiter logic; the failures are environmental and recorded above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8356eab1c8323ad0f8c0feb1c611d)