### PR TITLE
feat(frontend): normalize and iconize Image Inspector phase statuses

### DIFF
--- a/frontend/src/components/ui/phaseStatus.tsx
+++ b/frontend/src/components/ui/phaseStatus.tsx
@@ -1,0 +1,44 @@
+import { AlertCircle, CheckCircle2, Loader2, MinusCircle } from 'lucide-react'
+
+const PHASE_STATUS_ALIASES: Record<string, string> = {
+  complete: 'done',
+  completed: 'done',
+  success: 'done',
+  succeeded: 'done',
+  in_progress: 'running',
+  processing: 'running',
+  error: 'failed',
+  cancelled: 'canceled',
+  cancel_requested: 'cancel_requested',
+  notstarted: 'not_started',
+}
+
+/** Normalize backend phase statuses to a stable frontend vocabulary. */
+export function normalizePhaseStatus(status: string | null | undefined): string {
+  if (typeof status !== 'string') return 'unknown'
+  const trimmed = status.trim()
+  if (!trimmed) return 'unknown'
+  const canonical = trimmed.toLowerCase().replace(/[\s-]+/g, '_')
+  return PHASE_STATUS_ALIASES[canonical] ?? canonical
+}
+
+export function PhaseStatusIcon({ status }: { status: string }) {
+  const normalized = normalizePhaseStatus(status)
+  switch (normalized) {
+    case 'done':
+      return <CheckCircle2 size={12} className="text-[#89d185]" aria-hidden="true" />
+    case 'failed':
+      return <AlertCircle size={12} className="text-[#f44747]" aria-hidden="true" />
+    case 'running':
+    case 'queued':
+    case 'pending':
+    case 'partial':
+      return <Loader2 size={12} className="text-[#cca700]" aria-hidden="true" />
+    case 'skipped':
+    case 'canceled':
+    case 'cancel_requested':
+      return <MinusCircle size={12} className="text-[#6d6d6d]" aria-hidden="true" />
+    default:
+      return <div className="w-3 h-3 rounded-full border border-[#474747]" aria-hidden="true" />
+  }
+}

--- a/frontend/src/pages/ImageInspectorPage.tsx
+++ b/frontend/src/pages/ImageInspectorPage.tsx
@@ -5,6 +5,8 @@ import { ArrowLeft } from 'lucide-react'
 import { galleryApi } from '@/api/gallery'
 import { useUiStore } from '@/stores/uiStore'
 import { CollapsibleInspectorSection, KeyValueTable, formatInspectorValue } from '@/components/images/InspectorPrimitives'
+import { statusLabel } from '@/components/ui/badge'
+import { PhaseStatusIcon, normalizePhaseStatus } from '@/components/ui/phaseStatus'
 import type { ImageDetail, ImagePhaseStatusRow } from '@/types/api'
 
 function detailPreviewSrc(image: ImageDetail): string | null {
@@ -111,10 +113,22 @@ function PhaseStatusTable({ phases }: { phases: NonNullable<ImageDetail['phase_s
           {rows.map(([code, row]) => {
             const isString = typeof row === 'string'
             const r = isString ? null : (row as ImagePhaseStatusRow)
+            const rawStatus = isString ? row : r?.status
+            const normalizedStatus = normalizePhaseStatus(rawStatus)
+            const statusText = isString
+              ? row
+              : rawStatus
+                ? statusLabel(normalizedStatus)
+                : '—'
             return (
               <tr key={code} className="border-b border-[#2d2d2d] hover:bg-[#2a2a2a]">
                 <td className="px-2 py-1 font-mono text-[#4fc1ff]">{code}</td>
-                <td className="px-2 py-1">{isString ? row : r?.status ?? '—'}</td>
+                <td className="px-2 py-1">
+                  <div className="flex items-center gap-1.5">
+                    <PhaseStatusIcon status={normalizedStatus} />
+                    <span>{statusText}</span>
+                  </div>
+                </td>
                 <td className="px-2 py-1 text-[#6d6d6d] font-mono">
                   {isString ? '—' : r?.updated_at ? String(r.updated_at).slice(0, 19) : '—'}
                 </td>


### PR DESCRIPTION
### Motivation

- Phase status values from the backend are inconsistent in casing, spacing, and synonyms, causing the inspector UI to render varied text and icons.
- The Image Inspector’s phase status column should present a consistent, compact visual (icon + label) and reuse a shared normalization helper.
- Preserve legacy behavior for string-only rows while improving UX by showing an icon derived from a normalized value.

### Description

- Add a shared UI module `frontend/src/components/ui/phaseStatus.tsx` containing `normalizePhaseStatus(status)` and `PhaseStatusIcon` to normalize backend phase statuses and render a matching icon.
- Update `frontend/src/pages/ImageInspectorPage.tsx` to import `PhaseStatusIcon`, `normalizePhaseStatus`, and `statusLabel`, and render the Status cell as an inline row with icon + label using `flex items-center gap-1.5`.
- Normalize backend `status` values before rendering and use `statusLabel(normalized)` for the displayed label while preserving the string-row fallback (string rows still show their raw text but an icon is shown based on the normalized value).
- Leave the Error column logic unchanged so `last_error` / title and string-only fallbacks behave exactly as before.

### Testing

- Ran the frontend linter with `cd frontend && npm run -s lint`, which failed in this environment due to missing dev dependency `@eslint/js` (environment does not have frontend dev deps installed), so lint could not be validated here.
- No automated unit tests were modified or run as part of this change in this environment.
- Manual code inspection and local diffs confirm the new file and UI changes wire into `ImageInspectorPage` without backend/API changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e577b650048323b8352673e82fcb4c)