### PR TITLE
Keep root pipeline job_type stable when advancing multi-phase jobs

### DIFF
--- a/modules/db.py
+++ b/modules/db.py
@@ -4229,6 +4229,7 @@ def update_job_status(job_id, status, log=None, current_phase=None, next_phase_i
 
         old_status = (row["status"] or "pending").strip().lower()
         new_status = effect_status
+        root_job_type = row.get("job_type")
 
         allowed_next = JOB_ALLOWED_TRANSITIONS.get(old_status)
         if allowed_next is not None and old_status != new_status and new_status not in allowed_next:
@@ -4297,22 +4298,21 @@ def update_job_status(job_id, status, log=None, current_phase=None, next_phase_i
                 if active:
                     pc = active.get("phase_code")
                     po = int(active.get("phase_order") or 0)
-                    jt = job_type_for_phase_dispatch(pc)
                     pid = get_phase_id(pc)
                     tx.execute(
                         "UPDATE jobs SET status = 'running', finished_at = NULL, completed_at = NULL, "
                         "log = ?, current_phase = ?, next_phase_index = ?, runner_state = 'running', "
-                        "job_type = ?, phase_id = ? WHERE id = ?",
-                        (eff_log, pc, po, jt, pid, job_id),
+                        "phase_id = COALESCE(?, phase_id) WHERE id = ?",
+                        (eff_log, pc, po, pid, job_id),
                     )
-                    return old_status, "running", pc, po, "running", jt
+                    return old_status, "running", pc, po, "running", root_job_type
 
             final_rs = runner_state if runner_state is not None else "completed"
             tx.execute(
                 "UPDATE jobs SET status = ?, finished_at = ?, completed_at = ?, log = ?, current_phase = ?, next_phase_index = ?, runner_state = ? WHERE id = ?",
                 ("completed", now, now, eff_log, final_phase, final_next_idx, final_rs, job_id),
             )
-            return old_status, "completed", final_phase, final_next_idx, final_rs, row.get("job_type")
+            return old_status, "completed", final_phase, final_next_idx, final_rs, root_job_type
 
         if new_status == "running":
             tx.execute(
@@ -4368,9 +4368,7 @@ def update_job_status(job_id, status, log=None, current_phase=None, next_phase_i
         except Exception as e:
             logger.debug("update_job_status: failed to sync job_phases for job %s: %s", job_id, e)
 
-        job_row_after = tx.query_one("SELECT job_type FROM jobs WHERE id = ?", (job_id,))
-        jt_after = job_row_after.get("job_type") if job_row_after else None
-        return old_status, new_status, final_phase, final_next_idx, final_runner_state, jt_after
+        return old_status, new_status, final_phase, final_next_idx, final_runner_state, root_job_type
 
     old_status, broadcast_status, final_phase, final_next_idx, final_runner_state, job_type_after = get_connector().run_transaction(_tx)
 

--- a/tests/test_multi_phase_job_postgres.py
+++ b/tests/test_multi_phase_job_postgres.py
@@ -28,7 +28,7 @@ def test_update_job_status_completed_advances_phases_without_terminal_job():
     jid = db.create_job(
         "/mp/pg-scope",
         phase_code="indexing",
-        job_type="indexing",
+        job_type="pipeline",
         status="running",
         runner_state="running",
     )
@@ -37,7 +37,7 @@ def test_update_job_status_completed_advances_phases_without_terminal_job():
 
     row = db.get_job(jid)
     assert (row["status"] or "").lower() == "running"
-    assert (row["job_type"] or "").lower() == "metadata"
+    assert (row["job_type"] or "").lower() == "pipeline"
     assert row.get("finished_at") is None
     assert row.get("completed_at") is None
     assert (row.get("current_phase") or "").lower() == "metadata"
@@ -84,7 +84,7 @@ def test_dispatcher_starts_second_phase_after_first_completes():
     jid, _ = db.enqueue_job(
         "D:/mp-pg-chain/1",
         phase_code="indexing",
-        job_type="indexing",
+        job_type="pipeline",
         queue_payload={"input_path": "D:/mp-pg-chain/1"},
     )
     db.create_job_phases(jid, ["indexing", "metadata"], first_phase_state="queued")
@@ -93,11 +93,13 @@ def test_dispatcher_starts_second_phase_after_first_completes():
     while time.time() < deadline:
         d.tick_for_tests()
         j = db.get_job(jid)
-        if (j.get("job_type") or "").lower() == "metadata" and fake_meta.is_running:
+        if (j.get("current_phase") or "").lower() == "metadata" and fake_meta.is_running:
             break
         time.sleep(0.02)
 
-    assert (db.get_job(jid).get("job_type") or "").lower() == "metadata"
+    row = db.get_job(jid)
+    assert (row.get("job_type") or "").lower() == "pipeline"
+    assert (row.get("current_phase") or "").lower() == "metadata"
     assert fake_meta.is_running
 
     while time.time() < deadline:

--- a/tests/test_multi_phase_job_workflow.py
+++ b/tests/test_multi_phase_job_workflow.py
@@ -56,7 +56,7 @@ def test_update_job_status_completed_advances_phases_without_terminal_job(mp_db)
     jid = db.create_job(
         "/mp/scope",
         phase_code="indexing",
-        job_type="indexing",
+        job_type="pipeline",
         status="running",
         runner_state="running",
     )
@@ -65,7 +65,7 @@ def test_update_job_status_completed_advances_phases_without_terminal_job(mp_db)
 
     row = db.get_job(jid)
     assert (row["status"] or "").lower() == "running"
-    assert (row["job_type"] or "").lower() == "metadata"
+    assert (row["job_type"] or "").lower() == "pipeline"
     assert row.get("finished_at") is None
     assert row.get("completed_at") is None
     assert (row.get("current_phase") or "").lower() == "metadata"
@@ -114,7 +114,7 @@ def test_dispatcher_starts_second_phase_after_first_completes(mp_db):
     jid, _ = db.enqueue_job(
         "D:/mp-chain/1",
         phase_code="indexing",
-        job_type="indexing",
+        job_type="pipeline",
         queue_payload={"input_path": "D:/mp-chain/1"},
     )
     db.create_job_phases(jid, ["indexing", "metadata"], first_phase_state="queued")
@@ -123,11 +123,13 @@ def test_dispatcher_starts_second_phase_after_first_completes(mp_db):
     while time.time() < deadline:
         d.tick_for_tests()
         j = db.get_job(jid)
-        if (j.get("job_type") or "").lower() == "metadata" and fake_meta.is_running:
+        if (j.get("current_phase") or "").lower() == "metadata" and fake_meta.is_running:
             break
         time.sleep(0.02)
 
-    assert (db.get_job(jid).get("job_type") or "").lower() == "metadata"
+    row = db.get_job(jid)
+    assert (row.get("job_type") or "").lower() == "pipeline"
+    assert (row.get("current_phase") or "").lower() == "metadata"
     assert fake_meta.is_running
 
     while time.time() < deadline:


### PR DESCRIPTION
### Motivation
- Multi-phase jobs were mutating the `jobs.job_type` to a phase-mapped value when a phase completed, which obscures the root job type (e.g. `pipeline`) used for UI/context and telemetry.
- The intent is to advance the execution cursor (`current_phase`, `next_phase_index`, `phase_id`) for the next phase without losing the original root `jobs.job_type`.

### Description
- Capture the root job type once at transaction start by reading `job_type` from the initial `SELECT` into `root_job_type` and use it for transaction return/broadcast values.
- In the multi-phase handoff path (`new_status == "completed" and n_phases > 1`), stop writing a phase-mapped `job_type` back into the `jobs` row and instead only update `status`, `current_phase`, `next_phase_index`, `runner_state`, and `phase_id` for context (using `COALESCE` to avoid clobbering an unresolved `phase_id`).
- Ensure all return values from the transaction (normal and multi-phase handoff) report the stable `root_job_type` so downstream broadcasting/telemetry uses the root job type.
- Adjusted unit tests in `tests/test_multi_phase_job_postgres.py` and `tests/test_multi_phase_job_workflow.py` to assert that after phase advancement `jobs.job_type` remains `pipeline` while `current_phase` reflects the active phase (e.g. `metadata`).

### Testing
- Ran `python -m compileall modules/db.py tests/test_multi_phase_job_postgres.py tests/test_multi_phase_job_workflow.py`, which succeeded.
- Attempted `pytest -q tests/test_multi_phase_job_postgres.py -k "advances_phases_without_terminal_job or dispatcher_starts_second_phase_after_first_completes"`, which errored at collection due to missing environment dependencies (`pydantic`) in the test environment and lack of the project virtualenv; no runtime DB tests were executed in CI here.
- Updated multi-phase tests (Postgres & Firebird fixtures) to validate that `jobs.job_type` remains `pipeline` after advancement and that `current_phase`/phase rows progress; these tests were committed but could not be executed in this environment due to missing test dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e04bab2a8c8323810d0aa64e46b44f)