### PR TITLE
Persist indexing logs without forcing job status to "running"

### DIFF
--- a/modules/db.py
+++ b/modules/db.py
@@ -4180,6 +4180,17 @@ def update_job_progress(job_id, percent):
         logger.debug("update_job_progress: broadcast failed for job_id=%s", job_id, exc_info=True)
 
 
+def update_job_log(job_id, log):
+    """Update ``jobs.log`` only, preserving the current job status/state-machine invariants."""
+    def _tx(tx):
+        row = tx.query_one("SELECT id FROM jobs WHERE id = ?", (job_id,))
+        if not row:
+            raise ValueError(f"Job not found: {job_id}")
+        tx.execute("UPDATE jobs SET log = ? WHERE id = ?", (log, job_id))
+
+    get_connector().run_transaction(_tx)
+
+
 def job_type_for_phase_dispatch(phase_code: str) -> str:
     """Map ``job_phases.phase_code`` to ``jobs.job_type`` for JobDispatcher routing."""
     pc = (phase_code or "").strip().lower()

--- a/modules/indexing_runner.py
+++ b/modules/indexing_runner.py
@@ -193,21 +193,7 @@ class IndexingRunner:
             text = "\n".join(self.log_history)
             if len(text) > _MAX_PERSISTED_JOB_LOG_CHARS:
                 text = text[-_MAX_PERSISTED_JOB_LOG_CHARS:]
-            if hasattr(db, "update_job_log"):
-                db.update_job_log(job_id, text)
-                return
-
-            # Back-compat fallback: avoid forcing ``running`` on terminal jobs.
-            job_row = db.get_job(job_id)
-            status = (job_row.get("status") or "").strip().lower() if job_row else ""
-            if status in db.JOB_TERMINAL_STATES:
-                db.get_connector().execute(
-                    "UPDATE jobs SET log = ? WHERE id = ?",
-                    (text, job_id),
-                )
-                return
-
-            db.update_job_status(job_id, "running", log=text)
+            db.update_job_log(job_id, text)
         except Exception:
             logger.exception("IndexingRunner: failed to persist log to jobs row (job_id=%s)", job_id)
 

--- a/modules/indexing_runner.py
+++ b/modules/indexing_runner.py
@@ -193,7 +193,19 @@ class IndexingRunner:
             text = "\n".join(self.log_history)
             if len(text) > _MAX_PERSISTED_JOB_LOG_CHARS:
                 text = text[-_MAX_PERSISTED_JOB_LOG_CHARS:]
-            db.update_job_log(job_id, text)
+            if hasattr(db, "update_job_log"):
+                db.update_job_log(job_id, text)
+                return
+
+            row = db.get_connector().query_one("SELECT status FROM jobs WHERE id = ?", (job_id,))
+            current_status = (row.get("status") or "").strip().lower() if row else ""
+
+            # Keep writing logs for terminal/paused/etc jobs (post-failure cleanup/progress messages)
+            # without attempting an invalid terminal -> running state transition.
+            if current_status == "running":
+                db.update_job_status(job_id, "running", log=text)
+            else:
+                db.get_connector().execute("UPDATE jobs SET log = ? WHERE id = ?", (text, job_id))
         except Exception:
             logger.exception("IndexingRunner: failed to persist log to jobs row (job_id=%s)", job_id)
 

--- a/modules/indexing_runner.py
+++ b/modules/indexing_runner.py
@@ -193,7 +193,21 @@ class IndexingRunner:
             text = "\n".join(self.log_history)
             if len(text) > _MAX_PERSISTED_JOB_LOG_CHARS:
                 text = text[-_MAX_PERSISTED_JOB_LOG_CHARS:]
-            db.update_job_log(job_id, text)
+            if hasattr(db, "update_job_log"):
+                db.update_job_log(job_id, text)
+                return
+
+            # Back-compat fallback: avoid forcing ``running`` on terminal jobs.
+            job_row = db.get_job(job_id)
+            status = (job_row.get("status") or "").strip().lower() if job_row else ""
+            if status in db.JOB_TERMINAL_STATES:
+                db.get_connector().execute(
+                    "UPDATE jobs SET log = ? WHERE id = ?",
+                    (text, job_id),
+                )
+                return
+
+            db.update_job_status(job_id, "running", log=text)
         except Exception:
             logger.exception("IndexingRunner: failed to persist log to jobs row (job_id=%s)", job_id)
 

--- a/modules/indexing_runner.py
+++ b/modules/indexing_runner.py
@@ -186,14 +186,14 @@ class IndexingRunner:
         self.total_count = 0
 
     def _persist_log_to_job_row(self, job_id: Optional[int]) -> None:
-        """Append in-memory log to ``jobs.log`` while status stays ``running`` (Web UI polling + LogPanel)."""
+        """Persist in-memory log to ``jobs.log`` without mutating ``jobs.status``."""
         if not job_id:
             return
         try:
             text = "\n".join(self.log_history)
             if len(text) > _MAX_PERSISTED_JOB_LOG_CHARS:
                 text = text[-_MAX_PERSISTED_JOB_LOG_CHARS:]
-            db.update_job_status(job_id, "running", log=text)
+            db.update_job_log(job_id, text)
         except Exception:
             logger.exception("IndexingRunner: failed to persist log to jobs row (job_id=%s)", job_id)
 


### PR DESCRIPTION
### Motivation
- `_persist_log_to_job_row` repeatedly called `update_job_status(..., "running", ...)` while streaming logs, which could inadvertently cause invalid state transitions when a job was already terminal.
- The goal is to persist logs for indexing heartbeats without mutating the job state-machine or loosening transition validation in `update_job_status`.

### Description
- Added a new DB helper `update_job_log(job_id, log)` in `modules/db.py` that updates only the `jobs.log` column inside a transaction and validates the job exists via a `SELECT` before updating.
- Replaced the call in `IndexingRunner._persist_log_to_job_row` to use `db.update_job_log(job_id, text)` instead of `db.update_job_status(job_id, "running", log=text)` in `modules/indexing_runner.py`.
- Left `update_job_status` and the job transition invariants unchanged so the state machine remains strict.

### Testing
- Compiled the modified modules with `python -m compileall modules/indexing_runner.py modules/db.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e04c2b7e9c832398aa9f42e6fbd892)