### PR TITLE
Fix invalid failed→running transition while persisting indexing logs

### DIFF
--- a/modules/indexing_runner.py
+++ b/modules/indexing_runner.py
@@ -193,7 +193,15 @@ class IndexingRunner:
             text = "\n".join(self.log_history)
             if len(text) > _MAX_PERSISTED_JOB_LOG_CHARS:
                 text = text[-_MAX_PERSISTED_JOB_LOG_CHARS:]
-            db.update_job_status(job_id, "running", log=text)
+            row = db.get_connector().query_one("SELECT status FROM jobs WHERE id = ?", (job_id,))
+            current_status = (row.get("status") or "").strip().lower() if row else ""
+
+            # Keep writing logs for terminal jobs (post-failure cleanup/progress messages)
+            # without attempting an invalid terminal -> running state transition.
+            if current_status == "running":
+                db.update_job_status(job_id, "running", log=text)
+            elif row:
+                db.get_connector().execute("UPDATE jobs SET log = ? WHERE id = ?", (text, job_id))
         except Exception:
             logger.exception("IndexingRunner: failed to persist log to jobs row (job_id=%s)", job_id)
 


### PR DESCRIPTION
## Summary
- prevent `IndexingRunner._persist_log_to_job_row` from always forcing `jobs.status='running'`
- read current job status before persisting log text
- keep existing behavior for active running jobs (`update_job_status(..., "running", log=...)`)
- for non-running existing jobs, update only `jobs.log` directly to avoid invalid terminal->running transitions

## Why
The logs showed repeated exceptions:
- `ValueError: Invalid job status transition: failed -> running (job_id=...)`

This happened because periodic log persistence attempted a status transition even after the job had already moved to a terminal state.

## Impact
- stops noisy error spam from indexing log persistence
- preserves post-failure log updates without mutating terminal job status
- no behavior change for actively running jobs

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e04c0db5308323a48b364ceb605e3e)