### PR TITLE
docs: add merge-conflict recovery steps to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,29 @@ The tool uses a **triple fallback mechanism** for maximum reliability:
 - **Database locked**: Ensure only one instance is running
 - **Missing scores**: Check logs in WebUI or `logs/` directory
 
+### Git / Merge Issues
+
+1. **`git pull` reports conflicts (e.g., `modules/api.py`, `modules/db.py`)**:
+   ```bash
+   # 1) Confirm conflicted files
+   git status
+
+   # 2) Open each conflicted file and resolve blocks between:
+   # <<<<<<< HEAD
+   # =======
+   # >>>>>>> <incoming-branch>
+
+   # 3) Mark each file as resolved
+   git add modules/api.py modules/db.py modules/metadata_runner.py
+
+   # 4) Complete the merge
+   git commit
+   ```
+   - In VS Code, you can use **Accept Current / Accept Incoming / Accept Both** for each hunk.
+   - Re-run `git status` after editing; it should no longer show **unmerged paths**.
+   - If you want to discard the merge attempt and start over: `git merge --abort`.
+   - Before pushing, validate with `git pull --rebase` (or your team’s preferred pull strategy) to reduce future conflicts.
+
 📖 **See also:** [Project Review](docs/reports/project-reviews/PROJECT_REVIEW_DETAILED_2026-01-31.md) | [Test Status](docs/testing/TEST_STATUS.md)
 
 ---


### PR DESCRIPTION
### Motivation
- Provide quick, actionable troubleshooting for `git pull` merge conflicts (e.g., `modules/api.py`, `modules/db.py`) so contributors can recover from automatic merge failures.

### Description
- Add a new "Git / Merge Issues" subsection to `README.md` that documents a step-by-step flow (`git status` → resolve `<<<<<<<` / `=======` / `>>>>>>>` → `git add` → `git commit`) and includes VS Code tips, `git merge --abort`, and a recommendation to use `git pull --rebase` to reduce future conflicts.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e04e4880b08323b5b4d388ae18dd75)