### PR TITLE
Handle audit job creation failures in status recalculation endpoint

### DIFF
--- a/modules/api.py
+++ b/modules/api.py
@@ -6456,6 +6456,13 @@ def create_api_router() -> APIRouter:
                 db.set_job_phase_state(audit_run_id, "maintenance", "completed")
         except Exception as audit_err:
             logger.warning("recalculate_status_from_data: audit job row skipped: %s", audit_err)
+            summary.setdefault("warnings", []).append(
+                {
+                    "type": "audit_row_skipped",
+                    "message": "Audit job row creation failed; main recalculation completed successfully.",
+                    "details": str(audit_err),
+                }
+            )
 
         return ApiResponse(
             success=True,


### PR DESCRIPTION
### Motivation
- Ensure `maintenance_recalculate_status_from_data` does not fail the main recalculation when creating the audit `jobs` row fails and that the response returns `audit_run_id: null` while surfacing a warning.

### Description
- Initialize `audit_run_id` to `None` before the audit `try` block and, on exception, append a warning object to `summary['warnings']` instead of raising, while keeping follow-up audit writes guarded by `if audit_run_id:`.

### Testing
- Ran `python -m py_compile modules/api.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e04c2a52dc8323ad24ad5987345064)