### PR TITLE
Audit WSL tests: add markers, update runner defaults, add CI guard and docs

### DIFF
--- a/.github/workflows/wsl-marker-guard.yml
+++ b/.github/workflows/wsl-marker-guard.yml
@@ -1,0 +1,33 @@
+name: WSL marker guard
+
+on:
+  pull_request:
+    paths:
+      - 'tests/**'
+      - 'scripts/ci/check_wsl_marker_collection.py'
+      - '.github/workflows/wsl-marker-guard.yml'
+      - 'pytest.ini'
+  merge_group:
+    paths:
+      - 'tests/**'
+      - 'scripts/ci/check_wsl_marker_collection.py'
+      - '.github/workflows/wsl-marker-guard.yml'
+      - 'pytest.ini'
+
+jobs:
+  collect-wsl-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install pytest
+        run: python -m pip install --upgrade pip pytest
+
+      - name: Ensure WSL-marked tests are discoverable
+        run: python scripts/ci/check_wsl_marker_collection.py

--- a/docs/testing/TEST_STATUS.md
+++ b/docs/testing/TEST_STATUS.md
@@ -1,6 +1,6 @@
 # Unit Test Status
 
-**Last updated**: 2026-04-13
+**Last updated**: 2026-04-19
 
 ## Overview
 
@@ -23,12 +23,20 @@ The test suite is split into:
 
 - **WSL test venv**: `~/.venvs/image-scoring-tests`
 - **Setup**: `bash ./scripts/wsl/setup_wsl_test_env.sh`
-- **Run**: `bash ./scripts/wsl/run_wsl_tests.sh`
+- **Run**: `bash ./scripts/wsl/run_wsl_tests.sh` (default: `-m "wsl and not network"`)
+
+#### WSL marker inventory (current)
+
+- Total files marked with `@pytest.mark.wsl`: **17**
+- Coverage includes:
+  - TensorFlow/GPU and model stack tests (`test_tf_gpu`, `test_vila`, `test_model_sources`, `test_gpu`, `test_cuda_manual`, `test_launch`, `test_selector_runner_behavior`, `test_verify_thumbnail`, `test_verify_patching`, `test_culling`)
+  - Linux RAW/tooling tests (`test_raw_extraction`, `test_resolution`, `test_dcraw_thumb`, `test_rawpy`, `test_thumb_gen`)
+  - Archived Firebird WSL smoke tests (`tests/archive_firebird/test_fb_wsl.py`, `tests/archive_firebird/test_fb_wsl_integration.py`)
 
 #### Recent fixes (2026-03-14)
 
 1. **`tests/test_events.py`** — Refactored to use minimal FastAPI app (no `webui` import); avoids Gradio/TensorFlow.
-2. **`tests/test_selector_runner_behavior.py`** — Added `@pytest.mark.wsl` and import guard; skips when ML deps unavailable.
+2. **`tests/test_selector_runner_behavior.py`** — Marked with `@pytest.mark.wsl`; skips when ML deps unavailable.
 3. **`tests/test_culling.py`** — Now uses `scoring_history_test.fdb` (per test DB rule); added XMP format verification (`xmpDM:pick`, `xmpDM:good`); added optional `test_full_workflow_real_data` (env: `IMAGE_SCORING_TEST_CULLING_FOLDER`).
 4. **`scripts/setup_test_db.py`** — Clears `culling_picks` and `culling_sessions` tables.
 
@@ -54,5 +62,10 @@ The test suite is split into:
 
 - [WSL_TESTS.md](WSL_TESTS.md) — WSL test setup and markers
 - [ENVIRONMENTS.md](../setup/ENVIRONMENTS.md) — Virtual environment overview
+
+## CI Guard
+
+- `scripts/ci/check_wsl_marker_collection.py` runs `pytest -m wsl --collect-only` against WSL-marked files and fails if zero tests are collected.
+- GitHub Actions workflow: `.github/workflows/wsl-marker-guard.yml`.
 
 **Note:** Periodically re-run `pytest -m wsl -ra` (WSL test venv) and update the “Current State” sections above. Former meta-tracker: [archive/testing/DOCUMENTATION_ISSUES.md](../archive/testing/DOCUMENTATION_ISSUES.md).

--- a/docs/testing/WSL_TESTS.md
+++ b/docs/testing/WSL_TESTS.md
@@ -3,29 +3,36 @@
 This repo uses pytest markers to indicate tests that should be run in **WSL/Linux** (instead of native Windows).
 
 - **Marker**: `wsl`
-- **Run command in WSL**: `python -m pytest -m wsl -ra`
+- **Run command in WSL**: `python -m pytest -m "wsl and not network" -ra`
 
 ### Why WSL?
 
 Some tests depend on Linux tooling (e.g. `dcraw`, `exiftool`), Linux-only libraries, or a working TensorFlow/CUDA stack that is expected to be installed in WSL.
 
-### Tests currently marked `wsl`
+### Tests currently marked `wsl` (17 files)
 
-- **TensorFlow / GPU**
+- **TensorFlow / GPU / model stack**
   - `tests/test_tf_gpu.py`
   - `tests/test_vila.py`
   - `tests/test_model_sources.py`
   - `tests/test_launch.py` (imports `webui`, which pulls TensorFlow in this repo)
+  - `tests/test_gpu.py`
+  - `tests/test_cuda_manual.py`
+  - `tests/test_selector_runner_behavior.py`
   - `tests/test_verify_thumbnail.py`
   - `tests/test_verify_patching.py`
+  - `tests/test_culling.py`
 
-- **RAW extraction tooling + sample data**
+- **RAW extraction and Linux tooling**
   - `tests/test_raw_extraction.py` (requires `IMAGE_SCORING_TEST_RAW_FILE`)
   - `tests/test_resolution.py` (pyiqa/torch; optional sample thumbnail path)
+  - `tests/test_dcraw_thumb.py`
+  - `tests/test_rawpy.py`
+  - `tests/test_thumb_gen.py`
 
-- **Firebird WSL smoke/integration**
-  - `tests/test_fb_wsl.py`
-  - `tests/test_fb_wsl_integration.py`
+- **Firebird WSL smoke/integration (archived)**
+  - `tests/archive_firebird/test_fb_wsl.py`
+  - `tests/archive_firebird/test_fb_wsl_integration.py`
 
 ### Environment variables used by WSL tests
 
@@ -37,7 +44,7 @@ Some tests depend on Linux tooling (e.g. `dcraw`, `exiftool`), Linux-only librar
 ### Scripts
 
 - **Setup venv inside WSL**: `bash ./scripts/wsl/setup_wsl_test_env.sh`
-- **Run WSL tests inside WSL**: `bash ./scripts/wsl/run_wsl_tests.sh`
+- **Run WSL tests inside WSL**: `bash ./scripts/wsl/run_wsl_tests.sh` (default marker expression: `wsl and not network`)
 - **Run from Windows (PowerShell)**:
 
 ```powershell
@@ -70,5 +77,4 @@ The `wsl` marker runs WSL tests. Other markers in `pytest.ini` include: `network
 - [GPU setup guide](../setup/GPU_SETUP.md)
 - [Technical summary](../technical/TECHNICAL_SUMMARY.md)
 - [Docker setup](../setup/DOCKER_SETUP.md)
-
 

--- a/scripts/ci/check_wsl_marker_collection.py
+++ b/scripts/ci/check_wsl_marker_collection.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Guard: ensure WSL-marked tests are still discoverable by pytest.
+
+This script intentionally uses `pytest -m wsl --collect-only` and fails when
+that command yields zero collected tests.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _wsl_marked_test_files(root: Path) -> list[str]:
+    files: list[str] = []
+    for path in sorted(root.rglob("test_*.py")):
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        if "pytest.mark.wsl" in text:
+            files.append(path.as_posix())
+    return files
+
+
+def main() -> int:
+    test_files = _wsl_marked_test_files(Path("tests"))
+    if not test_files:
+        print("[error] No files contain pytest.mark.wsl under tests/.")
+        return 1
+
+    cmd = [sys.executable, "-m", "pytest", "-m", "wsl", "--collect-only", "-q", *test_files]
+    print(f"[run] {' '.join(cmd)}")
+    proc = subprocess.run(cmd, text=True, capture_output=True)
+
+    if proc.stdout:
+        print(proc.stdout, end="")
+    if proc.stderr:
+        print(proc.stderr, end="", file=sys.stderr)
+
+    collected = 0
+    combined = f"{proc.stdout}\n{proc.stderr}"
+    match = re.search(r"(\d+)\s+tests?\s+collected", combined)
+    if match:
+        collected = int(match.group(1))
+    elif "no tests collected" in combined.lower():
+        collected = 0
+
+    if collected == 0:
+        print("[error] pytest -m wsl --collect-only discovered zero tests.")
+        return 1
+
+    print(f"[ok] pytest collected {collected} wsl-marked tests.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/wsl/run_wsl_tests.sh
+++ b/scripts/wsl/run_wsl_tests.sh
@@ -10,7 +10,8 @@ set -euo pipefail
 #
 # Optional env vars:
 #   VENV_DIR=~/.venvs/image-scoring-tests
-#   PYTEST_ARGS="-ra -m wsl"
+#   PYTEST_MARK_EXPR='wsl and not network'
+#   PYTEST_ARGS='-k "not slow"'
 #   IMAGE_SCORING_TEST_RAW_FILE=/mnt/d/Photos/.../DSC_0001.NEF
 #   IMAGE_SCORING_TEST_THUMBNAIL=/path/to/image-scoring/thumbnails/....
 #   IMAGE_SCORING_RUN_NETWORK_TESTS=1
@@ -20,7 +21,8 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$REPO_ROOT"
 
 VENV_DIR="${VENV_DIR:-$HOME/.venvs/image-scoring-tests}"
-PYTEST_ARGS="${PYTEST_ARGS:--ra -m wsl}"
+PYTEST_MARK_EXPR="${PYTEST_MARK_EXPR:-wsl and not network}"
+PYTEST_ARGS="${PYTEST_ARGS:-}"
 
 if [[ ! -d "$VENV_DIR" ]]; then
   echo "[error] venv not found at $VENV_DIR. Run: bash ./scripts/wsl/setup_wsl_test_env.sh" >&2
@@ -30,5 +32,5 @@ fi
 # shellcheck disable=SC1090
 source "$VENV_DIR/bin/activate"
 
-echo "[run] pytest $PYTEST_ARGS"
-python -m pytest $PYTEST_ARGS
+echo "[run] pytest -ra -m \"$PYTEST_MARK_EXPR\" $PYTEST_ARGS"
+python -m pytest -ra -m "$PYTEST_MARK_EXPR" $PYTEST_ARGS

--- a/tests/test_cuda_manual.py
+++ b/tests/test_cuda_manual.py
@@ -5,6 +5,9 @@ Manual CUDA detection test
 
 import os
 import sys
+import pytest
+
+pytestmark = [pytest.mark.wsl, pytest.mark.gpu]
 
 def test_cuda_libraries():
     """Test if CUDA libraries can be loaded manually"""

--- a/tests/test_dcraw_thumb.py
+++ b/tests/test_dcraw_thumb.py
@@ -1,6 +1,8 @@
-
 import subprocess
 import os
+import pytest
+
+pytestmark = pytest.mark.wsl
 
 target_file = "/mnt/d/Photos/Z8/180-600mm/2025/2025-11-16/DSC_6008.NEF"
 

--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -6,10 +6,13 @@ Tests if GPU is available and working with TensorFlow
 
 import os
 import sys
+import pytest
 
 # Set environment variables
 os.environ['CUDA_VISIBLE_DEVICES'] = '0'
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'  # Reduce TensorFlow logging
+
+pytestmark = [pytest.mark.wsl, pytest.mark.gpu]
 
 def check_gpu():
     """Test GPU functionality."""

--- a/tests/test_rawpy.py
+++ b/tests/test_rawpy.py
@@ -2,6 +2,10 @@ import sys
 import os
 import datetime
 import importlib
+import pytest
+
+pytestmark = pytest.mark.wsl
+
 try:
     import rawpy
     print(f"rawpy version: {rawpy.__version__}")
@@ -40,4 +44,3 @@ if __name__ == "__main__":
         print(f"Utils result: {utils.get_image_creation_time(TARGET_FILE)}")
     except ImportError:
         print("Could not import modules.utils")
-

--- a/tests/test_selector_runner_behavior.py
+++ b/tests/test_selector_runner_behavior.py
@@ -1,5 +1,7 @@
 import pytest
 
+pytestmark = pytest.mark.wsl
+
 try:
     from modules.clustering import ClusteringEngine
     from modules.scoring import ScoringRunner

--- a/tests/test_thumb_gen.py
+++ b/tests/test_thumb_gen.py
@@ -1,11 +1,14 @@
 import sys
 import os
+import pytest
 try:
     from modules import thumbnails
 except ImportError:
     # Fix import path for script execution
     sys.path.append(os.getcwd())
     from modules import thumbnails
+
+pytestmark = pytest.mark.wsl
 
 
 def test_thumbnail_generation():


### PR DESCRIPTION
### Motivation

- Ensure tests that must run in WSL/Linux are consistently marked with `@pytest.mark.wsl` so the WSL test venv and runner pick them up reliably.
- Make the WSL run helper default to a safe marker expression that excludes network-dependent tests by default.
- Prevent regressions where WSL-marked tests become undiscoverable by adding a CI-level collection guard.
- Refresh documentation to reflect the corrected marker inventory and new CI guard.

### Description

- Added `pytestmark = pytest.mark.wsl` (and GPU marks where appropriate) to WSL/Linux-dependent tests: `tests/test_selector_runner_behavior.py`, `tests/test_gpu.py`, `tests/test_cuda_manual.py`, `tests/test_dcraw_thumb.py`, `tests/test_rawpy.py`, and `tests/test_thumb_gen.py`.
- Updated `scripts/wsl/run_wsl_tests.sh` to use a `PYTEST_MARK_EXPR` default of `wsl and not network` and keep `PYTEST_ARGS` as an override, and updated the run/echo invocation to use the marker expression.
- Added a CI guard script `scripts/ci/check_wsl_marker_collection.py` that runs `pytest -m wsl --collect-only` against files that contain `pytest.mark.wsl` and fails when zero tests are collected.
- Added a GitHub Actions workflow `.github/workflows/wsl-marker-guard.yml` that runs the guard on PRs/merge groups when tests or pytest configuration change.
- Updated documentation files `docs/testing/WSL_TESTS.md` and `docs/testing/TEST_STATUS.md` to list the corrected marker inventory (17 files), the updated run defaults, and CI guard information.

### Testing

- Ran the new CI guard script `python scripts/ci/check_wsl_marker_collection.py`, which invoked `pytest -m wsl --collect-only` against the detected wsl-marked files and reported a non-zero collected count (guard passed).
- Ran `python -m pytest -m wsl --collect-only -q tests` as an extra validation; pytest collected 18 wsl-marked tests but produced import errors for unrelated optional dependencies in the local environment (this is expected when optional WSL/ML deps are not installed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4482532888323a944ce47e185bdca)