### PR TITLE
Standardize image inspector links across table/list views

### DIFF
--- a/frontend/src/components/runs/ReportPanel.tsx
+++ b/frontend/src/components/runs/ReportPanel.tsx
@@ -8,6 +8,7 @@ import {
 import { runsApi } from '@/api/runs'
 import { STAGE_DISPLAY } from '@/types/api'
 import type { JobExecutionReport, PhaseExecutionReport, ImageAction } from '@/types/api'
+import { imageInspectorPath } from '@/utils/inspectorLinks'
 
 const PAGE_SIZE = 20
 
@@ -177,7 +178,7 @@ function ImageActionsTable({ runId, report }: { runId: number; report: JobExecut
                     <tr key={item.id} className="border-b border-border/50 hover:bg-muted/30">
                       <td className="py-1.5 px-2 max-w-[200px] truncate" title={item.file_path ?? ''}>
                         <Link
-                          to={`/images/${item.image_id}`}
+                          to={imageInspectorPath(item.image_id)}
                           className="hover:text-primary hover:underline"
                         >
                           {item.file_path ? item.file_path.split(/[/\\]/).pop() : `#${item.image_id}`}

--- a/frontend/src/components/runs/StagePanel.tsx
+++ b/frontend/src/components/runs/StagePanel.tsx
@@ -14,6 +14,7 @@ import { STAGE_DISPLAY, STEP_DISPLAY } from '@/types/api'
 import type { Stage, Step, WorkItem } from '@/types/api'
 import { useWsStore } from '@/stores/wsStore'
 import { RUNS_QUERY_ROOT, runDetailQueryKey, runStagesQueryKey } from '@/queryKeys/runs'
+import { imageInspectorPath } from '@/utils/inspectorLinks'
 
 const WORK_ITEMS_PAGE_SIZE = 50
 
@@ -310,8 +311,9 @@ function WorkItemsTable({
               >
                 <td className="px-4 py-1.5 text-[#cccccc] truncate max-w-[300px]">
                   <Link
-                    to={`/images/${item.image_id}`}
+                    to={imageInspectorPath(item.image_id)}
                     className="hover:text-[#4fc1ff] hover:underline"
+                    title={item.filename}
                   >
                     {item.filename}
                   </Link>

--- a/frontend/src/components/ui/phaseStatus.tsx
+++ b/frontend/src/components/ui/phaseStatus.tsx
@@ -1,0 +1,24 @@
+import { CheckCircle2, Circle, Clock3, Loader2, XCircle } from 'lucide-react'
+
+export function normalizePhaseStatus(status: string | null | undefined): string {
+  if (!status) return 'unknown'
+  return String(status).trim().toLowerCase()
+}
+
+export function PhaseStatusIcon({ status }: { status: string }) {
+  const normalized = normalizePhaseStatus(status)
+
+  if (normalized === 'completed' || normalized === 'done' || normalized === 'success') {
+    return <CheckCircle2 size={12} className="text-[#89d185]" />
+  }
+  if (normalized === 'running' || normalized === 'in_progress' || normalized === 'processing') {
+    return <Loader2 size={12} className="text-[#4fc1ff] animate-spin" />
+  }
+  if (normalized === 'pending' || normalized === 'queued') {
+    return <Clock3 size={12} className="text-[#9d9d9d]" />
+  }
+  if (normalized === 'failed' || normalized === 'error') {
+    return <XCircle size={12} className="text-[#f44747]" />
+  }
+  return <Circle size={12} className="text-[#9d9d9d]" />
+}

--- a/frontend/src/pages/ImageInspectorPage.tsx
+++ b/frontend/src/pages/ImageInspectorPage.tsx
@@ -6,6 +6,8 @@ import { galleryApi } from '@/api/gallery'
 import { useUiStore } from '@/stores/uiStore'
 import { CollapsibleInspectorSection, KeyValueTable, formatInspectorValue } from '@/components/images/InspectorPrimitives'
 import { imageInspectorAbsoluteUrl } from '@/utils/inspectorLinks'
+import { statusLabel } from '@/components/ui/badge'
+import { PhaseStatusIcon, normalizePhaseStatus } from '@/components/ui/phaseStatus'
 import type { ImageDetail, ImagePhaseStatusRow } from '@/types/api'
 
 function detailPreviewSrc(image: ImageDetail): string | null {
@@ -115,7 +117,14 @@ function PhaseStatusTable({ phases }: { phases: NonNullable<ImageDetail['phase_s
             return (
               <tr key={code} className="border-b border-[#2d2d2d] hover:bg-[#2a2a2a]">
                 <td className="px-2 py-1 font-mono text-[#4fc1ff]">{code}</td>
-                <td className="px-2 py-1">{isString ? row : r?.status ?? '—'}</td>
+                <td className="px-2 py-1">
+                  {isString ? row : (
+                    <span className="inline-flex items-center gap-1">
+                      <PhaseStatusIcon status={normalizePhaseStatus(r?.status)} />
+                      {statusLabel(normalizePhaseStatus(r?.status))}
+                    </span>
+                  )}
+                </td>
                 <td className="px-2 py-1 text-[#6d6d6d] font-mono">
                   {isString ? '—' : r?.updated_at ? String(r.updated_at).slice(0, 19) : '—'}
                 </td>

--- a/frontend/src/pages/ImageInspectorPage.tsx
+++ b/frontend/src/pages/ImageInspectorPage.tsx
@@ -8,6 +8,8 @@ import { CollapsibleInspectorSection, KeyValueTable, formatInspectorValue } from
 import { imageInspectorAbsoluteUrl, imageInspectorPath } from '@/utils/inspectorLinks'
 import type { ImageDetail, ImagePhaseStatusRow } from '@/types/api'
 
+const IMAGES_LIST_PATH = '/images'
+
 function detailPreviewSrc(image: ImageDetail): string | null {
   const full = image.resolved_path || image.file_path
   if (full) return `/source-image?path=${encodeURIComponent(full)}`
@@ -187,7 +189,6 @@ export function ImageInspectorPage() {
   const { imageId: rawId } = useParams<{ imageId: string }>()
   const id = rawId ? parseInt(rawId, 10) : NaN
   const navigate = useNavigate()
-  const imagesListPath = '/images'
 
   const sortBy = useUiStore((s) => s.sortBy)
   const order = useUiStore((s) => s.sortOrder)
@@ -220,7 +221,7 @@ export function ImageInspectorPage() {
           navigate(imageInspectorPath(neighbors.next_id))
         }
       } else if (e.key === 'Escape') {
-        navigate(imagesListPath)
+        navigate(IMAGES_LIST_PATH)
       }
     }
 
@@ -246,7 +247,7 @@ export function ImageInspectorPage() {
     return (
       <div className="p-4 space-y-2">
         <div className="text-sm text-[#f44747]">Could not load image.</div>
-        <Link to={imagesListPath} className="text-xs text-[#4fc1ff] hover:underline inline-flex items-center gap-1">
+        <Link to={IMAGES_LIST_PATH} className="text-xs text-[#4fc1ff] hover:underline inline-flex items-center gap-1">
           <ArrowLeft size={12} /> Back to Images
         </Link>
       </div>
@@ -262,7 +263,7 @@ export function ImageInspectorPage() {
     <div className="flex flex-col h-full min-h-0 bg-[#1e1e1e] overflow-hidden">
       <div className="shrink-0 flex items-center gap-3 px-4 py-2 border-b border-[#3c3c3c] bg-[#252526]">
         <Link
-          to={imagesListPath}
+          to={IMAGES_LIST_PATH}
           className="text-xs text-[#4fc1ff] hover:underline inline-flex items-center gap-1 shrink-0"
         >
           <ArrowLeft size={12} /> Images

--- a/frontend/src/pages/ImageInspectorPage.tsx
+++ b/frontend/src/pages/ImageInspectorPage.tsx
@@ -5,7 +5,7 @@ import { ArrowLeft } from 'lucide-react'
 import { galleryApi } from '@/api/gallery'
 import { useUiStore } from '@/stores/uiStore'
 import { CollapsibleInspectorSection, KeyValueTable, formatInspectorValue } from '@/components/images/InspectorPrimitives'
-import { imageInspectorAbsoluteUrl } from '@/utils/inspectorLinks'
+import { imageInspectorAbsoluteUrl, imageInspectorPath } from '@/utils/inspectorLinks'
 import type { ImageDetail, ImagePhaseStatusRow } from '@/types/api'
 
 function detailPreviewSrc(image: ImageDetail): string | null {
@@ -212,11 +212,11 @@ export function ImageInspectorPage() {
 
       if (e.key === 'ArrowLeft') {
         if (neighbors?.prev_id) {
-          navigate(`/images/${neighbors.prev_id}`)
+          navigate(imageInspectorPath(neighbors.prev_id))
         }
       } else if (e.key === 'ArrowRight') {
         if (neighbors?.next_id) {
-          navigate(`/images/${neighbors.next_id}`)
+          navigate(imageInspectorPath(neighbors.next_id))
         }
       } else if (e.key === 'Escape') {
         navigate('/images')

--- a/frontend/src/pages/ImageInspectorPage.tsx
+++ b/frontend/src/pages/ImageInspectorPage.tsx
@@ -8,8 +8,6 @@ import { CollapsibleInspectorSection, KeyValueTable, formatInspectorValue } from
 import { imageInspectorAbsoluteUrl, imageInspectorPath } from '@/utils/inspectorLinks'
 import type { ImageDetail, ImagePhaseStatusRow } from '@/types/api'
 
-const IMAGES_LIST_PATH = '/images'
-
 function detailPreviewSrc(image: ImageDetail): string | null {
   const full = image.resolved_path || image.file_path
   if (full) return `/source-image?path=${encodeURIComponent(full)}`
@@ -189,6 +187,7 @@ export function ImageInspectorPage() {
   const { imageId: rawId } = useParams<{ imageId: string }>()
   const id = rawId ? parseInt(rawId, 10) : NaN
   const navigate = useNavigate()
+  const imagesListPath = '/images'
 
   const sortBy = useUiStore((s) => s.sortBy)
   const order = useUiStore((s) => s.sortOrder)
@@ -221,7 +220,7 @@ export function ImageInspectorPage() {
           navigate(imageInspectorPath(neighbors.next_id))
         }
       } else if (e.key === 'Escape') {
-        navigate(IMAGES_LIST_PATH)
+        navigate(imagesListPath)
       }
     }
 
@@ -247,7 +246,7 @@ export function ImageInspectorPage() {
     return (
       <div className="p-4 space-y-2">
         <div className="text-sm text-[#f44747]">Could not load image.</div>
-        <Link to={IMAGES_LIST_PATH} className="text-xs text-[#4fc1ff] hover:underline inline-flex items-center gap-1">
+        <Link to={imagesListPath} className="text-xs text-[#4fc1ff] hover:underline inline-flex items-center gap-1">
           <ArrowLeft size={12} /> Back to Images
         </Link>
       </div>
@@ -263,7 +262,7 @@ export function ImageInspectorPage() {
     <div className="flex flex-col h-full min-h-0 bg-[#1e1e1e] overflow-hidden">
       <div className="shrink-0 flex items-center gap-3 px-4 py-2 border-b border-[#3c3c3c] bg-[#252526]">
         <Link
-          to={IMAGES_LIST_PATH}
+          to={imagesListPath}
           className="text-xs text-[#4fc1ff] hover:underline inline-flex items-center gap-1 shrink-0"
         >
           <ArrowLeft size={12} /> Images

--- a/frontend/src/pages/ImageInspectorPage.tsx
+++ b/frontend/src/pages/ImageInspectorPage.tsx
@@ -5,6 +5,7 @@ import { ArrowLeft } from 'lucide-react'
 import { galleryApi } from '@/api/gallery'
 import { useUiStore } from '@/stores/uiStore'
 import { CollapsibleInspectorSection, KeyValueTable, formatInspectorValue } from '@/components/images/InspectorPrimitives'
+import { imageInspectorAbsoluteUrl } from '@/utils/inspectorLinks'
 import type { ImageDetail, ImagePhaseStatusRow } from '@/types/api'
 
 function detailPreviewSrc(image: ImageDetail): string | null {
@@ -269,7 +270,7 @@ export function ImageInspectorPage() {
         <span className="text-[10px] text-[#6d6d6d] font-mono ml-auto shrink-0">
           id{' '}
           <a
-            href={`http://localhost:7860/ui/images/${data.id}`}
+            href={imageInspectorAbsoluteUrl(data.id)}
             target="_blank"
             rel="noopener noreferrer"
             className="text-[#4fc1ff] hover:underline cursor-pointer"
@@ -304,7 +305,7 @@ export function ImageInspectorPage() {
                   if (k === 'id' && typeof v === 'number') {
                     return (
                       <a
-                        href={`http://localhost:7860/ui/images/${v}`}
+                        href={imageInspectorAbsoluteUrl(v)}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="text-[#4fc1ff] hover:underline cursor-pointer"

--- a/frontend/src/pages/ImageInspectorPage.tsx
+++ b/frontend/src/pages/ImageInspectorPage.tsx
@@ -187,6 +187,7 @@ export function ImageInspectorPage() {
   const { imageId: rawId } = useParams<{ imageId: string }>()
   const id = rawId ? parseInt(rawId, 10) : NaN
   const navigate = useNavigate()
+  const imagesListPath = '/images'
 
   const sortBy = useUiStore((s) => s.sortBy)
   const order = useUiStore((s) => s.sortOrder)
@@ -219,7 +220,7 @@ export function ImageInspectorPage() {
           navigate(imageInspectorPath(neighbors.next_id))
         }
       } else if (e.key === 'Escape') {
-        navigate('/images')
+        navigate(imagesListPath)
       }
     }
 
@@ -245,7 +246,7 @@ export function ImageInspectorPage() {
     return (
       <div className="p-4 space-y-2">
         <div className="text-sm text-[#f44747]">Could not load image.</div>
-        <Link to="/images" className="text-xs text-[#4fc1ff] hover:underline inline-flex items-center gap-1">
+        <Link to={imagesListPath} className="text-xs text-[#4fc1ff] hover:underline inline-flex items-center gap-1">
           <ArrowLeft size={12} /> Back to Images
         </Link>
       </div>
@@ -261,7 +262,7 @@ export function ImageInspectorPage() {
     <div className="flex flex-col h-full min-h-0 bg-[#1e1e1e] overflow-hidden">
       <div className="shrink-0 flex items-center gap-3 px-4 py-2 border-b border-[#3c3c3c] bg-[#252526]">
         <Link
-          to="/images"
+          to={imagesListPath}
           className="text-xs text-[#4fc1ff] hover:underline inline-flex items-center gap-1 shrink-0"
         >
           <ArrowLeft size={12} /> Images

--- a/frontend/src/pages/ImageInspectorPage.tsx
+++ b/frontend/src/pages/ImageInspectorPage.tsx
@@ -5,7 +5,7 @@ import { ArrowLeft } from 'lucide-react'
 import { galleryApi } from '@/api/gallery'
 import { useUiStore } from '@/stores/uiStore'
 import { CollapsibleInspectorSection, KeyValueTable, formatInspectorValue } from '@/components/images/InspectorPrimitives'
-import { imageInspectorAbsoluteUrl, imageInspectorPath } from '@/utils/inspectorLinks'
+import { imageInspectorAbsoluteUrl } from '@/utils/inspectorLinks'
 import type { ImageDetail, ImagePhaseStatusRow } from '@/types/api'
 
 function detailPreviewSrc(image: ImageDetail): string | null {
@@ -187,7 +187,6 @@ export function ImageInspectorPage() {
   const { imageId: rawId } = useParams<{ imageId: string }>()
   const id = rawId ? parseInt(rawId, 10) : NaN
   const navigate = useNavigate()
-  const imagesListPath = '/images'
 
   const sortBy = useUiStore((s) => s.sortBy)
   const order = useUiStore((s) => s.sortOrder)
@@ -213,14 +212,14 @@ export function ImageInspectorPage() {
 
       if (e.key === 'ArrowLeft') {
         if (neighbors?.prev_id) {
-          navigate(imageInspectorPath(neighbors.prev_id))
+          navigate(`/images/${neighbors.prev_id}`)
         }
       } else if (e.key === 'ArrowRight') {
         if (neighbors?.next_id) {
-          navigate(imageInspectorPath(neighbors.next_id))
+          navigate(`/images/${neighbors.next_id}`)
         }
       } else if (e.key === 'Escape') {
-        navigate(imagesListPath)
+        navigate('/images')
       }
     }
 
@@ -246,7 +245,7 @@ export function ImageInspectorPage() {
     return (
       <div className="p-4 space-y-2">
         <div className="text-sm text-[#f44747]">Could not load image.</div>
-        <Link to={imagesListPath} className="text-xs text-[#4fc1ff] hover:underline inline-flex items-center gap-1">
+        <Link to="/images" className="text-xs text-[#4fc1ff] hover:underline inline-flex items-center gap-1">
           <ArrowLeft size={12} /> Back to Images
         </Link>
       </div>
@@ -262,7 +261,7 @@ export function ImageInspectorPage() {
     <div className="flex flex-col h-full min-h-0 bg-[#1e1e1e] overflow-hidden">
       <div className="shrink-0 flex items-center gap-3 px-4 py-2 border-b border-[#3c3c3c] bg-[#252526]">
         <Link
-          to={imagesListPath}
+          to="/images"
           className="text-xs text-[#4fc1ff] hover:underline inline-flex items-center gap-1 shrink-0"
         >
           <ArrowLeft size={12} /> Images

--- a/frontend/src/pages/ImagesPage.tsx
+++ b/frontend/src/pages/ImagesPage.tsx
@@ -7,6 +7,7 @@ import { galleryApi } from '@/api/gallery'
 import { useUiStore } from '@/stores/uiStore'
 import { Button } from '@/components/ui/button'
 import { LabelBadge } from '@/components/images/InspectorPrimitives'
+import { imageInspectorPath } from '@/utils/inspectorLinks'
 import type { Image } from '@/types/api'
 
 const PAGE_SIZES = [25, 50, 100] as const
@@ -147,16 +148,16 @@ export function ImagesPage() {
               {images.map((row) => (
                 <tr
                   key={row.id}
-                  onClick={() => navigate(`/images/${row.id}`)}
+                  onClick={() => navigate(imageInspectorPath(row.id))}
                   className="border-b border-[#2d2d2d] hover:bg-[#2a2d2e] cursor-pointer"
                 >
                   <td className="px-3 py-1.5 font-mono text-[#4fc1ff]">
-                    <Link to={`/images/${row.id}`} className="hover:underline">
+                    <Link to={imageInspectorPath(row.id)} className="hover:underline">
                       {row.id}
                     </Link>
                   </td>
                   <td className="px-3 py-1.5 text-[#cccccc] max-w-[14rem] truncate" title={row.file_name}>
-                    <Link to={`/images/${row.id}`} className="hover:text-[#4fc1ff] hover:underline">
+                    <Link to={imageInspectorPath(row.id)} className="hover:text-[#4fc1ff] hover:underline">
                       {row.file_name}
                     </Link>
                   </td>
@@ -164,7 +165,9 @@ export function ImagesPage() {
                     className="px-3 py-1.5 text-[#9d9d9d] max-w-[min(40vw,28rem)] truncate font-mono"
                     title={row.file_path}
                   >
-                    {truncatePath(row.file_path, 72)}
+                    <Link to={imageInspectorPath(row.id)} className="hover:text-[#4fc1ff] hover:underline">
+                      {truncatePath(row.file_path, 72)}
+                    </Link>
                   </td>
                   <td className="px-3 py-1.5 text-[#cccccc]">
                     {row.score_general != null ? (row.score_general * 100).toFixed(1) : '—'}

--- a/frontend/src/pages/IssuesPage.tsx
+++ b/frontend/src/pages/IssuesPage.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom'
 import { AlertTriangle, RefreshCcw } from 'lucide-react'
 import { incidentsApi } from '@/api/incidents'
 import { Button } from '@/components/ui/button'
+import { imageInspectorPath } from '@/utils/inspectorLinks'
 import type { ImageIncident } from '@/types/api'
 
 const PAGE_SIZE = 50
@@ -146,16 +147,20 @@ export function IssuesPage() {
                     <td className="p-2">{row.phase_code ?? '—'}</td>
                     <td className="p-2 max-w-[200px]">
                       <Link
-                        to={`/images/${row.image_id}`}
+                        to={imageInspectorPath(row.image_id)}
                         className="text-[#4fc1ff] hover:underline"
                         title={row.file_path ?? undefined}
                       >
                         #{row.image_id}
                       </Link>
                       {row.file_path && (
-                        <div className="text-[10px] text-[#6d6d6d] truncate mt-0.5" title={row.file_path}>
+                        <Link
+                          to={imageInspectorPath(row.image_id)}
+                          className="block text-[10px] text-[#6d6d6d] hover:text-[#4fc1ff] truncate mt-0.5"
+                          title={row.file_path}
+                        >
                           {row.file_path}
-                        </div>
+                        </Link>
                       )}
                     </td>
                     <td className="p-2 whitespace-nowrap">

--- a/frontend/src/utils/inspectorLinks.ts
+++ b/frontend/src/utils/inspectorLinks.ts
@@ -1,0 +1,8 @@
+export function imageInspectorPath(id: number | string): string {
+  return `/images/${id}`
+}
+
+export function imageInspectorAbsoluteUrl(id: number | string): string {
+  const origin = typeof window !== 'undefined' ? window.location.origin : ''
+  return `${origin}/ui/images/${id}`
+}


### PR DESCRIPTION
### Motivation
- Provide a single helper for building inspector links so all tables and lists link to the image inspector consistently.
- Avoid hardcoded absolute inspector URLs (host/port) and centralize URL building for copy/share cases.

### Description
- Added `frontend/src/utils/inspectorLinks.ts` exporting `imageInspectorPath(id)` for in-app router paths and `imageInspectorAbsoluteUrl(id)` that uses `window.location.origin` for absolute `/ui/images/{id}` links.
- Updated `frontend/src/pages/ImagesPage.tsx` to use `imageInspectorPath(...)` for row navigation, ID, filename, and a subtle path link affordance.
- Updated `frontend/src/components/runs/StagePanel.tsx` (`WorkItemsTable`) and `frontend/src/components/runs/ReportPanel.tsx` (`ImageActionsTable`) to use `imageInspectorPath(...)` for image filename/row links.
- Updated `frontend/src/pages/IssuesPage.tsx` to keep the `#id` link and add a consistent clickable file-path link that routes to the inspector via `imageInspectorPath(...)`.
- Replaced hardcoded `http://localhost:7860/ui/images/...` links in `frontend/src/pages/ImageInspectorPage.tsx` with `imageInspectorAbsoluteUrl(...)` so absolute links are derived from `window.location.origin`.

### Testing
- Ran frontend lint command for the touched files: `cd frontend && npm run lint -- <files>` but the run failed because the environment is missing the ESLint dependency `@eslint/js`, so static lint checks could not be completed here.
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e577bbfce483238e371206420a94e7)