### PR TITLE
Clarify fix_incomplete as scoring-only in UI, API docs, and dispatcher comments

### DIFF
--- a/docs/reference/api/openapi.yaml
+++ b/docs/reference/api/openapi.yaml
@@ -5988,8 +5988,10 @@ components:
           title: Fix Incomplete Stages
           description: >-
             When true, scoring targets only images under the scope that match
-            incomplete-record criteria (missing scores, rating, or label), and
-            forces those rows to be processed.
+            incomplete-record criteria (missing scoring fields, rating, or
+            label), and forces those rows to be processed. This selector is
+            currently scoring-only; metadata/tagging/culling still use normal
+            stage skip/re-run behavior.
           default: false
       type: object
       required:

--- a/frontend/src/components/scope/ScopeSelector.tsx
+++ b/frontend/src/components/scope/ScopeSelector.tsx
@@ -318,6 +318,7 @@ export function ScopeSelector() {
                   className="mt-1"
                   checked={runOptionsMode === 'fix_incomplete'}
                   onChange={() => setRunOptionsMode('fix_incomplete')}
+                  aria-describedby="fix-incomplete-help"
                 />
                 <span>
                   <span className="flex items-center gap-2">
@@ -326,9 +327,9 @@ export function ScopeSelector() {
                       Scoring only
                     </span>
                   </span>
-                  <span className="block text-xs text-[#6d6d6d] mt-0.5">
-                    For quality scoring, only images missing scores, rating, or label under the
-                    selected paths (other stages use normal skip rules).
+                  <span id="fix-incomplete-help" className="block text-xs text-[#6d6d6d] mt-0.5">
+                    Targets only images missing scores, rating, or label under selected paths
+                    (other stages use normal skip rules).
                   </span>
                 </span>
               </label>

--- a/frontend/src/components/scope/ScopeSelector.tsx
+++ b/frontend/src/components/scope/ScopeSelector.tsx
@@ -320,7 +320,12 @@ export function ScopeSelector() {
                   onChange={() => setRunOptionsMode('fix_incomplete')}
                 />
                 <span>
-                  <span className="text-[#cccccc]">Fix non-completed stages</span>
+                  <span className="flex items-center gap-2">
+                    <span className="text-[#cccccc]">Fix incomplete scoring data</span>
+                    <span className="rounded border border-[#007acc]/40 bg-[#003f6e]/30 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-[#4fc1ff]">
+                      Scoring only
+                    </span>
+                  </span>
                   <span className="block text-xs text-[#6d6d6d] mt-0.5">
                     For quality scoring, only images missing scores, rating, or label under the
                     selected paths (other stages use normal skip rules).

--- a/modules/db.py
+++ b/modules/db.py
@@ -6370,7 +6370,7 @@ def update_image_metadata(file_path, keywords, title, description, rating, label
 
 
 def _incomplete_images_where_sql(table_alias: str = "") -> str:
-    """SQL fragment: image row qualifies as incomplete (scores / rating / label)."""
+    """SQL fragment for scoring completeness checks (scores / rating / label)."""
     prefix = f"{table_alias}." if table_alias else ""
     score_checks = [
         f"{prefix}score_general IS NULL OR {prefix}score_general <= 0",
@@ -6413,7 +6413,7 @@ def get_incomplete_records(limit: int | None = None):
 def get_incomplete_image_ids_under_folder(folder_path: str, limit: int | None = None):
     """
     Image IDs under a folder tree (recursive) that match get_incomplete_records criteria.
-    Used when queuing a run with fix_incomplete_stages so scoring targets gaps only.
+    Used by fix_incomplete_stages for scoring only; other stages ignore this selector.
     """
     from modules import utils
 

--- a/modules/job_dispatcher.py
+++ b/modules/job_dispatcher.py
@@ -202,6 +202,8 @@ class JobDispatcher:
         if phase in ("score", "scoring"):
             skip_existing_val = bool(payload.get("skip_existing", True))
             resolved = payload.get("resolved_image_ids")
+            # Short-term behavior: fix_incomplete_stages resolves scoped IDs only for scoring.
+            # Metadata/tagging/culling continue to use their normal skip/re-run semantics.
             if bool(payload.get("fix_incomplete_stages")) and not resolved:
                 paths = payload.get("scope_paths")
                 if not isinstance(paths, list) or not paths:


### PR DESCRIPTION
### Motivation
- Make explicit that the `fix_incomplete_stages` mode currently targets scoring completeness (scores/rating/label) only rather than all pipeline stages. 
- Provide a short-term UX/Docs change (rename/label) so users do not assume the behavior applies to metadata/tagging/culling.

### Description
- Rename UI option in `frontend/src/components/scope/ScopeSelector.tsx` to “Fix incomplete scoring data” and add a visible `Scoring only` badge next to the label. 
- Update API docs in `docs/reference/api/openapi.yaml` (`RunSubmitRequest.fix_incomplete_stages`) to state the selector is currently scoring-only and that metadata/tagging/culling use normal skip/re-run rules. 
- Clarify comments in `modules/db.py` (`_incomplete_images_where_sql` / `get_incomplete_image_ids_under_folder`) to indicate the selector implements scoring completeness checks and is used by `fix_incomplete_stages` for scoring only. 
- Add inline comment in `modules/job_dispatcher.py` around dispatch logic to document the short-term scoring-only resolution behavior when `fix_incomplete_stages` is used. 

### Testing
- Ran `python -m compileall modules/job_dispatcher.py modules/db.py` and it completed successfully. 
- Ran `git diff --check` to verify no trailing whitespace or index errors and it returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da9b9e82048323a76bca73f725a714)