### PR TITLE
Use canonical package import for MultiModelMUSIQ in modules/scoring.py

### DIFF
--- a/modules/scoring.py
+++ b/modules/scoring.py
@@ -4,8 +4,6 @@ import json
 import logging
 from modules import db, thumbnails
 from modules.engine import BatchImageProcessor
-import sys
-from pathlib import Path
 from modules import pipeline
 from modules.events import event_manager
 from modules.run_log import runner_emit
@@ -13,15 +11,10 @@ from modules import score_normalization as snorm
 from modules.phases import PhaseCode, normalize_phase_codes
 from modules.indexing_policy import passes_nikon_nef_policy
 
-# Ensure paths are set up to import scripts
-project_root = Path(__file__).resolve().parent.parent
-if str(project_root / "scripts" / "python") not in sys.path:
-    sys.path.insert(0, str(project_root / "scripts" / "python"))
-
 logger = logging.getLogger(__name__)
 
 try:
-    from run_all_musiq_models import MultiModelMUSIQ
+    from scripts.python.run_all_musiq_models import MultiModelMUSIQ
     try:
         from modules.engines.base import IScoringEngine
 
@@ -680,8 +673,7 @@ class ScoringRunner:
         # Initialize models if needed
         if self.shared_scorer is None:
             try:
-                # Use local import if needed or assume globally imported
-                # from run_all_musiq_models import MultiModelMUSIQ
+                # MultiModelMUSIQ is imported via canonical package path at module import time.
                 new_scorer = MultiModelMUSIQ()
                 for m in ['spaq', 'ava']:
                     new_scorer.load_model(m)


### PR DESCRIPTION
### Motivation
- Remove environment-dependent `sys.path` mutation and prefer canonical package imports to make runtime imports predictable and robust.
- Align `modules/scoring.py` with existing runtime modules (for example `modules/pipeline.py`) that already use the package-qualified `scripts.python.run_all_musiq_models` path.
- Reduce ad-hoc path hacks in backend runtime code so production/service processes do not rely on implicit CWD-based resolution.

### Description
- Replaced the bare `run_all_musiq_models` import with the package-qualified import `from scripts.python.run_all_musiq_models import MultiModelMUSIQ` in `modules/scoring.py`.
- Removed the `sys.path` prepend block that injected `scripts/python` into `sys.path` from `modules/scoring.py`.
- Updated the inline comment in `run_single_image` to note that `MultiModelMUSIQ` is imported at module import time via the canonical package path.
- Kept the existing fallback dummy `MultiModelMUSIQ` stub when the import fails so startup/version-info checks remain safe.

### Testing
- Verified there are no remaining bare `from run_all_musiq_models import` occurrences in `modules/` by running a repository search with `rg` and confirming `modules/scoring.py` now uses `scripts.python.run_all_musiq_models`.
- Performed a syntax check with `python -m py_compile modules/scoring.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e062b516a08323b9e85e5b928227fb)