### PR TITLE
docs: refresh embedding roadmap to match implemented backend state

### DIFF
--- a/docs/plans/embedding/NEXT_STEPS.md
+++ b/docs/plans/embedding/NEXT_STEPS.md
@@ -25,6 +25,8 @@ Use these code references as the source of truth when reviewing status:
 - `tests/test_api_embedding_map.py` (API behavior and fallback/cache tests)
 - `modules/clustering.py` (`_select_best_image` centroid strategy)
 
+Similarity REST routes (search, duplicates, outliers) are tracked in [TODO.md](TODO.md) under **API REST Endpoints**; request/response shapes are described in [API_CONTRACT.md](../../technical/API_CONTRACT.md).
+
 ---
 
 ## Remaining Work (True Gaps Only)
@@ -46,3 +48,4 @@ Use these code references as the source of truth when reviewing status:
 
 - App 05 no longer needs to be treated as backend-planned: backend compute + endpoint + tests are in place.
 - App 06 centroid representative logic is implemented and should be tracked as complete on backend.
+- For App 06, `centroid` and `balanced` strategies use embeddings only when `_select_best_image` receives them (visual stack clustering); burst stack creation currently passes scores only, so those paths fall back to `score` until embeddings are supplied there.

--- a/docs/plans/embedding/NEXT_STEPS.md
+++ b/docs/plans/embedding/NEXT_STEPS.md
@@ -1,6 +1,6 @@
 # Embedding Features: Next Steps Roadmap
 
-This document summarizes the current implementation status and outlines the prioritized next steps for the 8 proposed embedding applications.
+This document summarizes the current implementation status and the **true remaining gaps** for the 8 proposed embedding applications.
 
 ## Status Overview
 
@@ -10,53 +10,39 @@ This document summarizes the current implementation status and outlines the prio
 | 02 | Near-Duplicate Detection | **Implemented** | `similar_search.py` (`find_near_duplicates`). |
 | 03 | Tag Propagation | **Implemented** | `tagging.py` (`propagate_tags`). |
 | 04 | Outlier Detection | **Implemented** | `similar_search.py` (`find_outliers`). |
-| 05 | 2D Embedding Map | **Planned** | Needs `umap-learn`, REST endpoint, and UI. |
-| 06 | Smart Stack Representative | **Partial** | Needs Centroid-based logic in `ClusteringEngine`. |
+| 05 | 2D Embedding Map | **Backend Implemented / UI Partial** | Projection service exists in `modules/projections.py`; API exposed at `GET /api/embedding_map`; coverage in `tests/test_api_embedding_map.py`. UI/Electron wiring may still be pending. |
+| 06 | Smart Stack Representative | **Implemented** | Centroid representative selection is implemented in `modules/clustering.py` (`_select_best_image`, `stack_representative_strategy`). |
 | 07 | "More Like This" UI | **Partial** | Search logic and REST API exist; UI wiring is still needed. |
-| 08 | Gradio Integration | **Planned** | Major architectural task (WebSockets, Headless). |
+| 08 | Gradio Integration | **Partial** | Backend APIs exist, but bidirectional control and orchestration work remain. |
 
 ---
 
-## Priority 1: Backend Infrastructure (Short Term)
+## Implementation Verification References
 
-### 1.1 Similarity API Exposure
-Completed in `modules/api.py`:
-- `GET /api/similarity/search` and compatibility alias `GET /api/similarity/similar`
-- `GET /api/similarity/duplicates`
-- `GET /api/outliers` and compatibility alias `GET /api/similarity/outliers`
-
-Next contract tasks:
-- Keep Electron-side API types in sync with the backend contract
-- Add UI wiring for similarity-driven workflows
-
-### 1.2 Clustering Refinement
-Update the `ClusteringEngine` in `modules/clustering.py`:
-- Add a configuration option for `stack_representative_strategy`.
-- Implement `centroid` strategy which calculates the mean embedding for a cluster and selects the image with the minimum cosine distance to that mean.
+Use these code references as the source of truth when reviewing status:
+- `modules/projections.py` (2D projection compute + cache layer)
+- `modules/api.py` (`/api/embedding_map` route)
+- `tests/test_api_embedding_map.py` (API behavior and fallback/cache tests)
+- `modules/clustering.py` (`_select_best_image` centroid strategy)
 
 ---
 
-## Priority 2: 2D Exploratory Map (Medium Term)
+## Remaining Work (True Gaps Only)
 
-### 2.1 Dependencies
-Add `umap-learn` to the environment. Note that UMAP requires `numpy`, `scipy`, and `scikit-learn` (already present).
+### 1) Electron / Gradio UX Wiring
+- Connect existing similarity and embedding-map APIs to production UI flows.
+- Add user-facing interactions for map exploration and "more like this" actions.
+- Keep frontend contracts aligned with backend payloads.
 
-### 2.2 Computation & Caching
-Implement `modules/projections.py`:
-- Function to compute 2D coordinates for a batch of images using UMAP.
-- Layer a caching mechanism (disk-based) to store projections at the folder level to avoid re-computation.
+### 2) Bidirectional Control Channel
+- Implement or finalize a robust bi-directional channel (per App 08 plan) so Electron/Gradio can trigger embedding operations and receive live progress/events.
 
----
-
-## Priority 3: Architecture & UI Integration (Long Term)
-
-### 3.1 Headless Mode & WebSocket Relay
-As per [App 08](EMBEDDING_APP_08_GRADIO_INTEGRATION_PLAN.md), implement the bi-directional command channel to allow the Electron app to trigger embedding operations and receive real-time updates.
-
-### 3.2 Gradio Similarity Search
-Add a "Similarity Search" tab or context menu in the Gradio WebUI that uses the `similar_search.py` module to browse the collection visually.
+### 3) Headless Orchestration
+- Complete headless orchestration path for embedding-driven workflows (job triggering, status tracking, and event relay) so UI and automation use the same control surface.
 
 ---
 
-## Conclusion
-The groundwork for embeddings is largely solid. The immediate focus should be **API exposure** and **Smart Representative** logic to make the existing features actionable from the UI.
+## Notes
+
+- App 05 no longer needs to be treated as backend-planned: backend compute + endpoint + tests are in place.
+- App 06 centroid representative logic is implemented and should be tracked as complete on backend.

--- a/docs/plans/embedding/TODO.md
+++ b/docs/plans/embedding/TODO.md
@@ -1,6 +1,6 @@
 # Embedding Features TODO
 
-Backend tasks for embedding-based features. See [NEXT_STEPS.md](NEXT_STEPS.md) for full roadmap.
+Backend tasks for embedding-based features. See [NEXT_STEPS.md](NEXT_STEPS.md) for roadmap + remaining cross-surface work.
 
 > See project root [TODO.md](../../../TODO.md) for consolidated list with Electron/DB tags.
 
@@ -9,18 +9,28 @@ Backend tasks for embedding-based features. See [NEXT_STEPS.md](NEXT_STEPS.md) f
 - [x] `GET /api/similarity/similar?image_id=123` — Visually similar images across folders
 - [x] `GET /api/similarity/duplicates?folder_path=...` — Near-duplicate pairs
 - [x] `GET /api/similarity/outliers?folder_path=...` — Low neighborhood similarity images
+- [x] `GET /api/embedding_map` — 2D embedding projection endpoint (`modules/api.py` + `modules/projections.py` + `tests/test_api_embedding_map.py`)
 
 ## Clustering & Selection
 
 - [x] Add `stack_representative_strategy` config option to `ClusteringEngine`
-- [ ] Implement centroid strategy (mean embedding → select closest image) in `modules/clustering.py`
+- [x] Implement centroid strategy (mean embedding → select closest image) in `modules/clustering.py` (`_select_best_image`)
 
 ## 2D Embedding Map (Priority 2)
 
-- [ ] Add `umap-learn` dependency
-- [ ] Implement `modules/projections.py` (UMAP 2D coords + folder-level caching)
+- [x] Implement `modules/projections.py` (UMAP/t-SNE 2D coords + folder-level cache)
+- [x] Add API-level tests in `tests/test_api_embedding_map.py` (success path, validation, fallback, cache)
+- [ ] UI integration in Electron/Gradio for interactive map usage
 
-## Gradio Integration (Priority 3)
+## Gradio/Electron Integration (Priority 3)
 
-- [ ] Bidirectional WebSocket command channel (see [EMBEDDING_APP_08_GRADIO_INTEGRATION_PLAN.md](EMBEDDING_APP_08_GRADIO_INTEGRATION_PLAN.md))
+- [ ] Bidirectional command/control channel (see [EMBEDDING_APP_08_GRADIO_INTEGRATION_PLAN.md](EMBEDDING_APP_08_GRADIO_INTEGRATION_PLAN.md))
+- [ ] Headless orchestration path for embedding workflows (shared trigger/status/event surface)
 - [ ] "Similarity Search" tab or context menu in Gradio WebUI using `similar_search.py`
+
+## Verification References
+
+- `modules/projections.py`
+- `modules/api.py` (`/api/embedding_map`)
+- `tests/test_api_embedding_map.py`
+- `modules/clustering.py` (`_select_best_image`)

--- a/docs/plans/embedding/TODO.md
+++ b/docs/plans/embedding/TODO.md
@@ -16,6 +16,8 @@ Backend tasks for embedding-based features. See [NEXT_STEPS.md](NEXT_STEPS.md) f
 - [x] Add `stack_representative_strategy` config option to `ClusteringEngine`
 - [x] Implement centroid strategy (mean embedding → select closest image) in `modules/clustering.py` (`_select_best_image`)
 
+`centroid` / `balanced` apply when that call receives per-image embedding features (visual stacks). Burst stack creation passes scores only today, so representative selection there stays on `score` until embeddings are wired into that path.
+
 ## 2D Embedding Map (Priority 2)
 
 - [x] Implement `modules/projections.py` (UMAP/t-SNE 2D coords + folder-level cache)


### PR DESCRIPTION
### Motivation
- Ensure the docs reflect the current backend implementation status for embedding features so reviewers and maintainers can verify behavior quickly.
- Reduce noise by removing already-implemented backend tasks and surfacing only true remaining gaps (UI wiring, bidirectional control, headless orchestration).

### Description
- Updated `docs/plans/embedding/NEXT_STEPS.md` to mark App 05 as `Backend Implemented / UI Partial` and App 06 as `Implemented`, to add a verification references section, and to replace outdated planned backend items with a concise "Remaining Work (True Gaps Only)" list.
- Updated `docs/plans/embedding/TODO.md` to mark `GET /api/embedding_map` implemented, mark the centroid representative strategy implemented in `modules/clustering.py` (`_select_best_image`), mark `modules/projections.py` and associated tests as present, and to leave only UI/integration/orchestration tasks open.
- Added explicit code/test pointers for quick verification: `modules/projections.py`, `modules/api.py` (`/api/embedding_map`), `tests/test_api_embedding_map.py`, and `modules/clustering.py` (`_select_best_image`).

### Testing
- Ran the targeted test command `python -m pytest tests/test_api_embedding_map.py -q`, which did not execute the tests due to an environment dependency issue (`ModuleNotFoundError: No module named 'pydantic'`) during test DB setup, causing the suite to skip; this PR contains documentation-only changes so no runtime behavior was modified.
- No full CI or broader test-suite run was performed as part of this documentation update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c74c24625c8323b13ae789f7d87fa3)