### PR TITLE
Add unresolved conflict marker repository check

### DIFF
--- a/.github/workflows/conflict-marker-check.yml
+++ b/.github/workflows/conflict-marker-check.yml
@@ -1,0 +1,15 @@
+name: Conflict Marker Check
+
+on:
+  pull_request:
+  merge_group:
+
+jobs:
+  conflict-markers:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check for unresolved merge markers
+        run: scripts/check_conflict_markers.sh

--- a/modules/api.py
+++ b/modules/api.py
@@ -6153,9 +6153,6 @@ def create_api_router() -> APIRouter:
                 dry_run=request.dry_run,
                 budget=request.budget,
                 run_mode=request.run_mode,
-<<<<<<< HEAD
-=======
-                dry_run=request.dry_run,
                 heal_thumbnails_global=request.heal_thumbnails_global,
             )
         except Exception as e:
@@ -6466,10 +6463,7 @@ def create_api_router() -> APIRouter:
                 status="completed",
                 queue_payload={**audit_payload, "summary": summary},
                 description=audit_desc,
->>>>>>> c6b6c5100acf4bc2d60ae3f82343055f1784c56a
             )
-            
-            n_resets = data.get("resets_performed", 0)
             if audit_run_id:
                 now = datetime.now()
                 log_text = json.dumps({"summary": summary}, default=str)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -59,3 +59,16 @@ python scripts/path/to/script.py
 | `validate-api-types.mjs` | Regenerate and fail with diff + regeneration command if `electron/apiTypes.ts` is stale. |
 
 Use `npm run api:types:generate` (local + CI standard) and `npm run api:types:check` for validation.
+
+## Repository Safety Checks
+
+| Script | Purpose |
+|--------|---------|
+| `check_conflict_markers.sh` | Fails if unresolved merge markers (`<<<<<<<`, `=======`, `>>>>>>>`) are present in tracked source files under `modules/`, `tests/`, or `scripts/`. |
+
+Run locally:
+
+```bash
+scripts/check_conflict_markers.sh
+```
+

--- a/scripts/check_conflict_markers.sh
+++ b/scripts/check_conflict_markers.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fail the check if unresolved merge conflict markers exist in tracked source files.
+# We intentionally scope this to code-heavy directories and source-like extensions,
+# excluding markdown/docs where divider lines like "=======" are legitimate.
+
+TARGET_DIRS=(modules tests scripts)
+PATTERN='^(<<<<<<< .*$|=======$|>>>>>>> .*$)'
+
+SOURCE_EXT_REGEX='\.(py|sh|bash|zsh|mjs|cjs|js|jsx|ts|tsx|ps1|bat|cmd|sql|toml|ini|cfg|conf|ya?ml)$'
+
+mapfile -t tracked_files < <(git ls-files -- "${TARGET_DIRS[@]}")
+
+scan_files=()
+for file in "${tracked_files[@]}"; do
+  if [[ "$file" =~ $SOURCE_EXT_REGEX ]]; then
+    scan_files+=("$file")
+  fi
+done
+
+if [[ ${#scan_files[@]} -eq 0 ]]; then
+  echo "No tracked source files matched configured directories/extensions."
+  exit 0
+fi
+
+if matches=$(rg --line-number --no-heading --color=never "$PATTERN" "${scan_files[@]}" 2>/dev/null); then
+  if [[ -n "$matches" ]]; then
+    echo "Unresolved conflict markers detected:"
+    echo "$matches"
+    exit 1
+  fi
+fi
+
+echo "No unresolved conflict markers found in tracked source files."


### PR DESCRIPTION
### Motivation
- Prevent accidental merge conflicts shipping by failing CI when unresolved merge markers (`<<<<<<<`, `=======`, `>>>>>>>`) exist in tracked source files.
- Keep the check lightweight and avoid false positives in documentation by scoping to code-like files and key source directories.

### Description
- Add `scripts/check_conflict_markers.sh`, which enumerates tracked files under `modules/`, `tests/`, and `scripts/`, filters by a source extension regex, and scans with `rg` for `<<<<<<< ...`, `======='`, or `>>>>>>> ...`, returning non-zero on true matches.
- Add a GitHub Actions workflow `.github/workflows/conflict-marker-check.yml` that runs the script on `pull_request` and `merge_group` events.
- Document the new check in `scripts/README.md` under a `Repository Safety Checks` section with the local invocation `scripts/check_conflict_markers.sh`.
- Remove pre-existing unresolved conflict markers in `modules/api.py` so the repository check passes on the current tree.

### Testing
- Ran `scripts/check_conflict_markers.sh` locally: it initially reported markers, changes were applied, and the script then reported no unresolved markers (exit 0).
- Verified Python syntax on the modified file with `python -m py_compile modules/api.py`, which succeeded (exit 0).
- The added CI workflow runs the same script on PRs and merge groups (manual verification via workflow file present).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0653f0fac8323bb0329017a24ef71)