### PR TITLE
Make PostgreSQL pytest setup explicit opt-in

### DIFF
--- a/docs/testing/TEST_STATUS.md
+++ b/docs/testing/TEST_STATUS.md
@@ -42,10 +42,12 @@ The test suite is split into:
 - **Opt-in** (default `pytest` does not require Postgres):
   - Set `RUN_POSTGRES_TESTS=1`, or
   - Run `pytest -m postgres`
+  - Optional hard-disable: `SKIP_POSTGRES_TESTS=1` (takes precedence over opt-in flags/markers)
 - **Dependencies**: `psycopg2-binary` and `pgvector` (see `requirements/requirements_wsl_gpu.txt`). If drivers are missing, tests **skip** with a clear reason.
 - **Server**: e.g. `docker compose up -d db` from the repo root (`pgvector/pgvector:pg17` on port `5432`).
 - **Pytest + `database.engine: postgres`**: `modules.db_postgres.get_pg_config()` always uses **`image_scoring_test`** while pytest is active (`POSTGRES_DB` and config `dbname` are ignored), matching Firebird’s `scoring_history_test.fdb` rule. To point pytest at another database (dangerous), set **`IMAGE_SCORING_POSTGRES_PRODUCTION_IN_PYTEST=1`** and **`IMAGE_SCORING_I_ACCEPT_PRODUCTION_PYTEST_RISK=1`**. Do not use **`image_scoring_test`** as a production database name on machines where you run tests.
-- **Session setup**: `pytest_sessionstart` in `tests/conftest.py` calls `ensure_database_exists(image_scoring_test)` when the resolved engine is `postgres` and the two-variable escape hatch is not set, so the test database exists before any test opens a pool.
+- **Session setup activation policy**: `tests/conftest.py` only activates Postgres setup when explicitly opted in (`RUN_POSTGRES_TESTS=1` or marker expression includes `postgres`) and does nothing for default test runs.
+- **Session setup behavior**: once activated, `pytest_sessionstart` calls `ensure_database_exists(image_scoring_test)` when the resolved engine is `postgres` and the two-variable escape hatch is not set, so the test database exists before any test opens a pool.
 - **Connection**: Same env/config as the app: `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_USER`, `POSTGRES_PASSWORD`; the `postgres_test_session` fixture sets `POSTGRES_DB=image_scoring_test` for clarity (effective name is still forced under pytest without the escape hatch).
 - **Fixtures** (in `tests/conftest.py`): `postgres_test_session` creates the DB if needed and runs `modules.db_postgres.init_db()`; `clean_postgres` truncates app tables before each test.
 - **Tests**: `tests/test_postgres_integration.py`

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,14 +18,22 @@ _log = logging.getLogger(__name__)
 
 
 def _postgres_tests_enabled(_config):
-    """PostgreSQL tests are enabled by default (v6.4+).
-
-    Disable with SKIP_POSTGRES_TESTS=1 if no Postgres instance is available.
-    """
+    """Return whether Postgres test setup should be active (explicit opt-in only)."""
     if os.environ.get("SKIP_POSTGRES_TESTS", "").strip().lower() in ("1", "true", "yes"):
         return False
     if os.environ.get("RUN_POSTGRES_TESTS", "").strip().lower() in ("1", "true", "yes"):
         return True
+    marker_expr = ""
+    if _config is not None:
+        try:
+            marker_expr = (_config.getoption("-m") or "").strip()
+        except Exception:
+            marker_expr = ""
+    marker_expr = marker_expr.lower()
+    if "postgres" not in marker_expr:
+        return False
+    if "not postgres" in marker_expr:
+        return False
     return True
 
 
@@ -33,11 +41,11 @@ def _postgres_tests_enabled(_config):
 def postgres_test_session(request):
     """
     Isolated PostgreSQL database (image_scoring_test) with full app schema.
-    Enabled by default since v6.4. Disable with SKIP_POSTGRES_TESTS=1.
+    Activation is explicit opt-in via ``RUN_POSTGRES_TESTS=1`` or ``pytest -m postgres``.
     """
     if not _postgres_tests_enabled(request.config):
         pytest.skip(
-            "PostgreSQL tests disabled via SKIP_POSTGRES_TESTS=1"
+            "PostgreSQL tests disabled (set RUN_POSTGRES_TESTS=1 or run with -m postgres)"
         )
 
     try:
@@ -90,7 +98,7 @@ def pytest_sessionstart(session):
     Firebird test setup (``scripts/setup_test_db.py``) is no longer invoked
     automatically — run it manually if you need a Firebird test database.
     """
-    if not postgres_production_allowed_in_pytest():
+    if _postgres_tests_enabled(session.config) and not postgres_production_allowed_in_pytest():
         try:
             from modules import config
         except Exception as e:

--- a/tests/test_postgres_activation_policy.py
+++ b/tests/test_postgres_activation_policy.py
@@ -1,0 +1,27 @@
+from tests import conftest as tests_conftest
+
+
+class _ConfigStub:
+    def __init__(self, marker_expr: str):
+        self._marker_expr = marker_expr
+
+    def getoption(self, name: str):
+        if name == "-m":
+            return self._marker_expr
+        raise ValueError(name)
+
+
+def test_postgres_activation_policy_is_explicit_opt_in(monkeypatch):
+    monkeypatch.delenv("RUN_POSTGRES_TESTS", raising=False)
+    monkeypatch.delenv("SKIP_POSTGRES_TESTS", raising=False)
+
+    assert tests_conftest._postgres_tests_enabled(_ConfigStub("")) is False
+    assert tests_conftest._postgres_tests_enabled(_ConfigStub("postgres")) is True
+    assert tests_conftest._postgres_tests_enabled(_ConfigStub("postgres and not slow")) is True
+    assert tests_conftest._postgres_tests_enabled(_ConfigStub("not postgres")) is False
+
+    monkeypatch.setenv("RUN_POSTGRES_TESTS", "1")
+    assert tests_conftest._postgres_tests_enabled(_ConfigStub("")) is True
+
+    monkeypatch.setenv("SKIP_POSTGRES_TESTS", "1")
+    assert tests_conftest._postgres_tests_enabled(_ConfigStub("postgres")) is False


### PR DESCRIPTION
### Motivation
- Documentation described PostgreSQL tests as opt-in but the test harness attempted Postgres setup by default, causing unwanted DB preflight in environments without Postgres.

### Description
- Change `tests/conftest.py::_postgres_tests_enabled()` to explicit opt-in semantics where the default is disabled and activation requires `RUN_POSTGRES_TESTS=1` or a `-m` marker expression that includes `postgres`.
- Preserve `SKIP_POSTGRES_TESTS=1` as a hard override that always disables Postgres activation and treat `"not postgres"` in the marker expression as a negative.
- Gate `pytest_sessionstart` Postgres preflight on the same activation function so the test DB is not probed in default runs.
- Add `tests/test_postgres_activation_policy.py` to assert activation logic for environment-variable and marker combinations and update `docs/testing/TEST_STATUS.md` to document the explicit opt-in policy and `SKIP_POSTGRES_TESTS` precedence.

### Testing
- Ran `python -m pytest -q tests/test_postgres_activation_policy.py` and it passed (`1 passed`).
- No other automated test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4482520688323ab6429a1486f615e)