### PR TITLE
Add backend smoke assertions + CI-friendly outputs to cross-app audit

### DIFF
--- a/docs/testing/CROSS_APP_INTEGRATION_AUDIT.md
+++ b/docs/testing/CROSS_APP_INTEGRATION_AUDIT.md
@@ -162,3 +162,58 @@ It currently runs:
 - Backend `pytest` checks for `test_api_queue.py` and `test_events.py`
 
 The script classifies results as `PASS`, `FAIL`, or `BLOCKED` so environment problems are separated from product failures.
+
+### Backend smoke behavior (health + submit + follow-up status assertion)
+
+`Run-CrossAppAudit.ps1` now includes a backend smoke probe that requires:
+
+- `GET /api/health` returns `status=healthy`
+- `POST /api/runs/submit` succeeds and returns a non-empty `run_id`
+- A follow-up `GET /api/jobs/{run_id}` assertion shows either:
+  - observed status progression across polls, or
+  - persisted phase rows (`phases[]`) for the submitted run
+
+This validates the minimal “backend reachable -> can enqueue work -> job state is queryable” flow.
+
+### Timeout and retry controls (anti-flake defaults)
+
+To reduce false negatives from transient startup lag/network jitter, the script uses bounded retries and polling:
+
+- `-HttpTimeoutSec` (default `10`)
+- `-RetryCount` (default `3`) for each HTTP call
+- `-RetryDelaySec` (default `2`) between retries
+- `-JobPollAttempts` (default `5`)
+- `-JobPollIntervalSec` (default `2`)
+
+Example with tuned CI values:
+
+```powershell
+.\scripts\powershell\Run-CrossAppAudit.ps1 `
+  -BackendApiBaseUrl "http://127.0.0.1:7860/api" `
+  -HttpTimeoutSec 15 `
+  -RetryCount 4 `
+  -RetryDelaySec 3 `
+  -JobPollAttempts 8 `
+  -JobPollIntervalSec 2
+```
+
+### Explicit exit codes + machine-readable summary
+
+The script now emits:
+
+- `AUDIT_SUMMARY_JSON=<compact-json>` on stdout for log scraping
+- optional JSON file via `-SummaryJsonPath <path>`
+
+Exit codes:
+
+- `0` = all **required** checks passed
+- `10` = at least one **required** check failed
+- `11` = at least one **required** check was blocked
+- `12` = unexpected script/runtime error
+
+### Non-blocking rollout plan for smoke check
+
+The backend smoke check is **non-blocking by default** (reported as `WARN` on failure).
+
+- Initial rollout: run with default behavior to collect stability metrics.
+- Promotion: once stable for an agreed burn-in period (for example 2-4 weeks of green CI), enable `-SmokeBlocking` in CI so smoke failures become required (`FAIL` with non-zero exit behavior).

--- a/scripts/powershell/Run-CrossAppAudit.ps1
+++ b/scripts/powershell/Run-CrossAppAudit.ps1
@@ -6,8 +6,21 @@
 
 param(
     [string]$BackendRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path,
-    [string]$ElectronRoot = (Join-Path (Split-Path (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path -Parent) "electron-image-scoring")
+    [string]$ElectronRoot = (Join-Path (Split-Path (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path -Parent) "electron-image-scoring"),
+    [string]$BackendApiBaseUrl = "http://127.0.0.1:7860/api",
+    [int]$HttpTimeoutSec = 10,
+    [int]$RetryCount = 3,
+    [int]$RetryDelaySec = 2,
+    [int]$JobPollAttempts = 5,
+    [int]$JobPollIntervalSec = 2,
+    [switch]$SmokeBlocking,
+    [string]$SummaryJsonPath = ""
 )
+
+$EXIT_SUCCESS = 0
+$EXIT_REQUIRED_FAILURE = 10
+$EXIT_REQUIRED_BLOCKED = 11
+$EXIT_UNEXPECTED_ERROR = 12
 
 function Add-AuditResult {
     param(
@@ -15,6 +28,7 @@ function Add-AuditResult {
         [string]$Name,
         [string]$Status,
         [int]$ExitCode,
+        [bool]$Required = $true,
         [string]$Notes = ""
     )
 
@@ -22,8 +36,95 @@ function Add-AuditResult {
         Name = $Name
         Status = $Status
         ExitCode = $ExitCode
+        Required = $Required
         Notes = $Notes
     })
+}
+
+function Invoke-WithRetry {
+    param(
+        [scriptblock]$Operation,
+        [string]$OperationName,
+        [int]$MaxAttempts = 3,
+        [int]$DelaySec = 2
+    )
+
+    $attempt = 0
+    while ($attempt -lt $MaxAttempts) {
+        $attempt += 1
+        try {
+            return & $Operation
+        } catch {
+            if ($attempt -ge $MaxAttempts) {
+                throw "[$OperationName] failed after $attempt attempts. Last error: $($_.Exception.Message)"
+            }
+            Start-Sleep -Seconds $DelaySec
+        }
+    }
+}
+
+function Invoke-BackendSmokeCheck {
+    param(
+        [string]$ApiBaseUrl,
+        [string]$RepoRoot,
+        [int]$TimeoutSec,
+        [int]$MaxRetries,
+        [int]$RetryBackoffSec,
+        [int]$PollAttempts,
+        [int]$PollIntervalSec
+    )
+
+    $runId = $null
+    $healthResponse = Invoke-WithRetry -OperationName "GET $ApiBaseUrl/health" -MaxAttempts $MaxRetries -DelaySec $RetryBackoffSec -Operation {
+        Invoke-RestMethod -Method Get -Uri "$ApiBaseUrl/health" -TimeoutSec $TimeoutSec
+    }
+    if (-not $healthResponse -or $healthResponse.status -ne "healthy") {
+        throw "Health check failed. Expected status='healthy' but got '$($healthResponse.status)'."
+    }
+
+    $smokeScope = Join-Path $RepoRoot ".tmp\cross-app-audit-smoke"
+    New-Item -ItemType Directory -Path $smokeScope -Force | Out-Null
+    $submitPayload = @{
+        scope_type = "folder"
+        scope_paths = @($smokeScope)
+        stages = @("indexing")
+        run_mode = "process_unprocessed_or_empty"
+    }
+    $submitBody = $submitPayload | ConvertTo-Json -Depth 6
+    $submitResponse = Invoke-WithRetry -OperationName "POST $ApiBaseUrl/runs/submit" -MaxAttempts $MaxRetries -DelaySec $RetryBackoffSec -Operation {
+        Invoke-RestMethod -Method Post -Uri "$ApiBaseUrl/runs/submit" -ContentType "application/json" -Body $submitBody -TimeoutSec $TimeoutSec
+    }
+    if (-not $submitResponse.success -or -not $submitResponse.run_id) {
+        throw "Run submission failed or run_id was missing. Response: $($submitResponse | ConvertTo-Json -Depth 6 -Compress)"
+    }
+    $runId = [int]$submitResponse.run_id
+
+    $observedStatuses = New-Object System.Collections.Generic.List[string]
+    $statusCheckPassed = $false
+    for ($i = 1; $i -le $PollAttempts; $i++) {
+        $job = Invoke-WithRetry -OperationName "GET $ApiBaseUrl/jobs/$runId (poll $i/$PollAttempts)" -MaxAttempts $MaxRetries -DelaySec $RetryBackoffSec -Operation {
+            Invoke-RestMethod -Method Get -Uri "$ApiBaseUrl/jobs/$runId" -TimeoutSec $TimeoutSec
+        }
+        $status = [string]($job.status)
+        if (-not [string]::IsNullOrWhiteSpace($status)) {
+            $observedStatuses.Add($status)
+        }
+        $hasPhaseData = ($job.phases -is [System.Array] -and $job.phases.Count -gt 0)
+        if ($hasPhaseData -or $observedStatuses.Count -ge 2) {
+            $statusCheckPassed = $true
+            break
+        }
+        Start-Sleep -Seconds $PollIntervalSec
+    }
+    if (-not $statusCheckPassed) {
+        throw "Follow-up status assertion failed for run_id=$runId. Observed statuses: $($observedStatuses -join ', ')."
+    }
+
+    return @{
+        run_id = $runId
+        queue_position = $submitResponse.queue_position
+        observed_statuses = @($observedStatuses)
+    }
 }
 
 function Get-BackendPytestBlocker {
@@ -50,49 +151,101 @@ if (-not (Test-Path $ElectronRoot)) {
     throw "Electron root not found: $ElectronRoot"
 }
 
-$results = New-Object System.Collections.Generic.List[object]
-
-Write-Host "Backend root:  $BackendRoot"
-Write-Host "Electron root: $ElectronRoot"
-Write-Host ""
-
-Push-Location $ElectronRoot
 try {
-    Write-Host "[RUN] node scripts/validate-api-types.mjs"
-    & node scripts/validate-api-types.mjs
-    Add-AuditResult -Results $results -Name "Electron contract validator" -Status ($(if ($LASTEXITCODE -eq 0) { "PASS" } else { "FAIL" })) -ExitCode $LASTEXITCODE
+    $results = New-Object System.Collections.Generic.List[object]
 
+    Write-Host "Backend root:  $BackendRoot"
+    Write-Host "Electron root: $ElectronRoot"
+    Write-Host "Backend API:   $BackendApiBaseUrl"
     Write-Host ""
-    Write-Host "[RUN] cmd /d /s /c `"npm run test:run -- electron/apiUrlResolver.test.ts src/services/WebSocketService.test.ts`""
-    & cmd /d /s /c "npm run test:run -- electron/apiUrlResolver.test.ts src/services/WebSocketService.test.ts"
-    Add-AuditResult -Results $results -Name "Electron resolver + WebSocket tests" -Status ($(if ($LASTEXITCODE -eq 0) { "PASS" } else { "FAIL" })) -ExitCode $LASTEXITCODE
-} finally {
-    Pop-Location
-}
 
-$backendBlocker = Get-BackendPytestBlocker -RepoRoot $BackendRoot
-if ($backendBlocker) {
-    Write-Host ""
-    Write-Host "[BLOCKED] Backend API + events pytest"
-    Write-Host $backendBlocker
-    Add-AuditResult -Results $results -Name "Backend API + events pytest" -Status "BLOCKED" -ExitCode 1 -Notes $backendBlocker
-} else {
-    Push-Location $BackendRoot
+    Push-Location $ElectronRoot
     try {
         Write-Host ""
-        Write-Host "[RUN] .\.venv\Scripts\pytest.exe tests/test_api_queue.py tests/test_events.py -q"
-        & .\.venv\Scripts\pytest.exe tests/test_api_queue.py tests/test_events.py -q
-        Add-AuditResult -Results $results -Name "Backend API + events pytest" -Status ($(if ($LASTEXITCODE -eq 0) { "PASS" } else { "FAIL" })) -ExitCode $LASTEXITCODE
+        Write-Host "[RUN] node scripts/validate-api-types.mjs"
+        & node scripts/validate-api-types.mjs
+        Add-AuditResult -Results $results -Name "Electron contract validator" -Status ($(if ($LASTEXITCODE -eq 0) { "PASS" } else { "FAIL" })) -ExitCode $LASTEXITCODE
+
+        Write-Host ""
+        Write-Host "[RUN] cmd /d /s /c `"npm run test:run -- electron/apiUrlResolver.test.ts src/services/WebSocketService.test.ts`""
+        & cmd /d /s /c "npm run test:run -- electron/apiUrlResolver.test.ts src/services/WebSocketService.test.ts"
+        Add-AuditResult -Results $results -Name "Electron resolver + WebSocket tests" -Status ($(if ($LASTEXITCODE -eq 0) { "PASS" } else { "FAIL" })) -ExitCode $LASTEXITCODE
     } finally {
         Pop-Location
     }
-}
 
-Write-Host ""
-Write-Host "Summary"
-Write-Host "-------"
-$results | Select-Object Name, Status, ExitCode, Notes | Format-Table -Wrap -AutoSize
+    $backendBlocker = Get-BackendPytestBlocker -RepoRoot $BackendRoot
+    if ($backendBlocker) {
+        Write-Host ""
+        Write-Host "[BLOCKED] Backend API + events pytest"
+        Write-Host $backendBlocker
+        Add-AuditResult -Results $results -Name "Backend API + events pytest" -Status "BLOCKED" -ExitCode 1 -Notes $backendBlocker
+    } else {
+        Push-Location $BackendRoot
+        try {
+            Write-Host ""
+            Write-Host "[RUN] .\.venv\Scripts\pytest.exe tests/test_api_queue.py tests/test_events.py -q"
+            & .\.venv\Scripts\pytest.exe tests/test_api_queue.py tests/test_events.py -q
+            Add-AuditResult -Results $results -Name "Backend API + events pytest" -Status ($(if ($LASTEXITCODE -eq 0) { "PASS" } else { "FAIL" })) -ExitCode $LASTEXITCODE
+        } finally {
+            Pop-Location
+        }
+    }
 
-if ($results.Status -contains "FAIL" -or $results.Status -contains "BLOCKED") {
-    exit 1
+    Write-Host ""
+    Write-Host "[RUN] Backend API smoke (health + submit + status progression)"
+    try {
+        $smokeInfo = Invoke-BackendSmokeCheck -ApiBaseUrl $BackendApiBaseUrl -RepoRoot $BackendRoot -TimeoutSec $HttpTimeoutSec -MaxRetries $RetryCount -RetryBackoffSec $RetryDelaySec -PollAttempts $JobPollAttempts -PollIntervalSec $JobPollIntervalSec
+        $smokeNotes = "run_id=$($smokeInfo.run_id); queue_position=$($smokeInfo.queue_position); statuses=$([string]::Join(',', $smokeInfo.observed_statuses))"
+        Add-AuditResult -Results $results -Name "Backend API smoke" -Status "PASS" -ExitCode 0 -Required $SmokeBlocking.IsPresent -Notes $smokeNotes
+    } catch {
+        $smokeStatus = if ($SmokeBlocking.IsPresent) { "FAIL" } else { "WARN" }
+        $smokeExit = if ($SmokeBlocking.IsPresent) { 1 } else { 0 }
+        Add-AuditResult -Results $results -Name "Backend API smoke" -Status $smokeStatus -ExitCode $smokeExit -Required $SmokeBlocking.IsPresent -Notes $_.Exception.Message
+    }
+
+    Write-Host ""
+    Write-Host "Summary"
+    Write-Host "-------"
+    $results | Select-Object Name, Status, ExitCode, Required, Notes | Format-Table -Wrap -AutoSize
+
+    $requiredResults = @($results | Where-Object { $_.Required })
+    $finalExitCode = $EXIT_SUCCESS
+    if ($requiredResults.Status -contains "BLOCKED") {
+        $finalExitCode = $EXIT_REQUIRED_BLOCKED
+    } elseif ($requiredResults.Status -contains "FAIL") {
+        $finalExitCode = $EXIT_REQUIRED_FAILURE
+    }
+
+    $summary = [pscustomobject]@{
+        backend_root = $BackendRoot
+        electron_root = $ElectronRoot
+        backend_api_base_url = $BackendApiBaseUrl
+        smoke_blocking = $SmokeBlocking.IsPresent
+        retry_count = $RetryCount
+        retry_delay_sec = $RetryDelaySec
+        http_timeout_sec = $HttpTimeoutSec
+        job_poll_attempts = $JobPollAttempts
+        job_poll_interval_sec = $JobPollIntervalSec
+        final_exit_code = $finalExitCode
+        generated_at_utc = (Get-Date).ToUniversalTime().ToString("o")
+        results = @($results)
+    }
+
+    $summaryJson = $summary | ConvertTo-Json -Depth 8 -Compress
+    Write-Host "AUDIT_SUMMARY_JSON=$summaryJson"
+
+    if (-not [string]::IsNullOrWhiteSpace($SummaryJsonPath)) {
+        $summaryDir = Split-Path -Parent $SummaryJsonPath
+        if ($summaryDir -and -not (Test-Path $summaryDir)) {
+            New-Item -ItemType Directory -Path $summaryDir -Force | Out-Null
+        }
+        $summary | ConvertTo-Json -Depth 8 | Set-Content -Path $SummaryJsonPath
+        Write-Host "Summary JSON written to: $SummaryJsonPath"
+    }
+
+    exit $finalExitCode
+} catch {
+    Write-Error $_
+    exit $EXIT_UNEXPECTED_ERROR
 }


### PR DESCRIPTION
### Motivation

- Add a lightweight cross-repo smoke path that validates the minimal flow: backend reachable (`/api/health`) → can enqueue work (`/api/runs/submit`) → run state is queryable (`/api/jobs/{run_id}`).
- Reduce flaky CI failures by adding bounded retries, polling, and configurable timeouts so transient startup/network issues don't cause false negatives.
- Emit machine-readable summary and explicit exit codes so CI systems can parse results and stage the gate from non-blocking to required.

### Description

- Extended `scripts/powershell/Run-CrossAppAudit.ps1` with new parameters: `-BackendApiBaseUrl`, `-HttpTimeoutSec`, `-RetryCount`, `-RetryDelaySec`, `-JobPollAttempts`, `-JobPollIntervalSec`, `-SmokeBlocking`, and `-SummaryJsonPath`.
- Added helper `Invoke-WithRetry` and `Invoke-BackendSmokeCheck` which perform: `GET /api/health` verification, `POST /api/runs/submit` and ensure a returned `run_id`, and follow-up `GET /api/jobs/{run_id}` polling to observe status progression or persisted `phases[]`.
- Added explicit exit codes (`0`, `10`, `11`, `12`), required-vs-non-required result handling, `AUDIT_SUMMARY_JSON=<compact-json>` output on stdout, and optional JSON artifact writing via `-SummaryJsonPath` for CI consumption.
- Kept the smoke check non-blocking by default (reported as `WARN` on failure) and added `-SmokeBlocking` to promote it to a required gate; documented timeout/retry defaults and rollout guidance in `docs/testing/CROSS_APP_INTEGRATION_AUDIT.md`.

### Testing

- Performed static inspection of the updated files and committed the changes successfully; the script content was exercised locally via read operations.
- Attempted to run a PowerShell syntax/parse validation (`pwsh -NoProfile -Command ...`) but the runner environment lacked `pwsh`, so runtime validation could not be executed in this environment (no runtime failures observed in the repo itself).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dada537b048323afd12925958e640f)