### PR TITLE
chore(ci): add cross-repo sync notice workflow

### DIFF
--- a/.github/workflows/cross-repo-sync-notice.yml
+++ b/.github/workflows/cross-repo-sync-notice.yml
@@ -1,0 +1,58 @@
+name: Cross-repo sync notice
+
+on:
+  pull_request:
+    paths:
+      - 'openapi.json'
+      - 'migrations/versions/**'
+      - 'modules/api.py'
+      - 'modules/db_postgres.py'
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  notice:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post or update cross-repo sync notice
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          MARKER='<!-- cross-repo-sync-notice -->'
+
+          BODY=$(cat <<'EOF'
+          <!-- cross-repo-sync-notice -->
+          ### Cross-repo sync notice
+
+          This PR changes backend API or schema (`openapi.json`, `migrations/versions/**`, `modules/api.py`, or `modules/db_postgres.py`).
+
+          The **image-scoring-gallery** repo likely needs follow-up updates:
+
+          - [ ] `api-contract/openapi.json` — re-sync from this PR's `openapi.json`
+          - [ ] `electron/apiTypes.ts` — regenerate via `npm run api:types:generate`
+          - [ ] `electron/apiService.ts` — update if endpoint paths or shapes changed
+          - [ ] `electron/db.ts` — update if column names, types, or queries changed
+
+          See [`docs/technical/AGENT_COORDINATION.md`](https://github.com/synthet/image-scoring-backend/blob/master/docs/technical/AGENT_COORDINATION.md) for the full coordination protocol.
+
+          **Discipline tracking:** [image-scoring-gallery#71](https://github.com/synthet/image-scoring-gallery/issues/71)
+
+          _This comment is auto-posted by `.github/workflows/cross-repo-sync-notice.yml` and updates in place on subsequent pushes._
+          EOF
+          )
+
+          EXISTING_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            | jq -r --arg marker "$MARKER" '[.[] | select(.body | startswith($marker))] | first | .id // empty')
+
+          if [ -n "$EXISTING_ID" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$EXISTING_ID" -f body="$BODY" >/dev/null
+            echo "Updated existing sync-notice comment ($EXISTING_ID)."
+          else
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$BODY"
+            echo "Posted new sync-notice comment."
+          fi

--- a/docs/technical/AGENT_COORDINATION.md
+++ b/docs/technical/AGENT_COORDINATION.md
@@ -61,6 +61,17 @@ COALESCE(
 
 **Docs:** [`PHASE4_KEYWORDS_HUB.md`](../planning/database/PHASE4_KEYWORDS_HUB.md) (index), [`PHASE4_KEYWORDS_DEPRECATION.md`](../planning/database/PHASE4_KEYWORDS_DEPRECATION.md), archived completion summary [`PHASE4_COMPLETION_SUMMARY.md`](../archive/plans/database/PHASE4_COMPLETION_SUMMARY.md)
 
+### 5. Cross-repo Sync Automation
+
+To keep the discipline above from being silently skipped, this repo runs the [`Cross-repo sync notice`](../../.github/workflows/cross-repo-sync-notice.yml) workflow on every PR that touches:
+
+* `openapi.json` (REST contract)
+* `migrations/versions/**` (Alembic schema)
+* `modules/api.py` (FastAPI surface)
+* `modules/db_postgres.py` (PostgreSQL schema authority)
+
+The workflow posts (and idempotently updates) a comment listing the gallery files that typically need follow-up — `api-contract/openapi.json`, `electron/apiTypes.ts`, `electron/apiService.ts`, `electron/db.ts` — and links back to the discipline-tracking issue [`image-scoring-gallery#71`](https://github.com/synthet/image-scoring-gallery/issues/71). The comment is a nudge, not a hard gate; reviewers are still responsible for confirming the gallery side is updated or a counterpart issue is filed.
+
 ## 🔍 Troubleshooting with MCP
 
 Agents use **stdio** MCP against the Python backend: **`imgscore-py-stdio`** in the **image-scoring-backend** workspace; **`imgscore-el-stdio`** in **image-scoring-gallery** (same server, different `cwd`). For WebUI / **`execute_code`**, enable **`imgscore-py-sse`** or **`imgscore-el-sse`** (unique keys, same URL). Use these to diagnose cross-project issues:


### PR DESCRIPTION
## Issue

Closes synthet/image-scoring-gallery#71

The discipline issue lives in the gallery repo, but the trigger that drives the cross-repo sync (backend API or schema changes) lives here, so the automation is implemented in this repo.

## Backlog hygiene

- [x] Card moved to `Stage = Review` on the [Project board](https://github.com/users/synthet/projects/1)
- [x] Cross-repo: counterpart is the linked issue above (gallery#71 itself)
- [x] API contract / OpenAPI / `API.md` — N/A, this PR adds notification automation, not a contract change

## Summary

**What changed:**

- New workflow `.github/workflows/cross-repo-sync-notice.yml` triggers on PRs that touch `openapi.json`, `migrations/versions/**`, `modules/api.py`, or `modules/db_postgres.py`. It posts (and idempotently updates via a `<!-- cross-repo-sync-notice -->` HTML marker) a PR comment listing the gallery files that typically need follow-up — `api-contract/openapi.json`, `electron/apiTypes.ts`, `electron/apiService.ts`, `electron/db.ts` — and links back to the discipline-tracking issue.
- New §5 in `docs/technical/AGENT_COORDINATION.md` documenting the workflow's trigger paths, behavior, and that the comment is a nudge, not a hard gate.

## Motivation

Until now the cross-repo sync between `image-scoring-backend` (API/schema authority) and `image-scoring-gallery` (consumer) has been entirely manual. `AGENT_COORDINATION.md` documented the protocol but nothing actually fired when the backend changed. A bottom-of-template checkbox is easy to miss; a sticky PR comment is much more visible to reviewers.

## How to test

The workflow only runs on PRs that touch one of the four trigger paths. To validate end-to-end on a follow-up PR:
1. Touch any of the trigger paths (e.g. tweak `openapi.json` whitespace).
2. Confirm a comment with the `<!-- cross-repo-sync-notice -->` marker appears.
3. Push another commit on the same PR — confirm the comment is updated in place (not duplicated).

This PR itself does not touch any trigger path, so the workflow won't run on the PR that introduces it. That's expected.

**Risk / testing notes:** The workflow uses only `${{ secrets.GITHUB_TOKEN }}` with `pull-requests: write` and `issues: write` permissions. No checkout of PR head code, so safe even if `pull_request_target` is needed later for forks.

## Risk / rollout

- Low risk. Adds a single advisory workflow; if it errors, it does not block merges (no required check is added).
- No migrations, no schema changes, no API surface changes.
- Easy to revert by deleting the workflow file.

## SDLC checklist (agent-sdlc)

- [x] Tests added or updated as needed — N/A, declarative GH Actions workflow
- [x] Lint / typecheck pass — workflow is YAML; no project lints touched
- [x] No secrets or credentials in code
- [x] Docs updated if behavior is user-visible — `AGENT_COORDINATION.md` §5 added