### PR TITLE
Handle MultiModelMUSIQ import failures in scoring runner flows

### DIFF
--- a/modules/scoring.py
+++ b/modules/scoring.py
@@ -20,6 +20,7 @@ if str(project_root / "scripts" / "python") not in sys.path:
 
 logger = logging.getLogger(__name__)
 
+_musiq_import_error = None
 try:
     from run_all_musiq_models import MultiModelMUSIQ
     try:
@@ -28,11 +29,9 @@ try:
         IScoringEngine.register(MultiModelMUSIQ)
     except Exception:
         pass
-except ImportError:
-    print("Warning: Could not import MultiModelMUSIQ for version info")
-
-    class MultiModelMUSIQ:
-        VERSION = "0.0.0"
+except ImportError as exc:
+    _musiq_import_error = exc
+    MultiModelMUSIQ = None
 
 class ScoringRunner:
     """
@@ -132,6 +131,17 @@ class ScoringRunner:
         if not target_phases:
              target_phases = [PhaseCode.SCORING]
         normalized_target_phases = normalize_phase_codes(target_phases)
+
+        if _musiq_import_error is not None:
+            msg = f"Failed to import MultiModelMUSIQ: {_musiq_import_error}"
+            log(msg, "ERROR")
+            self.status_message = "Error loading models"
+            db.update_job_status(job_id, "failed", msg)
+            event_manager.broadcast_threadsafe(
+                "job_completed",
+                {"job_id": job_id, "status": "failed", "error": msg},
+            )
+            return
         
         # Checking/Loading Models (skip when a scorer was injected via constructor)
         if self.shared_scorer is None:
@@ -421,6 +431,17 @@ class ScoringRunner:
         
         def log(msg):
             self.log_history.append(msg)
+
+        if _musiq_import_error is not None:
+            msg = f"Failed to import MultiModelMUSIQ: {_musiq_import_error}"
+            log(msg)
+            self.status_message = "Error loading models"
+            db.update_job_status(job_id, "failed", msg)
+            event_manager.broadcast_threadsafe(
+                "job_completed",
+                {"job_id": job_id, "status": "failed", "error": msg},
+            )
+            return
             
         records = db.get_incomplete_records()
         if not records:


### PR DESCRIPTION
### Motivation

- Prevent a silent/dubious dummy `MultiModelMUSIQ` fallback that can mask actionable dependency/import issues during runs.
- Ensure import failures are surfaced clearly to job logs and the UI so operators can diagnose missing dependencies quickly.

### Description

- Capture the original `ImportError` when importing `run_all_musiq_models.MultiModelMUSIQ` in a module-level variable ` _musiq_import_error`, and set `MultiModelMUSIQ` to `None` instead of defining a dummy class.
- Add a pre-flight check in `ScoringRunner._run_batch_internal()` that, when `_musiq_import_error` is set, logs an explicit error containing the original exception text, sets job status to failed with the message, broadcasts a failed `job_completed` event, and returns early.
- Add the same pre-flight import check in `ScoringRunner._fix_db_internal()` so fix-db jobs also fail fast with the original import error surfaced in run logs and job state.
- Keep existing behavior for normal operation when import succeeds and continue to initialize and load models via `MultiModelMUSIQ` as before.

### Testing

- Ran `python -m compileall modules/scoring.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e062b1f5b483239054d042b7837ad3)