### PR TITLE
Add conflict marker guard script and CI workflow

### DIFF
--- a/.github/workflows/conflict-marker-check.yml
+++ b/.github/workflows/conflict-marker-check.yml
@@ -1,0 +1,25 @@
+name: Conflict marker check
+
+on:
+  pull_request:
+    paths:
+      - 'modules/**'
+      - 'tests/**'
+      - 'scripts/**'
+      - '.github/workflows/conflict-marker-check.yml'
+  merge_group:
+    paths:
+      - 'modules/**'
+      - 'tests/**'
+      - 'scripts/**'
+      - '.github/workflows/conflict-marker-check.yml'
+
+jobs:
+  conflict-markers:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check for unresolved merge conflict markers
+        run: scripts/check_conflict_markers.sh

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -51,6 +51,16 @@ python scripts/path/to/script.py
 | `research_models.py` | Research NEF→model input parameters |
 
 
+## Repository Safety Check
+
+Run the unresolved conflict marker check locally before pushing:
+
+```bash
+scripts/check_conflict_markers.sh
+```
+
+The script scans tracked source files under `modules/`, `tests/`, and `scripts/`, and fails if it finds unresolved merge markers (`<<<<<<<`, `=======`, `>>>>>>>`).
+
 ## API Contract Scripts
 
 | Script | Purpose |

--- a/scripts/check_conflict_markers.sh
+++ b/scripts/check_conflict_markers.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Scan tracked source files for unresolved merge conflict markers.
+# Intentionally limited to source-like extensions under modules/, tests/, scripts/
+# to avoid false positives in documentation divider content.
+
+ROOTS=(modules tests scripts)
+
+is_source_file() {
+  case "$1" in
+    *.py|*.sh|*.bash|*.zsh|*.ps1|*.bat|*.cmd|*.yml|*.yaml|*.json|*.toml|*.ini|*.cfg|*.sql|*.js|*.jsx|*.ts|*.tsx)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+tracked_files=()
+for root in "${ROOTS[@]}"; do
+  while IFS= read -r -d '' file; do
+    if is_source_file "$file"; then
+      tracked_files+=("$file")
+    fi
+  done < <(git ls-files -z -- "$root")
+done
+
+if [ ${#tracked_files[@]} -eq 0 ]; then
+  echo "No tracked source files found in ${ROOTS[*]}; skipping conflict marker check."
+  exit 0
+fi
+
+pattern='^(<<<<<<<|>>>>>>>|={7}$)'
+
+if rg --line-number --with-filename --color=never -e "$pattern" -- "${tracked_files[@]}"; then
+  echo
+  echo "❌ Unresolved merge conflict markers detected."
+  exit 1
+fi
+
+echo "✅ No unresolved merge conflict markers found in tracked source files."


### PR DESCRIPTION
### Motivation
- Prevent merged code from containing unresolved Git conflict markers that can break builds or tests.
- Provide a lightweight, fast check contributors can run locally and integrate into CI to catch issues early.

### Description
- Add `scripts/check_conflict_markers.sh`, which scans tracked source files under `modules/`, `tests/`, and `scripts/` using `git ls-files` + `rg` and returns non-zero when exact conflict markers are found (`<<<<<<<`, `=======` as 7 `=` characters, `>>>>>>>`).
- Restrict the scan to common source file extensions to avoid false positives from documentation dividers and non-source files.
- Add `.github/workflows/conflict-marker-check.yml` to run the check on `pull_request` and `merge_group` events when `modules/**`, `tests/**`, or `scripts/**` change.
- Document the check in `scripts/README.md` with the command `scripts/check_conflict_markers.sh` for local usage.

### Testing
- Ran `bash -n scripts/check_conflict_markers.sh` to validate shell syntax; it succeeded.
- Ran `scripts/check_conflict_markers.sh` which exited non-zero as expected because it detected existing unresolved markers in `modules/api.py`, demonstrating the check successfully detects real issues.
- Files added and made executable: `scripts/check_conflict_markers.sh` and `.github/workflows/conflict-marker-check.yml`, and documentation updated in `scripts/README.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e06574c6e88323bf3d0d92cd50f09f)