### PR TITLE
docs: point setup installs to canonical requirements and add docs dependency-version lint

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -1,0 +1,21 @@
+name: Docs Dependency Lint
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  docs-dependency-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Lint setup docs for dependency version drift
+        run: python scripts/lint_docs_dependency_versions.py

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ That's it! The Docker container includes all dependencies, CUDA support, and con
    source ~/.venvs/tf/bin/activate
    cd /path/to/image-scoring
    pip install --upgrade pip
-   pip install -r requirements/requirements_wsl_gpu.txt
+   pip install -r requirements/requirements_wsl_gpu.txt  # Canonical WSL/Linux GPU requirements
    ```
 
 3. **Verify GPU access**:
@@ -91,7 +91,7 @@ That's it! The Docker container includes all dependencies, CUDA support, and con
    python launch.py
    ```
 
-📖 **Detailed guide:** [WSL2 TensorFlow GPU Setup](docs/setup/WSL2_TENSORFLOW_GPU_SETUP.md) | [Windows/WSL Deployment](docs/setup/WINDOWS_WSL_DEPLOYMENT.md)
+📖 **Detailed guide:** [WSL2 TensorFlow GPU Setup](docs/setup/WSL2_TENSORFLOW_GPU_SETUP.md) | [Windows/WSL Deployment](docs/setup/WINDOWS_WSL_DEPLOYMENT.md) | [Python & Dependency Version Caveats](docs/setup/PYTHON_VERSION_CAVEATS.md)
 
 ---
 
@@ -112,15 +112,17 @@ python -m venv .venv
 .venv\Scripts\activate.bat
 
 # Install dependencies
-pip install -r requirements.txt
+pip install -r requirements.txt  # Canonical Windows-native requirements
 ```
 
 **Limitations:**
 - ❌ No VILA model (requires TensorFlow Hub + Kaggle)
-- ❌ No GPU acceleration (TensorFlow dropped Windows GPU support after v2.10)
+- ❌ No GPU acceleration in this Windows-native path (use Docker/WSL2 GPU requirements instead)
 - ⚠️ Slower batch processing (5-10x slower than GPU)
 
 📖 **For production use, we strongly recommend Docker or WSL2.**
+
+📖 **Version caveats:** [Python & Dependency Version Caveats](docs/setup/PYTHON_VERSION_CAVEATS.md)
 
 ---
 
@@ -128,7 +130,7 @@ pip install -r requirements.txt
 
 **Why?** Run the Gradio WebUI natively on Windows without WSL. CPU-only, no VILA.
 
-**Prerequisites:** Python 3.10+, Firebird binaries in `Firebird/` (firebird.exe, fbclient.dll — see [Firebird 5.0](https://firebirdsql.org/en/firebird-5-0/) Embedded package).
+**Prerequisites:** Compatible Python (see [Python & Dependency Version Caveats](docs/setup/PYTHON_VERSION_CAVEATS.md)), Firebird binaries in `Firebird/` (firebird.exe, fbclient.dll — see [Firebird 5.0](https://firebirdsql.org/en/firebird-5-0/) Embedded package).
 
 **Setup:**
 
@@ -377,14 +379,14 @@ The tool uses a **triple fallback mechanism** for maximum reliability:
 2. **TensorFlow GPU not detected**:
    ```bash
    pip uninstall tensorflow
-   pip install tensorflow[and-cuda]==2.15.0
+   pip install -r requirements/requirements_wsl_gpu.txt
    ```
 
 3. **Import errors**:
    ```bash
    sudo apt install libgl1 libsm6 libxext6
    pip install --upgrade pip
-   pip install -r requirements.txt --force-reinstall
+   pip install -r requirements/requirements_wsl_gpu.txt  # Reinstall canonical WSL/Linux GPU requirements
    ```
 
 ### Windows Native Issues
@@ -456,19 +458,13 @@ The tool uses a **triple fallback mechanism** for maximum reliability:
 
 ## Dependencies
 
-### Core Dependencies (Image Quality Scoring)
-- **tensorflow-cpu==2.15.0**: CPU-only TensorFlow
-- **Pillow==10.4.0**: Image processing
-- **numpy==1.24.4**: Numerical computing
-- **tensorflow-hub==0.16.1**: TensorFlow Hub model loading (primary source)
-- **kagglehub==0.3.4**: Kaggle Hub for VILA and all models (fallback source)
-### Keyword Extraction Dependencies (Optional)
-- **torch>=2.0.0**: PyTorch framework
-- **transformers>=4.30.0**: Hugging Face transformers
-- **keybert>=0.7.0**: Keyword extraction
-- **spacy>=3.6.0**: Natural language processing
+Dependency versions are maintained in platform-specific requirements files.
 
-📖 **See:** [requirements.txt](requirements.txt) for complete dependency list
+- **WSL2 / Linux GPU (recommended):** [`requirements/requirements_wsl_gpu.txt`](requirements/requirements_wsl_gpu.txt)
+- **Windows-native CPU workflow:** [`requirements.txt`](requirements.txt)
+- **Minimal CPU experiments:** [`requirements/requirements_simple.txt`](requirements/requirements_simple.txt)
+
+📖 **Version caveats and platform guidance:** [Python & Dependency Version Caveats](docs/setup/PYTHON_VERSION_CAVEATS.md)
 
 ---
 

--- a/docs/setup/ENVIRONMENTS.md
+++ b/docs/setup/ENVIRONMENTS.md
@@ -27,7 +27,7 @@ This document describes each Python environment referenced in the image-scoring 
   ```bash
   python3 -m venv ~/.venvs/tf
   source ~/.venvs/tf/bin/activate
-  pip install -r requirements.txt  # and any GPU/requirements variants
+  pip install -r requirements/requirements_wsl_gpu.txt  # canonical WSL/Linux GPU requirements
   ```
 - **Note:** The path is in the **WSL home directory** (`~`), not under the project. Project-local `.venv` is not used by `run_webui.bat` or these scripts.
 
@@ -100,3 +100,6 @@ See also the Cursor rule **Run Python in WSL (Webapp Environment)** (`.cursor/ru
 | What does the Web UI use? | WSL + **`~/.venvs/tf`** (via `run_webui.bat`). |
 | Does default Web UI (`run_webui.bat`) use project `.venv`? | No — it uses `~/.venvs/tf`. |
 | Where do WSL pytest tests run? | In **`~/.venvs/image-scoring-tests`** (or custom `VENV_DIR`). |
+
+
+See also: [Python & Dependency Version Caveats](PYTHON_VERSION_CAVEATS.md).

--- a/docs/setup/INDEX.md
+++ b/docs/setup/INDEX.md
@@ -18,6 +18,7 @@
 
 | Document | Description |
 |----------|-------------|
+| [PYTHON_VERSION_CAVEATS.md](PYTHON_VERSION_CAVEATS.md) | Canonical requirements files by platform + Python compatibility caveats |
 | [ENVIRONMENTS.md](ENVIRONMENTS.md) | Virtual environments (.venv, ~/.venvs/tf, tests) |
 | [WINDOWS_WSL_DEPLOYMENT.md](WINDOWS_WSL_DEPLOYMENT.md) | Windows + WSL2 deployment guide |
 | [WSL_PYTHON_PACKAGES.md](WSL_PYTHON_PACKAGES.md) | Python packages in WSL2 venv |

--- a/docs/setup/PYTHON_VERSION_CAVEATS.md
+++ b/docs/setup/PYTHON_VERSION_CAVEATS.md
@@ -1,0 +1,23 @@
+# Python & Dependency Version Caveats
+
+This project supports multiple runtime targets (Docker/WSL2 GPU, WSL research, and Windows-native CPU workflows).
+
+To avoid stale docs and broken installs, treat requirement files as the canonical source of truth for package versions.
+
+## Canonical requirements files by platform
+
+- **WSL2 / Linux GPU (recommended for WebUI/dev):** `requirements/requirements_wsl_gpu.txt`
+- **Windows-native CPU workflow (limited support):** `requirements.txt`
+- **Minimal CPU-only experiments:** `requirements/requirements_simple.txt`
+
+## Python compatibility caveat
+
+`requirements.txt` currently uses a TensorFlow CPU constraint that is not compatible with Python 3.12.
+
+If you are on Python 3.12, use the WSL/Linux path with `requirements/requirements_wsl_gpu.txt`.
+
+## Documentation policy
+
+- Do **not** hardcode package versions in setup docs unless absolutely necessary.
+- Prefer referencing the platform's canonical requirements file.
+- If a one-off pinned version must be documented, keep it synchronized with the relevant requirements file.

--- a/docs/setup/WSL2_TENSORFLOW_GPU_SETUP.md
+++ b/docs/setup/WSL2_TENSORFLOW_GPU_SETUP.md
@@ -76,8 +76,8 @@ source ~/.bashrc
 # Make sure virtual environment is activated
 source ~/.venvs/tf/bin/activate
 
-# Install TensorFlow 2.15.0 with GPU support
-pip install tensorflow==2.15.0
+# Install canonical WSL/Linux GPU dependencies
+pip install -r requirements/requirements_wsl_gpu.txt
 ```
 
 ### Step 5: Verify Installation
@@ -171,7 +171,7 @@ Once setup is complete:
    - Restart Ubuntu terminal
 
 3. **"TensorFlow not built with CUDA"**
-   - Reinstall TensorFlow: `pip uninstall tensorflow && pip install tensorflow==2.15.0`
+   - Reinstall from canonical requirements: `pip install -r requirements/requirements_wsl_gpu.txt`
    - Check CUDA version compatibility
 
 4. **"Permission denied"**
@@ -184,6 +184,8 @@ Once setup is complete:
 |----------------|--------|-------|---------|
 | Windows Native | CPU | ~30ms | âœ… Working |
 | WSL2 + Ubuntu | GPU | ~5ms | âœ… Working (after setup) |
+
+See also: [Python & Dependency Version Caveats](PYTHON_VERSION_CAVEATS.md).
 
 ## Next Steps
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "api:types:generate": "node scripts/generate-api-types.mjs",
-    "api:types:check": "node scripts/validate-api-types.mjs"
+    "api:types:check": "node scripts/validate-api-types.mjs",
+    "docs:lint:deps": "python scripts/lint_docs_dependency_versions.py"
   }
 }

--- a/scripts/lint_docs_dependency_versions.py
+++ b/scripts/lint_docs_dependency_versions.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Lint README/docs setup files for dependency version literals that diverge from canonical requirements.
+
+This intentionally checks only quick-start/setup docs where stale literals cause copy/paste install drift.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+CANONICAL_REQUIREMENTS = [
+    REPO_ROOT / "requirements" / "requirements_wsl_gpu.txt",
+    REPO_ROOT / "requirements.txt",
+    REPO_ROOT / "requirements" / "requirements_simple.txt",
+]
+
+TARGET_FILES = [
+    REPO_ROOT / "README.md",
+    *sorted((REPO_ROOT / "docs" / "setup").glob("*.md")),
+]
+
+REQ_RE = re.compile(r"^\s*([A-Za-z0-9_.-]+)\s*(==|~=|>=|<=|>|<)\s*([^\s#;]+)")
+DOC_SPEC_RE = re.compile(r"\b([A-Za-z0-9_.-]+)\s*(==|~=|>=|<=|>|<)\s*([0-9][A-Za-z0-9_.-]*)\b")
+
+
+def normalize_name(name: str) -> str:
+    return name.strip().lower().replace("_", "-")
+
+
+def load_canonical_specs() -> dict[str, set[str]]:
+    specs: dict[str, set[str]] = {}
+    for req_file in CANONICAL_REQUIREMENTS:
+        if not req_file.exists():
+            continue
+        for raw_line in req_file.read_text(encoding="utf-8").splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            m = REQ_RE.match(line)
+            if not m:
+                continue
+            pkg, op, ver = m.groups()
+            specs.setdefault(normalize_name(pkg), set()).add(f"{op}{ver}")
+    return specs
+
+
+def main() -> int:
+    canonical = load_canonical_specs()
+    errors: list[str] = []
+
+    for target in TARGET_FILES:
+        rel = target.relative_to(REPO_ROOT)
+        for line_no, line in enumerate(target.read_text(encoding="utf-8").splitlines(), start=1):
+            if line.lstrip().startswith("#"):
+                continue
+            for pkg, op, ver in DOC_SPEC_RE.findall(line):
+                pkg_norm = normalize_name(pkg)
+                spec = f"{op}{ver}"
+                known_specs = canonical.get(pkg_norm)
+                if not known_specs:
+                    continue
+                if spec not in known_specs:
+                    allowed = ", ".join(sorted(known_specs))
+                    errors.append(
+                        f"{rel}:{line_no}: {pkg}{spec} diverges from canonical requirements ({allowed})"
+                    )
+
+    if errors:
+        print("Dependency version lint failed:\n")
+        for err in errors:
+            print(f"- {err}")
+        return 1
+
+    print("Dependency version lint passed for README/docs setup files.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Prevent stale, copy/paste package version literals in quick-start docs from diverging from the actual requirements files.
- Centralize Python-version caveats and platform guidance so readers know which requirements file is canonical per target.
- Ensure install commands in README and setup docs use the supported requirements file for each platform to reduce install failures.
- Add an automated guard so future doc edits cannot reintroduce divergent hardcoded pins.

### Description

- Replaced hardcoded package/version literals and one-off pip pin commands in `README.md` and WSL setup docs with references to the canonical requirements files (e.g. `requirements/requirements_wsl_gpu.txt` or `requirements.txt`).
- Added `docs/setup/PYTHON_VERSION_CAVEATS.md` to document Python compatibility caveats and list canonical requirements by platform.
- Updated setup docs (`docs/setup/INDEX.md`, `docs/setup/ENVIRONMENTS.md`, `docs/setup/WSL2_TENSORFLOW_GPU_SETUP.md`) and README links to reference the new caveats doc and canonical requirements paths.
- Added a lint script `scripts/lint_docs_dependency_versions.py` that flags hardcoded dependency specifiers in `README.md` and `docs/setup/*.md` which diverge from the requirements files.
- Hooked the lint into local tooling by adding `docs:lint:deps` in `package.json` and into CI via `.github/workflows/docs-lint.yml`.

### Testing

- Ran `python scripts/lint_docs_dependency_versions.py` against the modified docs and it reported no divergences (passed).
- Ran `npm run docs:lint:deps` (which invokes the lint script) and it completed successfully (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4482b94708323aa207fd5f16aa250)