### PR TITLE
Add coverage baseline docs and CI workflow to upload coverage artifacts

### DIFF
--- a/.github/workflows/coverage-artifacts.yml
+++ b/.github/workflows/coverage-artifacts.yml
@@ -27,7 +27,9 @@ jobs:
       - name: Install backend dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          # Python 3.12 CI: avoid requirements.txt (pins tensorflow-cpu<2.16, unavailable for py3.12)
+          grep -Ev '^(nvidia-|cuda-bindings|cuda-pathfinder|triton==)' requirements/requirements_wsl_gpu.txt > /tmp/requirements-ci.txt
+          pip install -r /tmp/requirements-ci.txt
           pip install pytest-cov coverage
 
       - name: Run backend coverage
@@ -60,6 +62,7 @@ jobs:
             | tee ../artifacts/coverage/frontend/vitest-term.txt
 
       - name: Upload backend coverage artifacts
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: backend-coverage-artifacts
@@ -70,6 +73,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload frontend coverage artifacts
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: frontend-coverage-artifacts

--- a/.github/workflows/coverage-artifacts.yml
+++ b/.github/workflows/coverage-artifacts.yml
@@ -1,0 +1,78 @@
+name: Coverage Artifacts
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install backend dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest-cov coverage
+
+      - name: Run backend coverage
+        run: |
+          mkdir -p artifacts/coverage/backend
+          python -m pytest \
+            -m "not gpu and not db and not ml and not firebird" \
+            --ignore=tests/test_probe.py \
+            --ignore=tests/test_exifread.py \
+            --cov=modules \
+            --cov-branch \
+            --cov-report=term-missing \
+            --cov-report=xml:artifacts/coverage/backend/coverage.xml \
+            --junitxml=artifacts/coverage/backend/pytest-junit.xml \
+            | tee artifacts/coverage/backend/pytest-term.txt
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Run frontend coverage
+        run: |
+          mkdir -p artifacts/coverage/frontend
+          cd frontend
+          npx vitest run --coverage \
+            --coverage.reporter=text \
+            --coverage.reporter=json-summary \
+            --coverage.reporter=lcov \
+            --coverage.reportsDirectory=../artifacts/coverage/frontend \
+            | tee ../artifacts/coverage/frontend/vitest-term.txt
+
+      - name: Upload backend coverage artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-coverage-artifacts
+          path: |
+            artifacts/coverage/backend/pytest-junit.xml
+            artifacts/coverage/backend/pytest-term.txt
+            artifacts/coverage/backend/coverage.xml
+          if-no-files-found: error
+
+      - name: Upload frontend coverage artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-coverage-artifacts
+          path: |
+            artifacts/coverage/frontend
+          if-no-files-found: error

--- a/docs/testing/COVERAGE_BASELINE.md
+++ b/docs/testing/COVERAGE_BASELINE.md
@@ -1,0 +1,63 @@
+# Coverage Baseline
+
+**Date captured (UTC): 2026-04-11**
+
+This document records the canonical commands and baseline coverage format for both backend (pytest) and gallery/frontend (Vitest).
+
+## Canonical commands
+
+### Backend (pytest)
+
+```bash
+mkdir -p artifacts/coverage/backend
+python -m pytest \
+  -m "not gpu and not db and not ml and not firebird" \
+  --ignore=tests/test_probe.py \
+  --ignore=tests/test_exifread.py \
+  --cov=modules \
+  --cov-branch \
+  --cov-report=term-missing \
+  --cov-report=xml:artifacts/coverage/backend/coverage.xml \
+  --junitxml=artifacts/coverage/backend/pytest-junit.xml \
+  | tee artifacts/coverage/backend/pytest-term.txt
+```
+
+### Gallery/frontend (Vitest)
+
+```bash
+mkdir -p artifacts/coverage/frontend
+cd frontend
+npm ci
+npx vitest run --coverage \
+  --coverage.reporter=text \
+  --coverage.reporter=json-summary \
+  --coverage.reporter=lcov \
+  --coverage.reportsDirectory=../artifacts/coverage/frontend \
+  | tee ../artifacts/coverage/frontend/vitest-term.txt
+```
+
+## Baseline metrics
+
+### Python (pytest-cov)
+
+- **Line coverage**: _Not captured in this environment (missing `pytest-cov`/`coverage` install due network restrictions)._
+- **Branch coverage**: _Not captured in this environment (missing `pytest-cov`/`coverage` install due network restrictions)._
+
+### Vitest
+
+- **Lines**: _Not captured in this environment (`npm ci` failed due registry/network policy restrictions)._
+- **Functions**: _Not captured in this environment (`npm ci` failed due registry/network policy restrictions)._
+- **Branches**: _Not captured in this environment (`npm ci` failed due registry/network policy restrictions)._
+- **Statements**: _Not captured in this environment (`npm ci` failed due registry/network policy restrictions)._
+
+## How to refresh baseline
+
+1. Run the backend command above from the repo root.
+2. Run the frontend command above from the repo root.
+3. Copy metric values from:
+   - `artifacts/coverage/backend/pytest-term.txt` (line/branch)
+   - `artifacts/coverage/frontend/coverage-summary.json` (Vitest lines/functions/branches/statements)
+4. Update:
+   - **Date captured** in this file
+   - all baseline metric values in this file
+5. Commit the updated baseline document and artifacts-producing workflow changes together.

--- a/docs/testing/INDEX.md
+++ b/docs/testing/INDEX.md
@@ -4,6 +4,7 @@
 |----------|-------------|
 | [CROSS_APP_INTEGRATION_AUDIT.md](CROSS_APP_INTEGRATION_AUDIT.md) | Audit of shared backend/Electron integration coverage and gaps |
 | [TEST_STATUS.md](TEST_STATUS.md) | Unit test status overview |
+| [COVERAGE_BASELINE.md](COVERAGE_BASELINE.md) | Canonical backend/gallery coverage commands and baseline metrics |
 | [WSL_TESTS.md](WSL_TESTS.md) | WSL-only pytest markers |
 | [DOCUMENTATION_ISSUES.md](DOCUMENTATION_ISSUES.md) | Testing documentation issues and recommendations |
 

--- a/docs/testing/TEST_IMPROVEMENTS_PLAN.md
+++ b/docs/testing/TEST_IMPROVEMENTS_PLAN.md
@@ -198,7 +198,6 @@ low cost:
 
 ---
 
-
 ## Canonical Baseline Commands (Backend + Gallery)
 
 Use these exact commands when capturing comparable baseline coverage artifacts.

--- a/docs/testing/TEST_IMPROVEMENTS_PLAN.md
+++ b/docs/testing/TEST_IMPROVEMENTS_PLAN.md
@@ -198,6 +198,49 @@ low cost:
 
 ---
 
+
+## Canonical Baseline Commands (Backend + Gallery)
+
+Use these exact commands when capturing comparable baseline coverage artifacts.
+
+### Backend baseline (pytest)
+
+```bash
+mkdir -p artifacts/coverage/backend
+python -m pytest \
+  -m "not gpu and not db and not ml and not firebird" \
+  --ignore=tests/test_probe.py \
+  --ignore=tests/test_exifread.py \
+  --cov=modules \
+  --cov-branch \
+  --cov-report=term-missing \
+  --cov-report=xml:artifacts/coverage/backend/coverage.xml \
+  --junitxml=artifacts/coverage/backend/pytest-junit.xml \
+  | tee artifacts/coverage/backend/pytest-term.txt
+```
+
+### Gallery baseline (Vitest)
+
+```bash
+mkdir -p artifacts/coverage/frontend
+cd frontend
+npm ci
+npx vitest run --coverage \
+  --coverage.reporter=text \
+  --coverage.reporter=json-summary \
+  --coverage.reporter=lcov \
+  --coverage.reportsDirectory=../artifacts/coverage/frontend \
+  | tee ../artifacts/coverage/frontend/vitest-term.txt
+```
+
+### How to refresh baseline quickly
+
+1. Run both commands above.
+2. Update `docs/testing/COVERAGE_BASELINE.md` with the new date and metric values.
+3. Keep command lines unchanged so results stay comparable across runs.
+
+---
+
 ## Running the New Tests
 
 ```bash


### PR DESCRIPTION
### Motivation

- Provide canonical, reproducible commands and a recorded baseline for backend (pytest) and gallery (Vitest) coverage so contributors can generate comparable artifacts. 
- Ensure CI captures and stores coverage outputs as artifacts for review and regression tracking. 
- Make it easy to refresh and commit updated baseline values with an explicit short procedure.

### Description

- Added `docs/testing/COVERAGE_BASELINE.md` containing exact backend and frontend command lines, capture date (`2026-04-11`), placeholder coverage metric fields, and a short “How to refresh baseline” procedure. 
- Added canonical baseline commands and a short refresh section to `docs/testing/TEST_IMPROVEMENTS_PLAN.md` so the plan references the exact commands (includes the documented ignores `tests/test_probe.py` and `tests/test_exifread.py`). 
- Added a GitHub Actions workflow `.github/workflows/coverage-artifacts.yml` that installs dependencies, runs backend pytest coverage and frontend Vitest coverage, and uploads the resulting artifacts (`pytest-junit.xml`, `pytest-term.txt`, `coverage.xml`, and `artifacts/coverage/frontend`). 
- Updated `docs/testing/INDEX.md` to include the new `COVERAGE_BASELINE.md` entry.

### Testing

- Ran `python -m pytest --version` to confirm `pytest` is available and it succeeded (`pytest 9.0.2`).
- Attempted to run the canonical backend coverage command locally with `--cov` flags but the environment lacked `pytest-cov`, causing pytest to reject the `--cov` arguments; coverage metrics could not be captured in this environment. 
- Attempted `pip install pytest-cov coverage` and `npm ci` for the frontend, but both failed due to network/registry access restrictions in this execution environment; therefore Vitest metrics were not generated locally. 
- Added the CI workflow so the full coverage runs and artifact uploads will execute in GitHub Actions where required dependencies and network access are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dada504ba8832398830a2334467758)