### PR TITLE
frontend: standardize image inspector links with shared route helper

### DIFF
--- a/frontend/src/components/runs/ReportPanel.tsx
+++ b/frontend/src/components/runs/ReportPanel.tsx
@@ -8,6 +8,7 @@ import {
 import { runsApi } from '@/api/runs'
 import { STAGE_DISPLAY } from '@/types/api'
 import type { JobExecutionReport, PhaseExecutionReport, ImageAction } from '@/types/api'
+import { imageInspectorPath } from '@/utils/routes'
 
 const PAGE_SIZE = 20
 
@@ -177,7 +178,7 @@ function ImageActionsTable({ runId, report }: { runId: number; report: JobExecut
                     <tr key={item.id} className="border-b border-border/50 hover:bg-muted/30">
                       <td className="py-1.5 px-2 max-w-[200px] truncate" title={item.file_path ?? ''}>
                         <Link
-                          to={`/images/${item.image_id}`}
+                          to={imageInspectorPath(item.image_id)}
                           className="hover:text-primary hover:underline"
                         >
                           {item.file_path ? item.file_path.split(/[/\\]/).pop() : `#${item.image_id}`}

--- a/frontend/src/components/runs/StagePanel.tsx
+++ b/frontend/src/components/runs/StagePanel.tsx
@@ -15,6 +15,7 @@ import { STAGE_DISPLAY, STEP_DISPLAY } from '@/types/api'
 import type { Stage, Step, WorkItem } from '@/types/api'
 import { useWsStore } from '@/stores/wsStore'
 import { RUNS_QUERY_ROOT, runDetailQueryKey, runStagesQueryKey } from '@/queryKeys/runs'
+import { imageInspectorPath } from '@/utils/routes'
 
 const WORK_ITEMS_PAGE_SIZE = 50
 
@@ -311,7 +312,7 @@ function WorkItemsTable({
               >
                 <td className="px-4 py-1.5 text-[#cccccc] truncate max-w-[300px]">
                   <Link
-                    to={`/images/${item.image_id}`}
+                    to={imageInspectorPath(item.image_id)}
                     className="hover:text-[#4fc1ff] hover:underline"
                   >
                     {item.filename}

--- a/frontend/src/pages/ImageInspectorPage.tsx
+++ b/frontend/src/pages/ImageInspectorPage.tsx
@@ -3,6 +3,7 @@ import { Link, useParams, useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { ArrowLeft } from 'lucide-react'
 import { galleryApi } from '@/api/gallery'
+import { imageInspectorPath } from '@/utils/routes'
 import { useUiStore } from '@/stores/uiStore'
 import { CollapsibleInspectorSection, KeyValueTable, formatInspectorValue } from '@/components/images/InspectorPrimitives'
 import { statusLabel } from '@/components/ui/badge'
@@ -225,11 +226,11 @@ export function ImageInspectorPage() {
 
       if (e.key === 'ArrowLeft') {
         if (neighbors?.prev_id) {
-          navigate(`/images/${neighbors.prev_id}`)
+          navigate(imageInspectorPath(neighbors.prev_id))
         }
       } else if (e.key === 'ArrowRight') {
         if (neighbors?.next_id) {
-          navigate(`/images/${neighbors.next_id}`)
+          navigate(imageInspectorPath(neighbors.next_id))
         }
       } else if (e.key === 'Escape') {
         navigate('/images')
@@ -282,14 +283,12 @@ export function ImageInspectorPage() {
         <span className="text-sm font-medium text-[#cccccc] truncate">{data.file_name}</span>
         <span className="text-[10px] text-[#6d6d6d] font-mono ml-auto shrink-0">
           id{' '}
-          <a
-            href={`http://localhost:7860/ui/images/${data.id}`}
-            target="_blank"
-            rel="noopener noreferrer"
+          <Link
+            to={imageInspectorPath(data.id)}
             className="text-[#4fc1ff] hover:underline cursor-pointer"
           >
             {data.id}
-          </a>
+          </Link>
         </span>
       </div>
 
@@ -317,14 +316,12 @@ export function ImageInspectorPage() {
                 renderValue={(k, v) => {
                   if (k === 'id' && typeof v === 'number') {
                     return (
-                      <a
-                        href={`http://localhost:7860/ui/images/${v}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
+                      <Link
+                        to={imageInspectorPath(v)}
                         className="text-[#4fc1ff] hover:underline cursor-pointer"
                       >
                         {v}
-                      </a>
+                      </Link>
                     )
                   }
                   return formatInspectorValue(v)

--- a/frontend/src/pages/ImagesPage.tsx
+++ b/frontend/src/pages/ImagesPage.tsx
@@ -7,6 +7,7 @@ import { galleryApi } from '@/api/gallery'
 import { useUiStore } from '@/stores/uiStore'
 import { Button } from '@/components/ui/button'
 import { LabelBadge } from '@/components/images/InspectorPrimitives'
+import { imageInspectorPath } from '@/utils/routes'
 import type { Image } from '@/types/api'
 
 const PAGE_SIZES = [25, 50, 100] as const
@@ -147,16 +148,16 @@ export function ImagesPage() {
               {images.map((row) => (
                 <tr
                   key={row.id}
-                  onClick={() => navigate(`/images/${row.id}`)}
+                  onClick={() => navigate(imageInspectorPath(row.id))}
                   className="border-b border-[#2d2d2d] hover:bg-[#2a2d2e] cursor-pointer"
                 >
                   <td className="px-3 py-1.5 font-mono text-[#4fc1ff]">
-                    <Link to={`/images/${row.id}`} className="hover:underline">
+                    <Link to={imageInspectorPath(row.id)} className="hover:underline">
                       {row.id}
                     </Link>
                   </td>
                   <td className="px-3 py-1.5 text-[#cccccc] max-w-[14rem] truncate" title={row.file_name}>
-                    <Link to={`/images/${row.id}`} className="hover:text-[#4fc1ff] hover:underline">
+                    <Link to={imageInspectorPath(row.id)} className="hover:text-[#4fc1ff] hover:underline">
                       {row.file_name}
                     </Link>
                   </td>

--- a/frontend/src/pages/IssuesPage.tsx
+++ b/frontend/src/pages/IssuesPage.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom'
 import { AlertTriangle, RefreshCcw } from 'lucide-react'
 import { incidentsApi } from '@/api/incidents'
 import { Button } from '@/components/ui/button'
+import { imageInspectorPath } from '@/utils/routes'
 import type { ImageIncident } from '@/types/api'
 
 const PAGE_SIZE = 50
@@ -146,7 +147,7 @@ export function IssuesPage() {
                     <td className="p-2">{row.phase_code ?? '—'}</td>
                     <td className="p-2 max-w-[200px]">
                       <Link
-                        to={`/images/${row.image_id}`}
+                        to={imageInspectorPath(row.image_id)}
                         className="text-[#4fc1ff] hover:underline"
                         title={row.file_path ?? undefined}
                       >

--- a/frontend/src/utils/routes.ts
+++ b/frontend/src/utils/routes.ts
@@ -1,0 +1,3 @@
+export function imageInspectorPath(id: string | number): string {
+  return `/images/${id}`
+}


### PR DESCRIPTION
### Motivation
- Provide a small, single-source helper for inspector routes to eliminate scattered string literals and hardcoded host/port assumptions and make links easy to update (`imageInspectorPath(id) => /images/${id}`).
- Replace absolute `http://localhost:7860` inspector anchors and inconsistent link construction with in-app React Router navigation to avoid environment-specific breakage and improve merge safety.
- Keep changes minimal and focused to reduce conflict risk and avoid unrelated refactors.

### Description
- Added `frontend/src/utils/routes.ts` with a single helper `imageInspectorPath(id: string | number): string` that returns `/images/${id}`.
- Replaced direct string literals and absolute anchors with the helper and React Router `<Link>` (or `navigate`) in the following files: `frontend/src/pages/ImagesPage.tsx`, `frontend/src/components/runs/StagePanel.tsx`, `frontend/src/components/runs/ReportPanel.tsx`, `frontend/src/pages/IssuesPage.tsx`, and `frontend/src/pages/ImageInspectorPage.tsx`.
- Removed hardcoded `http://localhost:7860/ui/images/...` anchors in `ImageInspectorPage` and replaced them with `Link` + `imageInspectorPath(...)` for consistent in-app behavior.
- Phase-status UI and normalization logic were left unchanged to avoid unrelated churn.

### Testing
- Ran conflict marker scan: `rg -n "^<<<<<<<|^=======|^>>>>>>>\

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e58781addc8323907b5ad54dadc058)