### PR TITLE
Add maintenance endpoint and UI to recalculate per-image status and folder aggregates

### DIFF
--- a/frontend/src/api/tools.ts
+++ b/frontend/src/api/tools.ts
@@ -20,6 +20,33 @@ export interface StaleRunningPhasesResponse {
   }>
 }
 
+export interface RecalculateStatusSummary {
+  scope: 'all' | 'selected_folder'
+  scope_path: string | null
+  target_images: number
+  per_image_changes: {
+    indexing_metadata_backfilled_images: number
+    keywords_phase_backfilled_rows: number
+    culling_failed_to_done_rows: number
+    total_rows_changed_estimate: number
+  }
+  folder_aggregate_changes: {
+    folders_recomputed: number
+    folders_marked_keywords_processed: number
+  }
+  before: {
+    missing_indexing_or_metadata_with_scoring_done: number
+    missing_keywords_status_with_keywords_data: number
+    culling_failed_with_data_present: number
+  }
+  after: {
+    missing_indexing_or_metadata_with_scoring_done: number
+    missing_keywords_status_with_keywords_data: number
+    culling_failed_with_data_present: number
+  }
+  warnings: string[]
+}
+
 export const toolsApi = {
   staleRunningPhases: (minAgeSeconds = 3600, limit = 50) =>
     api.get<StaleRunningPhasesResponse>(
@@ -45,6 +72,14 @@ export const toolsApi = {
   repairThumbnailPaths: (opts?: { repairAll?: boolean }) => {
     const q = opts?.repairAll ? '?repair_all=true' : ''
     return api.post<ApiEnvelope>(`/maintenance/repair-thumbnail-paths${q}`)
+  },
+
+  recalculateStatusFromData: (opts?: { scope?: 'all' | 'selected_folder'; scopePath?: string }) => {
+    const p = new URLSearchParams()
+    if (opts?.scope) p.set('scope', opts.scope)
+    if (opts?.scopePath?.trim()) p.set('scope_path', opts.scopePath.trim())
+    const q = p.toString()
+    return api.post<ApiEnvelope>(`/maintenance/recalculate-status-from-data${q ? `?${q}` : ''}`)
   },
 }
 

--- a/frontend/src/components/runs/RunsToolsTab.tsx
+++ b/frontend/src/components/runs/RunsToolsTab.tsx
@@ -134,7 +134,7 @@ export function RunsToolsTab() {
     mutationFn: () =>
       toolsApi.recalculateStatusFromData({
         scope: recalcScope,
-        scopePath: selectedScopePath?.trim() || undefined,
+        scopePath: recalcScope === 'selected_folder' ? selectedScopePath?.trim() || undefined : undefined,
       }),
     onSuccess: (r) => {
       setFromEnvelope('Recalculate status', r)

--- a/frontend/src/components/runs/RunsToolsTab.tsx
+++ b/frontend/src/components/runs/RunsToolsTab.tsx
@@ -1,13 +1,14 @@
-import { useState, type ReactNode } from 'react'
+import { useMemo, useState, type ReactNode } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Link } from 'react-router-dom'
 import { Wrench, RefreshCcw, ExternalLink } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { toolsApi, formatToolError, type ApiEnvelope } from '@/api/tools'
+import { toolsApi, formatToolError, type ApiEnvelope, type RecalculateStatusSummary } from '@/api/tools'
 import { runsApi } from '@/api/runs'
 import { FULL_PIPELINE_STAGE_CODES } from '@/constants/pipeline'
 import { STAGE_DISPLAY } from '@/types/api'
 import { useUiStore } from '@/stores/uiStore'
+import { Card, CardTitle } from '@/components/ui/card'
 
 const STALE_MIN_AGE = 3600
 const BACKFILL_LIMIT = 1000
@@ -49,6 +50,9 @@ export function RunsToolsTab() {
   const selectedScopePath = useUiStore((s) => s.selectedScopePath)
   const setPendingTreeRevealPaths = useUiStore((s) => s.setPendingTreeRevealPaths)
   const [lastAction, setLastAction] = useState<{ ok: boolean; text: string } | null>(null)
+  const [recalcScope, setRecalcScope] = useState<'all' | 'selected_folder'>('selected_folder')
+  const [showRecalcConfirm, setShowRecalcConfirm] = useState(false)
+  const [recalcSummary, setRecalcSummary] = useState<RecalculateStatusSummary | null>(null)
 
   const staleQuery = useQuery({
     queryKey: ['maintenance-stale-phases', STALE_MIN_AGE],
@@ -126,13 +130,45 @@ export function RunsToolsTab() {
     onError: (e) => setLastAction({ ok: false, text: formatToolError(e) }),
   })
 
+  const recalcStatusMut = useMutation({
+    mutationFn: () =>
+      toolsApi.recalculateStatusFromData({
+        scope: recalcScope,
+        scopePath: selectedScopePath?.trim() || undefined,
+      }),
+    onSuccess: (r) => {
+      setFromEnvelope('Recalculate status', r)
+      const summaryCandidate = r.data?.summary
+      if (summaryCandidate && typeof summaryCandidate === 'object') {
+        setRecalcSummary(summaryCandidate as RecalculateStatusSummary)
+      } else {
+        setRecalcSummary(null)
+      }
+      void queryClient.invalidateQueries({ queryKey: ['maintenance-stale-phases'] })
+      void queryClient.invalidateQueries({ queryKey: ['folders-tree'] })
+      void queryClient.invalidateQueries({ queryKey: ['runs'] })
+      setShowRecalcConfirm(false)
+    },
+    onError: (e) => {
+      setLastAction({ ok: false, text: formatToolError(e) })
+      setShowRecalcConfirm(false)
+    },
+  })
+
+  const selectedScopeMissing = recalcScope === 'selected_folder' && !selectedScopePath?.trim()
+  const recalcButtonHint = useMemo(() => {
+    if (recalcScope === 'all') return 'Entire database'
+    return selectedScopePath?.trim() ? `Selected: ${selectedScopePath.trim()}` : 'Select a folder first'
+  }, [recalcScope, selectedScopePath])
+
   const mutationPending =
     reconcileMut.isPending ||
     fixDbMut.isPending ||
     backfillMut.isPending ||
     healThumbMut.isPending ||
     repairThumbDeepMut.isPending ||
-    fullPipelineMut.isPending
+    fullPipelineMut.isPending ||
+    recalcStatusMut.isPending
   /** Block concurrent tool actions (mutations or stale probe refetch). */
   const toolsLocked = mutationPending || staleQuery.isFetching
 
@@ -269,6 +305,120 @@ export function RunsToolsTab() {
         </div>
         {!selectedScopePath?.trim() && (
           <p className="text-xs text-[#6d6d6d] mt-2">Select a folder in Scope Navigator to enable this action.</p>
+        )}
+      </ToolSection>
+
+      <ToolSection
+        title="Recalculate status from data"
+        description={
+          'Recomputes derivable per-image phase states and rebuilds folder aggregate flags/caches. ' +
+          'Use after crashes, import drifts, or legacy migrations when badges look inconsistent.'
+        }
+      >
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-3">
+            <label className="text-xs text-[#9d9d9d] inline-flex items-center gap-1.5">
+              <input
+                type="radio"
+                name="recalc-scope"
+                checked={recalcScope === 'selected_folder'}
+                onChange={() => setRecalcScope('selected_folder')}
+                disabled={toolsLocked}
+              />
+              Selected folder
+            </label>
+            <label className="text-xs text-[#9d9d9d] inline-flex items-center gap-1.5">
+              <input
+                type="radio"
+                name="recalc-scope"
+                checked={recalcScope === 'all'}
+                onChange={() => setRecalcScope('all')}
+                disabled={toolsLocked}
+              />
+              Entire database
+            </label>
+          </div>
+
+          <p className="text-xs text-[#6d6d6d]">{recalcButtonHint}</p>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={() => setShowRecalcConfirm(true)}
+              disabled={toolsLocked || selectedScopeMissing}
+              loading={recalcStatusMut.isPending}
+            >
+              Recalculate Status from Data
+            </Button>
+          </div>
+
+          {selectedScopeMissing && (
+            <p className="text-xs text-[#6d6d6d]">Select a folder in Scope Navigator to run this scope.</p>
+          )}
+
+          {showRecalcConfirm && (
+            <div className="rounded border border-[#6f4e00] bg-[#3a2d00] p-3">
+              <p className="text-xs text-[#f2cc60]">
+                Confirm recalculation for{' '}
+                <span className="font-medium">
+                  {recalcScope === 'all' ? 'entire database' : selectedScopePath?.trim() || 'selected folder'}
+                </span>
+                ?
+              </p>
+              <p className="text-xs text-[#d7ba7d] mt-1">
+                This updates derivable per-image statuses and rebuilds folder rollups/flags.
+              </p>
+              <div className="flex items-center gap-2 mt-2">
+                <Button
+                  variant="danger"
+                  size="sm"
+                  onClick={() => recalcStatusMut.mutate()}
+                  disabled={toolsLocked || selectedScopeMissing}
+                  loading={recalcStatusMut.isPending}
+                >
+                  Confirm and run
+                </Button>
+                <Button variant="secondary" size="sm" onClick={() => setShowRecalcConfirm(false)} disabled={toolsLocked}>
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {recalcSummary && (
+          <Card className="mt-3 border-[#3c3c3c] bg-[#1f1f1f]">
+            <CardTitle className="mb-2">Last recalculation summary</CardTitle>
+            <div className="space-y-1 text-xs text-[#9d9d9d]">
+              <p>
+                Scope: <span className="text-[#cccccc]">{recalcSummary.scope === 'all' ? 'Entire database' : recalcSummary.scope_path || 'Selected folder'}</span>
+              </p>
+              <p>
+                Changed rows (estimate):{' '}
+                <span className="text-[#cccccc] font-medium">{recalcSummary.per_image_changes.total_rows_changed_estimate}</span>
+              </p>
+              <p>
+                Per-image changes: index/meta={recalcSummary.per_image_changes.indexing_metadata_backfilled_images}, keywords={recalcSummary.per_image_changes.keywords_phase_backfilled_rows}, culling={recalcSummary.per_image_changes.culling_failed_to_done_rows}
+              </p>
+              <p>
+                Folder rebuild: recomputed={recalcSummary.folder_aggregate_changes.folders_recomputed}, keyword flags updated={recalcSummary.folder_aggregate_changes.folders_marked_keywords_processed}
+              </p>
+              <p>
+                Remaining drift: index/meta={recalcSummary.after.missing_indexing_or_metadata_with_scoring_done}, keywords={recalcSummary.after.missing_keywords_status_with_keywords_data}, culling={recalcSummary.after.culling_failed_with_data_present}
+              </p>
+              {recalcSummary.warnings.length > 0 && (
+                <div className="mt-2 rounded border border-[#5a3a3a] bg-[#2a1a1a] p-2">
+                  <p className="text-[#f44747] mb-1">Warnings</p>
+                  <ul className="list-disc pl-4 space-y-0.5 text-[#d7a7a7]">
+                    {recalcSummary.warnings.map((w) => (
+                      <li key={w}>{w}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          </Card>
         )}
       </ToolSection>
 

--- a/modules/api.py
+++ b/modules/api.py
@@ -5634,6 +5634,275 @@ def create_api_router() -> APIRouter:
         )
 
     @router.post(
+        "/maintenance/recalculate-status-from-data",
+        response_model=ApiResponse,
+        summary="Recalculate derivable per-image status and folder aggregates",
+        description=(
+            "Repairs derivable per-image phase status drift (index/meta, keywords, culling), "
+            "then rebuilds folder phase aggregates and legacy flags. Supports all-db or selected-folder scope."
+        ),
+        tags=["General API"],
+    )
+    async def maintenance_recalculate_status_from_data(
+        scope: str = Query("selected_folder", pattern="^(all|selected_folder)$"),
+        scope_path: Optional[str] = Query(
+            None,
+            description="Required when scope=selected_folder. Uses folder + descendants.",
+        ),
+    ):
+        from modules.ui.security import _check_rate_limit
+        from modules import db, utils
+
+        _check_rate_limit("maintenance_recalculate_status_from_data")
+
+        selected_scope = (scope or "selected_folder").strip().lower()
+        if selected_scope == "selected_folder" and not (scope_path and scope_path.strip()):
+            raise HTTPException(status_code=400, detail="scope_path is required when scope=selected_folder")
+
+        target_scope_path = None
+        target_folder_paths: List[str] = []
+        if selected_scope == "selected_folder":
+            wsl_path = (
+                utils.convert_path_to_wsl(scope_path.strip())
+                if hasattr(utils, "convert_path_to_wsl")
+                else scope_path.strip()
+            )
+            target_scope_path = wsl_path or scope_path.strip()
+            target_folder_paths = db.list_folder_paths_under_scope(target_scope_path)
+            if not target_folder_paths:
+                row = db.get_connector().query_one("SELECT path FROM folders WHERE path = ?", (target_scope_path,))
+                if row and row.get("path"):
+                    target_folder_paths = [row["path"]]
+                else:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"Scope folder not found in folders cache: {scope_path}",
+                    )
+        else:
+            rows = db.get_connector().query("SELECT path FROM folders")
+            target_folder_paths = [r["path"] for r in rows if r and r.get("path")]
+
+        connector = db.get_connector()
+        image_scope_sql = ""
+        image_scope_params: List[Any] = []
+        if selected_scope == "selected_folder":
+            placeholders = ",".join(["?"] * len(target_folder_paths))
+            image_scope_sql = f" AND i.folder_id IN (SELECT id FROM folders WHERE path IN ({placeholders}))"
+            image_scope_params = list(target_folder_paths)
+
+        before = {
+            "missing_indexing_or_metadata_with_scoring_done": 0,
+            "missing_keywords_status_with_keywords_data": 0,
+            "culling_failed_with_data_present": 0,
+        }
+        after = dict(before)
+        warnings: List[str] = []
+
+        before_idx_meta_sql = (
+            """
+            SELECT COUNT(*) AS cnt
+            FROM images i
+            JOIN pipeline_phases p_score ON LOWER(TRIM(p_score.code)) = 'scoring'
+            JOIN image_phase_status ips_score ON ips_score.image_id = i.id
+                AND ips_score.phase_id = p_score.id
+                AND LOWER(TRIM(ips_score.status)) = 'done'
+            WHERE (
+                NOT EXISTS (
+                    SELECT 1 FROM image_phase_status ips_i
+                    JOIN pipeline_phases p_i ON p_i.id = ips_i.phase_id
+                    WHERE ips_i.image_id = i.id
+                      AND LOWER(TRIM(p_i.code)) = 'indexing'
+                      AND LOWER(TRIM(ips_i.status)) = 'done'
+                )
+                OR NOT EXISTS (
+                    SELECT 1 FROM image_phase_status ips_m
+                    JOIN pipeline_phases p_m ON p_m.id = ips_m.phase_id
+                    WHERE ips_m.image_id = i.id
+                      AND LOWER(TRIM(p_m.code)) = 'metadata'
+                      AND LOWER(TRIM(ips_m.status)) = 'done'
+                )
+            )
+            """
+            + image_scope_sql
+        )
+        before["missing_indexing_or_metadata_with_scoring_done"] = int(
+            (connector.query_one(before_idx_meta_sql, tuple(image_scope_params)) or {}).get("cnt", 0)
+        )
+
+        kw_sql = (
+            """
+            SELECT COUNT(*) AS cnt
+            FROM images i
+            WHERE EXISTS (SELECT 1 FROM image_keywords ik WHERE ik.image_id = i.id)
+              AND NOT EXISTS (
+                SELECT 1 FROM image_phase_status ips
+                JOIN pipeline_phases pp ON pp.id = ips.phase_id
+                WHERE ips.image_id = i.id
+                  AND LOWER(TRIM(pp.code)) = 'keywords'
+              )
+            """
+            + image_scope_sql
+        )
+        before["missing_keywords_status_with_keywords_data"] = int(
+            (connector.query_one(kw_sql, tuple(image_scope_params)) or {}).get("cnt", 0)
+        )
+
+        has_culling_data_expr = (
+            "i.stack_id IS NOT NULL OR EXISTS (SELECT 1 FROM image_embeddings ie WHERE ie.image_id = i.id)"
+            if getattr(connector, "type", "") == "postgres"
+            else "i.stack_id IS NOT NULL OR i.image_embedding IS NOT NULL"
+        )
+
+        culling_sql = (
+            """
+            SELECT COUNT(*) AS cnt
+            FROM image_phase_status ips
+            JOIN pipeline_phases pp ON pp.id = ips.phase_id
+            JOIN images i ON i.id = ips.image_id
+            WHERE LOWER(TRIM(pp.code)) = 'culling'
+              AND LOWER(TRIM(ips.status)) = 'failed'
+              AND (
+            """
+            + has_culling_data_expr
+            + """
+              )
+            """
+            + image_scope_sql
+        )
+        before["culling_failed_with_data_present"] = int(
+            (connector.query_one(culling_sql, tuple(image_scope_params)) or {}).get("cnt", 0)
+        )
+
+        if selected_scope == "selected_folder":
+            idx_meta_changed = int(db.backfill_index_meta_for_folder(target_scope_path))
+        else:
+            idx_meta_changed = int(db.backfill_index_meta_global(limit=1_000_000))
+
+        kw_rows = connector.query(
+            (
+                """
+                SELECT DISTINCT i.id AS image_id
+                FROM images i
+                WHERE EXISTS (SELECT 1 FROM image_keywords ik WHERE ik.image_id = i.id)
+                  AND NOT EXISTS (
+                    SELECT 1 FROM image_phase_status ips
+                    JOIN pipeline_phases pp ON pp.id = ips.phase_id
+                    WHERE ips.image_id = i.id
+                      AND LOWER(TRIM(pp.code)) = 'keywords'
+                  )
+                """
+                + image_scope_sql
+            ),
+            tuple(image_scope_params),
+        )
+        kw_backfilled = 0
+        for row in kw_rows:
+            db.set_image_phase_status(int(row["image_id"]), "keywords", "done")
+            kw_backfilled += 1
+
+        culling_rows = connector.query(
+            (
+                """
+                SELECT ips.id AS ips_id
+                FROM image_phase_status ips
+                JOIN pipeline_phases pp ON pp.id = ips.phase_id
+                JOIN images i ON i.id = ips.image_id
+                WHERE LOWER(TRIM(pp.code)) = 'culling'
+                  AND LOWER(TRIM(ips.status)) = 'failed'
+                  AND (
+                """
+                + has_culling_data_expr
+                + """
+                  )
+                """
+                + image_scope_sql
+            ),
+            tuple(image_scope_params),
+        )
+        culling_ids = [int(r["ips_id"]) for r in culling_rows]
+        if culling_ids:
+            now = datetime.now()
+
+            def _repair_culling_tx(tx):
+                for ips_id in culling_ids:
+                    tx.execute(
+                        """
+                        UPDATE image_phase_status
+                        SET status = 'done',
+                            last_error = NULL,
+                            finished_at = COALESCE(finished_at, ?),
+                            updated_at = ?
+                        WHERE id = ?
+                        """,
+                        (now, now, ips_id),
+                    )
+
+            connector.run_transaction(_repair_culling_tx)
+
+        folders_recomputed = 0
+        keywords_flag_updates = 0
+        for path in target_folder_paths:
+            try:
+                db.invalidate_folder_phase_aggregates(folder_path=path)
+                db.get_folder_phase_summary(path, force_refresh=True)
+                folders_recomputed += 1
+                if db.check_and_update_folder_keywords_status(path):
+                    keywords_flag_updates += 1
+            except Exception as folder_err:
+                warnings.append(f"Folder aggregate rebuild failed for {path}: {folder_err}")
+
+        if selected_scope == "all" and not target_folder_paths:
+            warnings.append("No folders found; aggregate rebuild skipped.")
+
+        after["missing_indexing_or_metadata_with_scoring_done"] = int(
+            (connector.query_one(before_idx_meta_sql, tuple(image_scope_params)) or {}).get("cnt", 0)
+        )
+        after["missing_keywords_status_with_keywords_data"] = int(
+            (connector.query_one(kw_sql, tuple(image_scope_params)) or {}).get("cnt", 0)
+        )
+        after["culling_failed_with_data_present"] = int(
+            (connector.query_one(culling_sql, tuple(image_scope_params)) or {}).get("cnt", 0)
+        )
+
+        target_images_row = connector.query_one(
+            (
+                "SELECT COUNT(*) AS cnt FROM images i WHERE 1=1"
+                + image_scope_sql
+            ),
+            tuple(image_scope_params),
+        )
+        target_images = int((target_images_row or {}).get("cnt", 0))
+
+        summary = {
+            "scope": selected_scope,
+            "scope_path": target_scope_path if selected_scope == "selected_folder" else None,
+            "target_images": target_images,
+            "per_image_changes": {
+                "indexing_metadata_backfilled_images": idx_meta_changed,
+                "keywords_phase_backfilled_rows": kw_backfilled,
+                "culling_failed_to_done_rows": len(culling_ids),
+                "total_rows_changed_estimate": (idx_meta_changed * 2) + kw_backfilled + len(culling_ids),
+            },
+            "folder_aggregate_changes": {
+                "folders_recomputed": folders_recomputed,
+                "folders_marked_keywords_processed": keywords_flag_updates,
+            },
+            "before": before,
+            "after": after,
+            "warnings": warnings,
+        }
+
+        return ApiResponse(
+            success=True,
+            message=(
+                "Status recalculation finished: "
+                f"{summary['per_image_changes']['total_rows_changed_estimate']} per-image row changes "
+                f"(estimated), {folders_recomputed} folder aggregate(s) rebuilt."
+            ),
+            data={"summary": summary},
+        )
+
+    @router.post(
         "/maintenance/backfill-exif-dates",
         response_model=ApiResponse,
         summary="Re-extract EXIF dates for rows with NULL date_time_original",

--- a/modules/api.py
+++ b/modules/api.py
@@ -5739,6 +5739,7 @@ def create_api_router() -> APIRouter:
                 JOIN pipeline_phases pp ON pp.id = ips.phase_id
                 WHERE ips.image_id = i.id
                   AND LOWER(TRIM(pp.code)) = 'keywords'
+                  AND LOWER(TRIM(ips.status)) = 'done'
               )
             """
             + image_scope_sql
@@ -5789,6 +5790,7 @@ def create_api_router() -> APIRouter:
                     JOIN pipeline_phases pp ON pp.id = ips.phase_id
                     WHERE ips.image_id = i.id
                       AND LOWER(TRIM(pp.code)) = 'keywords'
+                      AND LOWER(TRIM(ips.status)) = 'done'
                   )
                 """
                 + image_scope_sql
@@ -5853,6 +5855,9 @@ def create_api_router() -> APIRouter:
 
         if selected_scope == "all" and not target_folder_paths:
             warnings.append("No folders found; aggregate rebuild skipped.")
+        warnings.append(
+            "total_rows_changed_estimate is heuristic: index/meta assumes up to 2 per-image phase rows per repaired image."
+        )
 
         after["missing_indexing_or_metadata_with_scoring_done"] = int(
             (connector.query_one(before_idx_meta_sql, tuple(image_scope_params)) or {}).get("cnt", 0)
@@ -5897,7 +5902,7 @@ def create_api_router() -> APIRouter:
             message=(
                 "Status recalculation finished: "
                 f"{summary['per_image_changes']['total_rows_changed_estimate']} per-image row changes "
-                f"(estimated), {folders_recomputed} folder aggregate(s) rebuilt."
+                f"(heuristic estimate), {folders_recomputed} folder aggregate(s) rebuilt."
             ),
             data={"summary": summary},
         )


### PR DESCRIPTION
### Motivation

- Provide an operator-safe maintenance action to repair phase/status drift (derivable per-image phase states and folder rollups) after crashes, legacy imports, or migration gaps. 

### Description

- Add `POST /api/maintenance/recalculate-status-from-data` in `modules/api.py` which supports `scope=all|selected_folder` (with `scope_path`) and runs scoped repairs including index/metadata backfill, keywords-phase backfill, culling repairs (failed→done when data present), folder aggregate invalidation/recompute (`phase_agg_json`, `is_fully_scored`, `is_keywords_processed`), and returns a `summary` payload with before/after counts and warnings. 
- Reused existing DB helpers (`backfill_index_meta_for_folder` / `backfill_index_meta_global`, `set_image_phase_status`, `invalidate_folder_phase_aggregates`, `get_folder_phase_summary`, `check_and_update_folder_keywords_status`) and added SQL probes to produce a diff summary. 
- Expose the action in the frontend by adding a typed `RecalculateStatusSummary` and `toolsApi.recalculateStatusFromData(...)` client in `frontend/src/api/tools.ts`. 
- Add a UI flow in `frontend/src/components/runs/RunsToolsTab.tsx` with scope selection (selected folder vs entire DB), a confirmation block, and a post-run summary `Card` that displays changed row estimates, residual drift counts, and any warnings.

### Testing

- Ran `python -m py_compile modules/api.py`, which succeeded. 
- Attempted `npm --prefix frontend run -s build`, which failed in this environment due to missing TypeScript type definition files (`vite/client` and `node`), so full frontend build verification was not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da9bb192508323ad1a89a4c08578cf)