### PR TITLE
Add bidirectional WebSocket command dispatcher with per-request responses

### DIFF
--- a/docs/plans/embedding/EMBEDDING_APP_08_GRADIO_INTEGRATION_PLAN.md
+++ b/docs/plans/embedding/EMBEDDING_APP_08_GRADIO_INTEGRATION_PLAN.md
@@ -73,6 +73,8 @@ graph TD
 
 ## Part 1: Bidirectional WebSocket Protocol
 
+**Status:** ✅ Completed (backend runtime command channel, dispatcher, correlation responses, and tests shipped).
+
 ### Python side -- upgrade `/ws/updates`
 
 The WebSocket endpoint in `webui.py:220-234` currently receives text but does nothing with it (`pass`). Upgrade it to parse JSON commands and dispatch to runners.

--- a/docs/plans/embedding/TODO.md
+++ b/docs/plans/embedding/TODO.md
@@ -22,5 +22,5 @@ Backend tasks for embedding-based features. See [NEXT_STEPS.md](NEXT_STEPS.md) f
 
 ## Gradio Integration (Priority 3)
 
-- [ ] Bidirectional WebSocket command channel (see [EMBEDDING_APP_08_GRADIO_INTEGRATION_PLAN.md](EMBEDDING_APP_08_GRADIO_INTEGRATION_PLAN.md))
+- [x] Bidirectional WebSocket command channel (see [EMBEDDING_APP_08_GRADIO_INTEGRATION_PLAN.md](EMBEDDING_APP_08_GRADIO_INTEGRATION_PLAN.md))
 - [ ] "Similarity Search" tab or context menu in Gradio WebUI using `similar_search.py`

--- a/modules/command_dispatcher.py
+++ b/modules/command_dispatcher.py
@@ -1,0 +1,156 @@
+import logging
+from typing import Any, Awaitable, Callable, Dict, Optional
+
+from modules.events import event_manager
+
+logger = logging.getLogger(__name__)
+
+Handler = Callable[[Dict[str, Any]], Awaitable[Dict[str, Any]]]
+
+
+class CommandDispatcher:
+    """Dispatch inbound WebSocket commands to explicit action handlers."""
+
+    def __init__(self):
+        self._handlers: Dict[str, Handler] = {
+            "submit_image": self._handle_submit_image,
+            "submit_folder": self._handle_submit_folder,
+            "start_clustering": self._handle_start_clustering,
+            "get_status": self._handle_get_status,
+            "ping": self._handle_ping,
+        }
+        self._scoring_runner = None
+        self._tagging_runner = None
+        self._clustering_runner = None
+
+    def set_runners(self, scoring_runner=None, tagging_runner=None, clustering_runner=None):
+        self._scoring_runner = scoring_runner
+        self._tagging_runner = tagging_runner
+        self._clustering_runner = clustering_runner
+
+    def register(self, action: str, handler: Handler):
+        self._handlers[action] = handler
+
+    async def handle(self, websocket, message: Dict[str, Any]):
+        request_id = None
+        if isinstance(message, dict):
+            request_id = message.get("request_id")
+
+        if not isinstance(message, dict):
+            await self._respond(websocket, request_id, False, error="Invalid command payload; expected JSON object")
+            return
+
+        action = message.get("action")
+        if not action:
+            await self._respond(websocket, request_id, False, error="Missing required field: action")
+            return
+
+        handler = self._handlers.get(action)
+        if handler is None:
+            await self._respond(websocket, request_id, False, error=f"Unknown action: {action}")
+            return
+
+        try:
+            payload = message.get("data") or {}
+            if not isinstance(payload, dict):
+                raise ValueError("data must be an object")
+            result = await handler(payload)
+            await self._respond(websocket, request_id, True, data=result)
+        except Exception as exc:
+            logger.error("WebSocket command failed (action=%s): %s", action, exc)
+            await self._respond(websocket, request_id, False, error=str(exc))
+
+    async def _respond(self, websocket, request_id: Optional[str], success: bool, data: Optional[Dict[str, Any]] = None, error: Optional[str] = None):
+        message: Dict[str, Any] = {
+            "type": "command_response",
+            "request_id": request_id,
+            "success": success,
+            "data": data or {},
+        }
+        if error:
+            message["error"] = error
+        await event_manager.send_to(websocket, message)
+
+    async def _handle_submit_image(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        return self._enqueue_submit(data, default_scope_type="file")
+
+    async def _handle_submit_folder(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        return self._enqueue_submit(data, default_scope_type="folder_recursive")
+
+    async def _handle_start_clustering(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        clustered_data = dict(data)
+        clustered_data["jobType"] = "cluster"
+        clustered_data.setdefault("options", {})
+        return self._enqueue_submit(clustered_data, default_scope_type="folder_recursive")
+
+    async def _handle_get_status(self, _data: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "scoring": self._runner_status(self._scoring_runner),
+            "tagging": self._runner_status(self._tagging_runner),
+            "clustering": self._runner_status(self._clustering_runner),
+        }
+
+    async def _handle_ping(self, _data: Dict[str, Any]) -> Dict[str, Any]:
+        return {"message": "pong"}
+
+    def _runner_status(self, runner) -> Dict[str, Any]:
+        if runner is None:
+            return {"available": False}
+        is_running, _log_text, status_message, current, total = runner.get_status()[:5]
+        return {
+            "available": True,
+            "is_running": bool(is_running),
+            "status_message": status_message,
+            "progress": {"current": current, "total": total},
+        }
+
+    def _enqueue_submit(self, data: Dict[str, Any], default_scope_type: str) -> Dict[str, Any]:
+        from modules import db
+
+        target_paths = data.get("targetPaths") or data.get("target_paths") or []
+        if not isinstance(target_paths, list) or not target_paths:
+            raise ValueError("targetPaths must be a non-empty list")
+
+        options = data.get("options") or {}
+        if not isinstance(options, dict):
+            raise ValueError("options must be an object")
+
+        primary_path = str(target_paths[0])
+        job_type_in = (data.get("jobType") or "score").strip().lower()
+        job_type_map = {
+            "score": ("scoring", "scoring", ["indexing", "metadata", "scoring"]),
+            "tag": ("keywords", "tagging", ["keywords"]),
+            "cluster": ("culling", "clustering", ["culling"]),
+            "pipeline": ("scoring", "scoring", ["indexing", "metadata", "scoring", "keywords", "culling"]),
+        }
+        if job_type_in not in job_type_map:
+            raise ValueError(f"Unsupported jobType: {job_type_in}")
+
+        phase_code, enqueue_job_type, phases = job_type_map[job_type_in]
+
+        payload = {
+            "scope_type": data.get("scopeType") or default_scope_type,
+            "scope_paths": target_paths,
+            "input_path": primary_path,
+            "skip_done": bool(options.get("skip_existing", True)),
+            "skip_existing": bool(options.get("skip_existing", True)),
+            "force_rerun": bool(options.get("force_rerun", False)),
+            "phases": phases,
+            "target_phases": phases,
+            "command_source": "websocket",
+        }
+
+        job_id, queue_position = db.enqueue_job(primary_path, phase_code, enqueue_job_type, payload)
+        if not job_id:
+            raise RuntimeError("Failed to enqueue job")
+
+        db.create_job_phases(job_id, phases, "queued")
+        return {
+            "job_id": job_id,
+            "queue_position": queue_position,
+            "job_type": enqueue_job_type,
+            "input_path": primary_path,
+        }
+
+
+command_dispatcher = CommandDispatcher()

--- a/modules/events.py
+++ b/modules/events.py
@@ -59,6 +59,14 @@ class EventManager:
                 logger.error(f"Failed to send message to client: {e}")
                 self.disconnect(connection)
 
+    async def send_to(self, websocket: WebSocket, message: Dict[str, Any]):
+        """Send a JSON-serializable message to a specific WebSocket client."""
+        try:
+            await websocket.send_text(json.dumps(message))
+        except Exception as e:
+            logger.error(f"Failed to send unicast message to client: {e}")
+            self.disconnect(websocket)
+
     def broadcast_threadsafe(self, event_type: str, data: Any = None):
         """
         Broadcasts an event from a separate thread.

--- a/tests/test_command_dispatcher.py
+++ b/tests/test_command_dispatcher.py
@@ -1,0 +1,131 @@
+import asyncio
+import json
+from contextlib import asynccontextmanager
+
+import pytest
+from fastapi import FastAPI, WebSocket
+from fastapi.testclient import TestClient
+
+from modules.command_dispatcher import CommandDispatcher
+from modules.events import event_manager
+
+
+class _FakeWebSocket:
+    def __init__(self):
+        self.messages = []
+
+    async def send_text(self, text: str):
+        self.messages.append(json.loads(text))
+
+
+@pytest.fixture(autouse=True)
+def _reset_connections():
+    event_manager.active_connections.clear()
+    yield
+    event_manager.active_connections.clear()
+
+
+def _make_ws_app(dispatcher: CommandDispatcher):
+    @asynccontextmanager
+    async def lifespan(_app):
+        loop = asyncio.get_running_loop()
+        event_manager.set_loop(loop)
+        yield
+
+    app = FastAPI(lifespan=lifespan)
+
+    @app.websocket("/ws/updates")
+    async def websocket_endpoint(websocket: WebSocket):
+        await event_manager.connect(websocket)
+        try:
+            while True:
+                data = await websocket.receive_text()
+                try:
+                    msg = json.loads(data)
+                except json.JSONDecodeError:
+                    await event_manager.send_to(
+                        websocket,
+                        {
+                            "type": "command_response",
+                            "request_id": None,
+                            "success": False,
+                            "data": {},
+                            "error": "Malformed JSON payload",
+                        },
+                    )
+                    continue
+                await dispatcher.handle(websocket, msg)
+        except Exception:
+            event_manager.disconnect(websocket)
+
+    return app
+
+
+def test_malformed_json_returns_command_response():
+    dispatcher = CommandDispatcher()
+    app = _make_ws_app(dispatcher)
+
+    with TestClient(app).websocket_connect("/ws/updates") as websocket:
+        websocket.send_text("{not-valid-json")
+        response = websocket.receive_json()
+
+    assert response["type"] == "command_response"
+    assert response["success"] is False
+    assert response["error"] == "Malformed JSON payload"
+
+
+def test_unknown_action_returns_error_response():
+    dispatcher = CommandDispatcher()
+    app = _make_ws_app(dispatcher)
+
+    with TestClient(app).websocket_connect("/ws/updates") as websocket:
+        websocket.send_json({"action": "does_not_exist", "request_id": "req-1", "data": {}})
+        response = websocket.receive_json()
+
+    assert response["type"] == "command_response"
+    assert response["request_id"] == "req-1"
+    assert response["success"] is False
+    assert "Unknown action" in response["error"]
+
+
+def test_successful_dispatch_and_request_correlation():
+    dispatcher = CommandDispatcher()
+
+    async def _echo(data):
+        return {"echo": data.get("value")}
+
+    dispatcher.register("echo", _echo)
+    app = _make_ws_app(dispatcher)
+
+    with TestClient(app).websocket_connect("/ws/updates") as websocket:
+        websocket.send_json(
+            {
+                "action": "echo",
+                "request_id": "req-correlation-123",
+                "data": {"value": "ok"},
+            }
+        )
+        response = websocket.receive_json()
+
+    assert response["type"] == "command_response"
+    assert response["request_id"] == "req-correlation-123"
+    assert response["success"] is True
+    assert response["data"] == {"echo": "ok"}
+
+
+def test_unicast_response_targets_requesting_socket_only():
+    dispatcher = CommandDispatcher()
+
+    async def _ok(_data):
+        return {"done": True}
+
+    dispatcher.register("ok", _ok)
+
+    ws_one = _FakeWebSocket()
+    ws_two = _FakeWebSocket()
+
+    asyncio.run(dispatcher.handle(ws_one, {"action": "ok", "request_id": "r-1", "data": {}}))
+
+    assert len(ws_one.messages) == 1
+    assert ws_one.messages[0]["request_id"] == "r-1"
+    assert ws_two.messages == []

--- a/webui.py
+++ b/webui.py
@@ -2,6 +2,7 @@ import os
 import platform
 import warnings
 import logging
+import json
 from contextlib import asynccontextmanager
 import gradio as gr
 from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
@@ -11,6 +12,7 @@ from fastapi.staticfiles import StaticFiles
 import uvicorn
 from modules.ui import app as app_module
 from modules.events import event_manager
+from modules.command_dispatcher import command_dispatcher
 
 # Suppress TensorFlow logging (C++ level)
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
@@ -280,6 +282,11 @@ def main():
         app, runner, tagging_runner, clustering_runner, selection_runner, 
         orchestrator, indexing_runner=indexing_runner, metadata_runner=metadata_runner
     )
+    command_dispatcher.set_runners(
+        scoring_runner=runner,
+        tagging_runner=tagging_runner,
+        clustering_runner=clustering_runner,
+    )
     
     # Mount MCP SSE endpoints (if enabled) onto the final app instance.
     # MUST be mounted BEFORE Gradio to avoid being shadowed by Gradio's catch-all route at /
@@ -299,10 +306,22 @@ def main():
         try:
             while True:
                 # Keep connection alive and listen for any incoming messages (though we mainly push)
-                # We can also handle simple pings or subscription requests here if needed
                 data = await websocket.receive_text()
-                # Echo back or handle commands if necessary
-                pass 
+                try:
+                    message = json.loads(data)
+                except json.JSONDecodeError:
+                    await event_manager.send_to(
+                        websocket,
+                        {
+                            "type": "command_response",
+                            "request_id": None,
+                            "success": False,
+                            "data": {},
+                            "error": "Malformed JSON payload",
+                        },
+                    )
+                    continue
+                await command_dispatcher.handle(websocket, message)
         except WebSocketDisconnect:
             event_manager.disconnect(websocket)
         except Exception as e:


### PR DESCRIPTION
### Motivation
- Enable a bidirectional command channel on the existing `/ws/updates` endpoint so clients can send commands (submit jobs, start clustering, query status) and receive correlated responses. 
- Provide a clear unicast response path for request/response semantics while keeping existing broadcast events for shared state updates.

### Description
- Add a new `modules/command_dispatcher.py` implementing `CommandDispatcher` with handlers for `submit_image`, `submit_folder`, `start_clustering`, `get_status`, and `ping`, plus a small handler registry to allow additional actions to be registered. 
- Extend `modules/events.py` with `EventManager.send_to(...)` to send unicast JSON messages to a specific WebSocket client while preserving `broadcast`/`broadcast_threadsafe` for global events. 
- Update the WebSocket loop in `webui.py` to parse inbound text as JSON, route messages to the dispatcher, and return a structured `command_response` for malformed JSON or dispatcher results. 
- Add `tests/test_command_dispatcher.py` covering malformed JSON handling, unknown action error, successful dispatch with `request_id` correlation, and ensuring unicast responses go to the requesting socket only. 
- Mark the bidirectional WebSocket task as completed in the embedding plan docs and TODO list.

### Testing
- Ran static compilation check with `python -m py_compile webui.py modules/events.py modules/command_dispatcher.py tests/test_command_dispatcher.py`, which succeeded. 
- Ran unit tests via `python -m pytest tests/test_events.py tests/test_command_dispatcher.py -q`, which failed in this environment due to missing runtime dependencies (`fastapi`, `pydantic`) and the unavailable virtualenv, so test collection could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c74c26147883239da4f5f493c1bb7b)