### PR TITLE
frontend: centralize phase status icon rendering across run views

### DIFF
--- a/frontend/src/components/runs/StagePanel.tsx
+++ b/frontend/src/components/runs/StagePanel.tsx
@@ -10,6 +10,7 @@ import { runsApi } from '@/api/runs'
 import { Button } from '@/components/ui/button'
 import { StageBadge } from '@/components/ui/badge'
 import { Progress } from '@/components/ui/progress'
+import { PhaseStatusIcon, getPhaseStatusMeta, normalizePhaseStatus } from '@/components/status/PhaseStatusIcon'
 import { STAGE_DISPLAY, STEP_DISPLAY } from '@/types/api'
 import type { Stage, Step, WorkItem } from '@/types/api'
 import { useWsStore } from '@/stores/wsStore'
@@ -372,21 +373,25 @@ function WorkItemsTable({
 }
 
 function WorkItemStatus({ status }: { status: string }) {
-  const styles: Record<string, string> = {
-    done: 'text-[#89d185]',
-    running: 'text-[#4fc1ff]',
-    failed: 'text-[#f44747]',
-    skipped: 'text-[#6d6d6d]',
-    pending: 'text-[#6d6d6d]',
-  }
+  const normalized = normalizePhaseStatus(status)
+  const { colorClass } = getPhaseStatusMeta(status)
   const labels: Record<string, string> = {
-    done: '✓ Done',
-    running: '⟳ Running',
-    failed: '✗ Failed',
-    skipped: '— Skipped',
-    pending: '○ Waiting',
+    completed: 'Done',
+    running: 'Running',
+    failed: 'Failed',
+    skipped: 'Skipped',
+    pending: 'Waiting',
+    queued: 'Queued',
+    partial: 'Partial',
   }
-  return <span className={clsx('font-medium', styles[status] ?? 'text-[#6d6d6d]')}>{labels[status] ?? status}</span>
+  const label = labels[normalized] ?? normalized.replace('_', ' ')
+
+  return (
+    <span className={clsx('inline-flex items-center gap-1 font-medium', colorClass)}>
+      <PhaseStatusIcon status={status} size={12} animated />
+      {label}
+    </span>
+  )
 }
 
 function formatEta(sec: number): string {

--- a/frontend/src/components/runs/WorkflowGraph.tsx
+++ b/frontend/src/components/runs/WorkflowGraph.tsx
@@ -1,10 +1,11 @@
 import { clsx } from 'clsx'
 import {
-  CheckCircle2, XCircle, Loader2, Circle, MinusCircle, ChevronRight, AlertTriangle,
+  ChevronRight,
 } from 'lucide-react'
 import { STAGE_DISPLAY } from '@/types/api'
 import type { Stage, StageState } from '@/types/api'
 import { Progress } from '@/components/ui/progress'
+import { PhaseStatusIcon, normalizePhaseStatus, getPhaseStatusMeta } from '@/components/status/PhaseStatusIcon'
 import { useWsStore } from '@/stores/wsStore'
 
 interface WorkflowGraphProps {
@@ -106,36 +107,12 @@ function StageNode({ stage, liveProgress, isSelected, onClick }: StageNodeProps)
 }
 
 function StateIcon({ state }: { state: StageState }) {
-  switch (state) {
-    case 'completed':
-      return <CheckCircle2 size={14} className="text-[#89d185] shrink-0" />
-    case 'running':
-      return <Loader2 size={14} className="text-[#4fc1ff] shrink-0 animate-spin" />
-    case 'failed':
-      return <XCircle size={14} className="text-[#f44747] shrink-0" />
-    case 'interrupted':
-      return <AlertTriangle size={14} className="text-[#cca700] shrink-0" />
-    case 'skipped':
-      return <MinusCircle size={14} className="text-[#6d6d6d] shrink-0" />
-    default:
-      return <Circle size={14} className="text-[#474747] shrink-0" />
-  }
+  return <PhaseStatusIcon status={state} size={14} animated />
 }
 
 function StageBadgeText({ state }: { state: StageState }) {
-  const colors: Record<StageState, string> = {
-    pending: 'text-[#6d6d6d]',
-    queued: 'text-[#9d9d9d]',
-    running: 'text-[#4fc1ff]',
-    paused: 'text-[#cca700]',
-    completed: 'text-[#89d185]',
-    failed: 'text-[#f44747]',
-    skipped: 'text-[#6d6d6d]',
-    interrupted: 'text-[#cca700]',
-    cancel_requested: 'text-[#cca700]',
-    restarting: 'text-[#9d9d9d]',
-    canceled: 'text-[#f44747]',
-  }
+  const { colorClass } = getPhaseStatusMeta(state)
+  const normalizedState = normalizePhaseStatus(state)
   const labels: Record<StageState, string> = {
     pending: 'Pending',
     queued: 'Queued',
@@ -149,7 +126,8 @@ function StageBadgeText({ state }: { state: StageState }) {
     restarting: 'Restarting',
     canceled: 'Canceled',
   }
-  return <span className={clsx('text-[10px]', colors[state])}>{labels[state]}</span>
+  const fallbackLabel = normalizedState.charAt(0).toUpperCase() + normalizedState.slice(1).replace('_', ' ')
+  return <span className={clsx('text-[10px]', colorClass)}>{labels[state] ?? fallbackLabel}</span>
 }
 
 function DurationText({ stage }: { stage: Stage }) {

--- a/frontend/src/components/scope/ScopeSelector.tsx
+++ b/frontend/src/components/scope/ScopeSelector.tsx
@@ -1,11 +1,12 @@
 import { useState, useEffect } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { clsx } from 'clsx'
-import { X, Plus, Trash2, FolderOpen, CheckCircle2, AlertCircle, Loader2 } from 'lucide-react'
+import { X, Plus, Trash2, FolderOpen } from 'lucide-react'
 import { ApiError, parseApiErrorDetail } from '@/api/client'
 import { runsApi, type RunSubmitRequest } from '@/api/runs'
 import { scopeApi } from '@/api/scope'
 import { Button } from '@/components/ui/button'
+import { PhaseStatusIcon } from '@/components/status/PhaseStatusIcon'
 import { useUiStore } from '@/stores/uiStore'
 import { STAGE_DISPLAY } from '@/types/api'
 import type { StageCode, ScopePreviewResult, ValidationRepairPreview } from '@/types/api'
@@ -476,16 +477,5 @@ function PreviewPanel({ preview }: { preview: ScopePreviewResult }) {
 }
 
 function StageStatusIcon({ status }: { status: string }) {
-  switch (status) {
-    case 'done':
-      return <CheckCircle2 size={12} className="text-[#89d185]" />
-    case 'failed':
-      return <AlertCircle size={12} className="text-[#f44747]" />
-    case 'partial':
-    case 'running':
-    case 'queued':
-      return <Loader2 size={12} className="text-[#cca700]" />
-    default:
-      return <div className="w-3 h-3 rounded-full border border-[#474747]" />
-  }
+  return <PhaseStatusIcon status={status} size={12} animated />
 }

--- a/frontend/src/components/status/PhaseStatusIcon.tsx
+++ b/frontend/src/components/status/PhaseStatusIcon.tsx
@@ -1,0 +1,81 @@
+import type { LucideIcon } from 'lucide-react'
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Circle,
+  Clock3,
+  Loader2,
+  MinusCircle,
+  PauseCircle,
+  XCircle,
+} from 'lucide-react'
+import { clsx } from 'clsx'
+
+export type PhaseStatus =
+  | 'pending'
+  | 'queued'
+  | 'running'
+  | 'paused'
+  | 'completed'
+  | 'done'
+  | 'failed'
+  | 'skipped'
+  | 'interrupted'
+  | 'cancel_requested'
+  | 'restarting'
+  | 'canceled'
+  | 'partial'
+  | 'not_started'
+
+export type NormalizedPhaseStatus = Exclude<PhaseStatus, 'done' | 'not_started'> | 'completed' | 'pending'
+
+type PhaseStatusMeta = {
+  icon: LucideIcon
+  colorClass: string
+}
+
+const PHASE_STATUS_META: Record<NormalizedPhaseStatus, PhaseStatusMeta> = {
+  pending: { icon: Circle, colorClass: 'text-[#6d6d6d]' },
+  queued: { icon: Clock3, colorClass: 'text-[#9d9d9d]' },
+  running: { icon: Loader2, colorClass: 'text-[#4fc1ff]' },
+  paused: { icon: PauseCircle, colorClass: 'text-[#cca700]' },
+  completed: { icon: CheckCircle2, colorClass: 'text-[#89d185]' },
+  failed: { icon: XCircle, colorClass: 'text-[#f44747]' },
+  skipped: { icon: MinusCircle, colorClass: 'text-[#6d6d6d]' },
+  interrupted: { icon: AlertTriangle, colorClass: 'text-[#cca700]' },
+  cancel_requested: { icon: AlertTriangle, colorClass: 'text-[#cca700]' },
+  restarting: { icon: Loader2, colorClass: 'text-[#9d9d9d]' },
+  canceled: { icon: XCircle, colorClass: 'text-[#f44747]' },
+  partial: { icon: AlertTriangle, colorClass: 'text-[#cca700]' },
+}
+
+export function normalizePhaseStatus(status: string): NormalizedPhaseStatus {
+  if (status === 'done') return 'completed'
+  if (status === 'not_started') return 'pending'
+  if (status in PHASE_STATUS_META) return status as NormalizedPhaseStatus
+  return 'pending'
+}
+
+export function getPhaseStatusMeta(status: string): PhaseStatusMeta & { normalizedStatus: NormalizedPhaseStatus } {
+  const normalizedStatus = normalizePhaseStatus(status)
+  return { ...PHASE_STATUS_META[normalizedStatus], normalizedStatus }
+}
+
+interface PhaseStatusIconProps {
+  status: string
+  size?: number
+  animated?: boolean
+  className?: string
+}
+
+export function PhaseStatusIcon({ status, size = 12, animated = false, className }: PhaseStatusIconProps) {
+  const { icon: Icon, colorClass, normalizedStatus } = getPhaseStatusMeta(status)
+  const shouldSpin = animated && (normalizedStatus === 'running' || normalizedStatus === 'restarting')
+
+  return (
+    <Icon
+      size={size}
+      className={clsx(colorClass, shouldSpin && 'animate-spin', 'shrink-0', className)}
+    />
+  )
+}


### PR DESCRIPTION
### Motivation

- Reduce duplicated status→icon/color logic across run-related UI components and standardize visual semantics for stages, previews, and work items.
- Provide a single normalization entrypoint so aliases like `done` and `not_started` map consistently to `completed` and `pending` respectively.

### Description

- Add shared module `frontend/src/components/status/PhaseStatusIcon.tsx` that exposes `PhaseStatusIcon`, `normalizePhaseStatus`, and `getPhaseStatusMeta`, a single status→icon/color mapping table, and optional `size`/`animated` props.
- Replace inline switch logic in `WorkflowGraph` (`StateIcon`) to use `PhaseStatusIcon` and shared color metadata via `getPhaseStatusMeta` and `normalizePhaseStatus`.
- Replace inline switch logic in `ScopeSelector` (`StageStatusIcon`) to render via `PhaseStatusIcon`.
- Update `StagePanel` (`WorkItemStatus`) to use `normalizePhaseStatus`, `getPhaseStatusMeta`, and `PhaseStatusIcon` so work-item labels, icons, and colors follow the same mapping and dark-theme palette.

### Testing

- Ran repository scans to verify duplicate logic was removed with `rg -n "function StateIcon|function StageStatusIcon" frontend/src/components/runs/WorkflowGraph.tsx frontend/src/components/scope/ScopeSelector.tsx frontend/src/components/runs/StagePanel.tsx`, which showed the new centralized usage.
- Verified there are no remaining `switch (state)` / `switch (status)` blocks at the three target files with `rg -n "switch \\(state\\)|switch \\(status\\)" frontend/src/components/runs/WorkflowGraph.tsx frontend/src/components/scope/ScopeSelector.tsx frontend/src/components/runs/StagePanel.tsx`.
- Attempted to run frontend lint with `cd frontend && npx eslint ...` but it failed in this environment due to missing frontend dev-dependencies (error: missing `@eslint/js`), so full ESLint checks could not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e577b428e483239987ad35e5f927d5)