### PR TITLE
Fix merge artifacts in maintenance API handlers

### DIFF
--- a/modules/api.py
+++ b/modules/api.py
@@ -6153,10 +6153,6 @@ def create_api_router() -> APIRouter:
                 dry_run=request.dry_run,
                 budget=request.budget,
                 run_mode=request.run_mode,
-<<<<<<< HEAD
-=======
-                dry_run=request.dry_run,
-                heal_thumbnails_global=request.heal_thumbnails_global,
             )
         except Exception as e:
             raise HTTPException(status_code=500, detail=str(e)) from e
@@ -6466,10 +6462,7 @@ def create_api_router() -> APIRouter:
                 status="completed",
                 queue_payload={**audit_payload, "summary": summary},
                 description=audit_desc,
->>>>>>> c6b6c5100acf4bc2d60ae3f82343055f1784c56a
             )
-            
-            n_resets = data.get("resets_performed", 0)
             if audit_run_id:
                 now = datetime.now()
                 log_text = json.dumps({"summary": summary}, default=str)


### PR DESCRIPTION
### Motivation
- Remove unresolved merge markers that caused a function body to be split and statements to leak between two maintenance endpoints in `modules/api.py`.

### Description
- Removed conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) and restored clear function boundaries for `maintenance_heal_phase` and `maintenance_recalculate_status_from_data`.
- Reconstructed `maintenance_heal_phase` so it calls `workflow_healing.heal_phase_data(...)` exactly once with a single, non-duplicated `dry_run` argument list.
- Removed a leaked statement (`n_resets = data.get(...)`) that had migrated into the recalculation handler so each route has its own independent body and return.

### Testing
- Ran syntax-only validation with `python -m py_compile modules/api.py`, which passed.
- Attempted import check `python -c "from modules import api, api_db; print('import_ok')"`, which failed in this environment due to missing runtime dependency `fastapi` (environment issue, not a syntax error).
- Attempted to start the app with `python webui.py`, which failed in this environment due to missing `gradio` (environment issue, not related to the patched file).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e06574bdd4832396f80f5145ad6200)