### PR TITLE
feat(atlas): drive embedding-space dropdown from /api/embedding_spaces

### DIFF
--- a/frontend/src/features/embedding-atlas/components/ProjectionSettingsDialog.tsx
+++ b/frontend/src/features/embedding-atlas/components/ProjectionSettingsDialog.tsx
@@ -1,6 +1,12 @@
 import * as Dialog from '@radix-ui/react-dialog';
 import { Settings, X } from 'lucide-react';
 import type { FetchEmbeddingMapParams } from '../hooks/useEmbeddingMap';
+import {
+  FALLBACK_DEFAULT_SPACE_CODE,
+  resolveDefaultSpaceCode,
+  useEmbeddingSpaces,
+  type EmbeddingSpace,
+} from '../hooks/useEmbeddingSpaces';
 
 interface ProjectionSettingsDialogProps {
   params: FetchEmbeddingMapParams;
@@ -8,7 +14,21 @@ interface ProjectionSettingsDialogProps {
   onRefresh: () => void;
 }
 
+function formatSpaceLabel(space: EmbeddingSpace): string {
+  const base = space.description?.trim() || space.code;
+  return `${base} (${space.dim}d)`;
+}
+
 export function ProjectionSettingsDialog({ params, setParams, onRefresh }: ProjectionSettingsDialogProps) {
+  const { data: spacesData, isLoading: spacesLoading, error: spacesError } = useEmbeddingSpaces();
+  const spaces = spacesData?.spaces ?? [];
+  const defaultCode = resolveDefaultSpaceCode(spacesData);
+  const selectedCode = params.space_code || defaultCode || FALLBACK_DEFAULT_SPACE_CODE;
+
+  // If the currently-selected code isn't in the registry, surface it as an extra option
+  // so the select doesn't silently snap to another value.
+  const hasSelected = spaces.some((s) => s.code === selectedCode);
+
   return (
     <Dialog.Root>
       <Dialog.Trigger asChild>
@@ -17,7 +37,7 @@ export function ProjectionSettingsDialog({ params, setParams, onRefresh }: Proje
           Settings
         </button>
       </Dialog.Trigger>
-      
+
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50" />
         <Dialog.Content className="fixed left-[50%] top-[50%] max-h-[85vh] w-[90vw] max-w-[450px] translate-x-[-50%] translate-y-[-50%] rounded-xl bg-slate-900 p-6 shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] focus:outline-none z-50 border border-slate-700">
@@ -31,31 +51,45 @@ export function ProjectionSettingsDialog({ params, setParams, onRefresh }: Proje
               </button>
             </Dialog.Close>
           </div>
-          
+
           <div className="space-y-4">
             <div className="flex flex-col gap-1">
               <label className="text-sm font-medium text-slate-300" htmlFor="spaceCode">
                 Embedding Space
               </label>
-              <select 
-                id="spaceCode" 
-                className="rounded bg-slate-950 border border-slate-700 px-3 py-2 text-sm text-slate-200"
-                value={params.space_code || 'mobilenet_v2_imagenet_gap'}
+              <select
+                id="spaceCode"
+                className="rounded bg-slate-950 border border-slate-700 px-3 py-2 text-sm text-slate-200 disabled:opacity-60"
+                value={selectedCode}
+                disabled={spacesLoading}
                 onChange={(e) => setParams({ ...params, space_code: e.target.value })}
               >
-                <option value="mobilenet_v2_imagenet_gap">MobileNetV2 (1280d)</option>
-                <option value="clip_vit_b32_image">CLIP ViT-B/32 (512d)</option>
-                <option value="blip_vit_b16_image">BLIP ViT-B/16 (256d)</option>
-                <option value="bioclip_2_image">BioCLIP 2 (512d)</option>
+                {spacesLoading && spaces.length === 0 ? (
+                  <option value={selectedCode}>Loading…</option>
+                ) : null}
+                {spaces.map((s) => (
+                  <option key={s.code} value={s.code}>
+                    {formatSpaceLabel(s)}
+                    {s.is_default ? ' — default' : ''}
+                  </option>
+                ))}
+                {!hasSelected && !spacesLoading ? (
+                  <option value={selectedCode}>{selectedCode} (unknown)</option>
+                ) : null}
               </select>
+              {spacesError ? (
+                <p className="text-xs text-amber-400">
+                  Could not load embedding spaces — using fallback default.
+                </p>
+              ) : null}
             </div>
 
             <div className="flex flex-col gap-1">
               <label className="text-sm font-medium text-slate-300" htmlFor="method">
                 Method
               </label>
-              <select 
-                id="method" 
+              <select
+                id="method"
                 className="rounded bg-slate-950 border border-slate-700 px-3 py-2 text-sm text-slate-200"
                 value={params.method || 'umap'}
                 onChange={(e) => setParams({ ...params, method: e.target.value as 'umap' | 'tsne' })}
@@ -71,10 +105,9 @@ export function ProjectionSettingsDialog({ params, setParams, onRefresh }: Proje
                   Close
                 </button>
               </Dialog.Close>
-              <button 
+              <button
                 onClick={() => {
                   onRefresh();
-                  // Ideally close dialog here too
                 }}
                 className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
               >

--- a/frontend/src/features/embedding-atlas/hooks/useEmbeddingSpaces.test.ts
+++ b/frontend/src/features/embedding-atlas/hooks/useEmbeddingSpaces.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import {
+  FALLBACK_DEFAULT_SPACE_CODE,
+  resolveDefaultSpaceCode,
+  type EmbeddingSpacesData,
+} from './useEmbeddingSpaces';
+
+describe('resolveDefaultSpaceCode', () => {
+  it('falls back when data is undefined', () => {
+    expect(resolveDefaultSpaceCode(undefined)).toBe(FALLBACK_DEFAULT_SPACE_CODE);
+  });
+
+  it('prefers meta.default_code when present', () => {
+    const data: EmbeddingSpacesData = {
+      spaces: [
+        { code: 'clip_vit_b32_image', dim: 512, description: 'CLIP', active: true, is_default: false },
+      ],
+      meta: { default_code: 'clip_vit_b32_image', engine: 'postgres' },
+    };
+    expect(resolveDefaultSpaceCode(data)).toBe('clip_vit_b32_image');
+  });
+
+  it('uses the is_default flag when meta is empty', () => {
+    const data: EmbeddingSpacesData = {
+      spaces: [
+        { code: 'a', dim: 256, description: null, active: true, is_default: false },
+        { code: 'b', dim: 512, description: null, active: true, is_default: true },
+      ],
+      meta: { default_code: '', engine: 'postgres' },
+    };
+    expect(resolveDefaultSpaceCode(data)).toBe('b');
+  });
+
+  it('falls back to first space when nothing is flagged', () => {
+    const data: EmbeddingSpacesData = {
+      spaces: [
+        { code: 'first', dim: 256, description: null, active: true, is_default: false },
+        { code: 'second', dim: 512, description: null, active: true, is_default: false },
+      ],
+      meta: { default_code: '', engine: 'postgres' },
+    };
+    expect(resolveDefaultSpaceCode(data)).toBe('first');
+  });
+
+  it('falls back to MobileNetV2 when the registry is empty', () => {
+    const data: EmbeddingSpacesData = {
+      spaces: [],
+      meta: { default_code: '', engine: 'firebird' },
+    };
+    expect(resolveDefaultSpaceCode(data)).toBe(FALLBACK_DEFAULT_SPACE_CODE);
+  });
+});

--- a/frontend/src/features/embedding-atlas/hooks/useEmbeddingSpaces.ts
+++ b/frontend/src/features/embedding-atlas/hooks/useEmbeddingSpaces.ts
@@ -1,0 +1,60 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '@/api/client';
+
+export const FALLBACK_DEFAULT_SPACE_CODE = 'mobilenet_v2_imagenet_gap';
+
+export interface EmbeddingSpace {
+  code: string;
+  dim: number;
+  description: string | null;
+  active: boolean;
+  is_default: boolean;
+}
+
+export interface EmbeddingSpacesData {
+  spaces: EmbeddingSpace[];
+  meta: {
+    default_code: string;
+    engine: string;
+  };
+}
+
+interface RawEnvelope {
+  data?: EmbeddingSpacesData;
+  spaces?: EmbeddingSpace[];
+  meta?: EmbeddingSpacesData['meta'];
+}
+
+function unwrap(res: RawEnvelope): EmbeddingSpacesData {
+  if (res.data && Array.isArray(res.data.spaces)) return res.data;
+  if (Array.isArray(res.spaces)) {
+    return {
+      spaces: res.spaces,
+      meta: res.meta ?? { default_code: FALLBACK_DEFAULT_SPACE_CODE, engine: 'unknown' },
+    };
+  }
+  return {
+    spaces: [],
+    meta: { default_code: FALLBACK_DEFAULT_SPACE_CODE, engine: 'unknown' },
+  };
+}
+
+export function useEmbeddingSpaces() {
+  return useQuery({
+    queryKey: ['embeddingSpaces'],
+    queryFn: async () => {
+      const res = await api.get<RawEnvelope>('/embedding_spaces');
+      return unwrap(res);
+    },
+    staleTime: Infinity,
+  });
+}
+
+export function resolveDefaultSpaceCode(data: EmbeddingSpacesData | undefined): string {
+  if (!data) return FALLBACK_DEFAULT_SPACE_CODE;
+  if (data.meta?.default_code) return data.meta.default_code;
+  const flagged = data.spaces.find((s) => s.is_default);
+  if (flagged) return flagged.code;
+  if (data.spaces.length > 0) return data.spaces[0].code;
+  return FALLBACK_DEFAULT_SPACE_CODE;
+}

--- a/frontend/src/features/embedding-atlas/pages/EmbeddingAtlasPage.tsx
+++ b/frontend/src/features/embedding-atlas/pages/EmbeddingAtlasPage.tsx
@@ -30,7 +30,6 @@ export function EmbeddingAtlasPage() {
   const inspectorPanelRef = usePanelRef();
 
   const [params, setParams] = useState<FetchEmbeddingMapParams>({
-    space_code: 'mobilenet_v2_imagenet_gap',
     method: 'umap',
   });
 


### PR DESCRIPTION
## Summary
- Replace the hardcoded `space_code` initial value and static `<option>` list in the Atlas page with a registry-driven dropdown.
- New `useEmbeddingSpaces` TanStack Query hook wraps `GET /api/embedding_spaces` (cached with `staleTime: Infinity` — registry rarely changes per session).
- `ProjectionSettingsDialog` now renders spaces from the hook, surfaces a fallback warning if the request fails, and shows a synthetic `<option>` when the currently-selected code isn't in the registry (avoids silent snap to another value).
- Default resolution: `meta.default_code` → first `is_default` row → first row → `mobilenet_v2_imagenet_gap` constant.

## Acceptance (from #133)
- [x] `useEmbeddingSpaces` hook wraps `/api/embedding_spaces`
- [x] Dialog populates `<select>` from the hook (no static list)
- [x] Falls back to `mobilenet_v2_imagenet_gap` if the registry is empty
- [x] Changing space re-keys the embedding-map query → automatic refetch (TanStack `queryKey` already includes `params`; no manual invalidation needed)
- [x] Unknown / inactive space handling preserved (`meta.error: unknown_embedding_space` path in `EmbeddingAtlasPage` untouched)

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.app.json` — clean
- [x] `npx vitest run src/features/embedding-atlas` — 6/6 passing (5 new for the resolver + 1 existing store test)
- [ ] Manual smoke: open Atlas → Settings dialog → confirm spaces load, switching triggers refetch, unknown code surfaces gracefully

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)