### PR TITLE
docs: add Cloud VM setup gotchas to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -361,3 +361,5 @@ ruff check
 - The base `requirements.txt` pins `tensorflow-cpu>=2.15.1,<2.16.0` which is **incompatible with Python 3.12**. Use `requirements/requirements_wsl_gpu.txt` (filtered to remove NVIDIA/CUDA packages) for installing deps on Python 3.12.
 - The DB migration in `_init_db_impl()` may log errors about missing columns (`CULL_DECISION`, `RATING`) when creating a fresh database. The server still starts and serves API requests.
 - No `config.json` ships with the repo — it is created at runtime. The app handles its absence gracefully.
+- After installing Firebird, `/tmp/firebird/` files are owned by the `firebird` user. Run `sudo chmod -R 777 /tmp/firebird/` before using `isql` as a non-firebird user, or the client will fail with "Permission denied" on `fb_init`/`fb50_trace`.
+- `tests/test_exifread.py` may also fail collection if the `exifread` package is not installed; add `--ignore=tests/test_exifread.py` alongside `test_probe.py` when running the fast test subset.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds two non-obvious gotchas to the `AGENTS.md` Cursor Cloud instructions section discovered during development environment setup:

1. **Firebird `/tmp/firebird/` permissions**: After installing Firebird, the temp directory files are owned by the `firebird` user. Non-firebird users (like `ubuntu`) need `sudo chmod -R 777 /tmp/firebird/` before running `isql`, or the client fails with "Permission denied" on `fb_init`/`fb50_trace`.

2. **`test_exifread.py` collection error**: This test file may fail during pytest collection if the `exifread` package is not installed. Added note to ignore it alongside `test_probe.py` when running the fast test subset.

## Verified

- Lint: `ruff check` — 752 pre-existing warnings, no new issues
- Tests: `pytest -m "not gpu and not db and not ml and not firebird"` — 349 passed, 44 skipped
- WebUI: `python webui.py` starts and serves on port 7860 with healthy API responses
- Scoring API: `POST /api/scoring/single` processes images end-to-end
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f32fde6b-4b76-4cae-8d42-62295710bd38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f32fde6b-4b76-4cae-8d42-62295710bd38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

