### PR TITLE
feat(scoring): add TOPIQ-NR scoring engine wrapper (shadow)

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -21,9 +21,10 @@
       "aesthetic": { "ava": 0.55, "spaq": 0.45 }
     },
     "models": {
-      "spaq": { "enabled": true,  "shadow": false },
-      "ava":  { "enabled": true,  "shadow": false },
-      "liqe": { "enabled": true,  "shadow": false }
+      "spaq":  { "enabled": true,  "shadow": false },
+      "ava":   { "enabled": true,  "shadow": false },
+      "liqe":  { "enabled": true,  "shadow": false },
+      "topiq": { "enabled": false, "shadow": true  }
     }
   },
   "processing": {

--- a/modules/engines/__init__.py
+++ b/modules/engines/__init__.py
@@ -21,6 +21,7 @@ from modules.engines.registry import (
     get_registry,
     reset_registry,
 )
+from modules.engines.topiq_model import TopiqModelWrapper
 
 __all__ = [
     "IScoringEngine",
@@ -38,5 +39,11 @@ __all__ = [
     "MusiqModelWrapper",
     "make_musiq_wrappers",
     "LiqeModelWrapper",
+    "TopiqModelWrapper",
     "MultiModelHost",
 ]
+
+# Register one shadow-capable instance at import time. The wrapper lazy-loads
+# its pyiqa backend on first `load()`, so this is cheap (no torch import here).
+# Production vs. shadow membership is decided by `scoring.models` in config.
+get_registry().register(TopiqModelWrapper())

--- a/modules/engines/topiq_model.py
+++ b/modules/engines/topiq_model.py
@@ -1,0 +1,85 @@
+"""IScoringModel wrapper around `TopiqScorer` (modules/topiq.py).
+
+`TopiqScorer.predict()` returns the dict shape we need:
+    {"score": float, "status": "success"|"failed", "score_range": "0.0-1.0"}
+
+The wrapper adapts that to the `IScoringModel` contract, lazy-loads the
+backend, and reports score_range (0.0, 1.0). It mirrors
+`modules.engines.liqe_model.LiqeModelWrapper`.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+from modules.engines.base import IScoringModel
+
+logger = logging.getLogger(__name__)
+
+
+class TopiqModelWrapper(IScoringModel):
+    """TOPIQ-NR (PyTorch via pyiqa). Score range: 0.0 – 1.0."""
+
+    name = "topiq"
+    framework = "torch"
+    score_range = (0.0, 1.0)
+
+    def __init__(self, scorer: Optional[Any] = None, device: str = "cuda") -> None:
+        """`scorer` may be an existing `TopiqScorer` (or duck-typed mock) for
+        sharing across the process; if `None`, the backend is constructed
+        lazily on first `load()`.
+        """
+        self._scorer = scorer
+        self._device = device
+        self._loaded = scorer is not None and getattr(scorer, "available", False)
+        if self._loaded:
+            self.load_status = "loaded"
+        self.version = getattr(scorer, "VERSION", None) or "topiq-nr-1"
+
+    def load(self) -> bool:
+        if self._loaded:
+            return True
+        if self._scorer is None:
+            try:
+                from modules.topiq import TopiqScorer
+            except Exception as exc:
+                logger.error("Could not import TopiqScorer: %s", exc)
+                self.load_status = "failed"
+                return False
+            try:
+                self._scorer = TopiqScorer(device=self._device)
+            except Exception as exc:
+                logger.error("TopiqScorer construction failed: %s", exc)
+                self.load_status = "failed"
+                return False
+        self._loaded = bool(getattr(self._scorer, "available", False))
+        self.load_status = "loaded" if self._loaded else "failed"
+        return self._loaded
+
+    def predict(self, image_path: str) -> Dict[str, Any]:
+        if not self._loaded or self._scorer is None:
+            return {"score": None, "status": "not_loaded", "error": "Model not loaded"}
+        try:
+            result = self._scorer.predict(image_path)
+        except Exception as exc:
+            logger.error("TOPIQ predict raised: %s", exc)
+            return {"score": None, "status": "failed", "error": str(exc)}
+
+        if not isinstance(result, dict) or result.get("status") != "success":
+            err = result.get("error") if isinstance(result, dict) else "unknown"
+            return {"score": None, "status": "failed", "error": err}
+
+        return {
+            "score": float(result.get("score", 0.0)),
+            "status": "success",
+            "error": None,
+        }
+
+    @property
+    def scorer(self) -> Optional[Any]:
+        """Expose the underlying `TopiqScorer` (for sharing or shutdown)."""
+        return self._scorer
+
+
+__all__ = ["TopiqModelWrapper"]

--- a/modules/topiq.py
+++ b/modules/topiq.py
@@ -1,0 +1,128 @@
+"""Persistent TOPIQ-NR scorer (PyTorch via pyiqa).
+
+Mirrors `modules/liqe.py` (`LiqeScorer`): a long-lived object that loads the
+pyiqa ``topiq_nr`` metric once and scores images on demand. TOPIQ-NR is a
+no-reference image-quality metric whose output is normalized to roughly
+``0.0 - 1.0`` (higher is better).
+
+The matching `IScoringModel` adapter is `modules.engines.topiq_model`.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import logging
+from typing import Any, Dict, Optional
+
+from PIL import Image
+
+logger = logging.getLogger(__name__)
+
+try:
+    import torch
+
+    TORCH_AVAILABLE = True
+except ImportError:
+    TORCH_AVAILABLE = False
+
+try:
+    from torchvision.transforms import functional as TF
+except ImportError:
+    pass
+
+
+class TopiqScorer:
+    """Persistent TOPIQ-NR scorer to avoid re-loading the model per image."""
+
+    # Default max dimension (longest edge) before downscaling; config can override.
+    DEFAULT_MAX_DIM = 1024
+    VERSION = "topiq-nr-1"
+    SCORE_RANGE = "0.0-1.0"
+
+    def __init__(self, device: str = "cuda", max_dimension: Optional[int] = None) -> None:
+        self.device = device
+        self.available = False
+        self.metric = None
+        self.max_dimension = (
+            int(max_dimension) if max_dimension is not None else self._load_max_dimension()
+        )
+
+        if not TORCH_AVAILABLE:
+            logger.warning("TOPIQ: PyTorch not installed. TOPIQ-NR scoring will be unavailable.")
+            return
+
+        if self.device == "cuda" and not torch.cuda.is_available():
+            logger.info("TOPIQ: CUDA not available, falling back to CPU")
+            self.device = "cpu"
+
+        try:
+            import pyiqa
+
+            # Suppress "Loading pretrained model..." output.
+            with contextlib.redirect_stdout(io.StringIO()):
+                self.metric = pyiqa.create_metric("topiq_nr", device=self.device)
+            self.available = True
+            logger.info("TOPIQ-NR model loaded on %s", self.device)
+        except ImportError:
+            logger.warning("TOPIQ: pyiqa not installed. Install with 'pip install pyiqa'")
+        except Exception as exc:
+            logger.error("TOPIQ: Failed to load model: %s", exc)
+
+    def _load_max_dimension(self) -> int:
+        """Read the TOPIQ max dimension from config (``scoring.topiq_max_dimension``)."""
+        try:
+            from modules.config import get_config_value
+
+            v = get_config_value("scoring.topiq_max_dimension")
+            if v is not None:
+                return max(224, min(2048, int(v)))
+        except Exception:
+            pass
+        return self.DEFAULT_MAX_DIM
+
+    def predict(self, image_path: str) -> Dict[str, Any]:
+        """Score a single image. Returns a dict with score/status/score_range."""
+        if not self.available:
+            return {"error": "Model not loaded", "status": "failed"}
+
+        try:
+            img = Image.open(image_path).convert("RGB")
+
+            # Downscale very large images to bound memory/time.
+            if max(img.size) > self.max_dimension:
+                ratio = self.max_dimension / max(img.size)
+                new_size = (int(img.size[0] * ratio), int(img.size[1] * ratio))
+                img = img.resize(new_size, Image.BICUBIC)
+
+            img_tensor = TF.to_tensor(img).unsqueeze(0).to(self.device)
+
+            with torch.no_grad():
+                score = self.metric(img_tensor).item()
+
+            return {
+                "score": score,
+                "status": "success",
+                "device": self.device,
+                "score_range": self.SCORE_RANGE,
+            }
+        except Exception as exc:
+            # Fallback: let pyiqa load the file directly if tensor prep failed.
+            try:
+                if self.metric is not None:
+                    with torch.no_grad():
+                        score = self.metric(image_path).item()
+                    return {
+                        "score": score,
+                        "status": "success",
+                        "device": self.device,
+                        "note": "fallback_path",
+                        "score_range": self.SCORE_RANGE,
+                    }
+            except Exception:
+                pass
+
+            return {"error": str(exc), "status": "failed"}
+
+
+__all__ = ["TopiqScorer"]

--- a/tests/test_engines_wrappers.py
+++ b/tests/test_engines_wrappers.py
@@ -16,6 +16,7 @@ from modules.engines.host import MultiModelHost
 from modules.engines.liqe_model import LiqeModelWrapper
 from modules.engines.musiq_model import MusiqModelWrapper, make_musiq_wrappers
 from modules.engines.registry import ModelRegistry
+from modules.engines.topiq_model import TopiqModelWrapper
 
 
 class _StubMusiqBackend:
@@ -82,6 +83,20 @@ class _StubLiqeScorer:
         if self._status != "success":
             return {"status": "failed", "error": "boom"}
         return {"score": self._score, "status": "success", "score_range": "1.0-5.0"}
+
+
+class _StubTopiqScorer:
+    available = True
+    VERSION = "topiq-stub-1"
+
+    def __init__(self, score: float = 0.62, status: str = "success") -> None:
+        self._score = score
+        self._status = status
+
+    def predict(self, _path: str) -> Dict[str, Any]:
+        if self._status != "success":
+            return {"status": "failed", "error": "boom"}
+        return {"score": self._score, "status": "success", "score_range": "0.0-1.0"}
 
 
 # ---------- MusiqModelWrapper ----------
@@ -181,6 +196,42 @@ def test_liqe_normalize_matches_native_range():
     assert liqe.normalize(1.0) == pytest.approx(0.0)
     assert liqe.normalize(3.0) == pytest.approx(0.5)
     assert liqe.normalize(5.0) == pytest.approx(1.0)
+
+
+# ---------- TopiqModelWrapper ----------
+
+def test_topiq_wrapper_predict_success():
+    topiq = TopiqModelWrapper(scorer=_StubTopiqScorer(score=0.62))
+    assert topiq.name == "topiq"
+    assert topiq.score_range == (0.0, 1.0)
+    assert topiq.framework == "torch"
+    assert topiq.load() is True
+    out = topiq.predict("/x.jpg")
+    assert out == {"score": 0.62, "status": "success", "error": None}
+
+
+def test_topiq_wrapper_failed_status_propagates():
+    topiq = TopiqModelWrapper(scorer=_StubTopiqScorer(status="failed"))
+    topiq.load()
+    out = topiq.predict("/x.jpg")
+    assert out["status"] == "failed"
+    assert out["score"] is None
+
+
+def test_topiq_wrapper_unloaded_returns_not_loaded():
+    class _Unavailable:
+        available = False
+
+    topiq = TopiqModelWrapper(scorer=_Unavailable())
+    out = topiq.predict("/x.jpg")
+    assert out["status"] == "not_loaded"
+
+
+def test_topiq_normalize_matches_native_range():
+    topiq = TopiqModelWrapper(scorer=_StubTopiqScorer())
+    assert topiq.normalize(0.0) == pytest.approx(0.0)
+    assert topiq.normalize(0.5) == pytest.approx(0.5)
+    assert topiq.normalize(1.0) == pytest.approx(1.0)
 
 
 # ---------- MultiModelHost ----------


### PR DESCRIPTION
## Issue

Closes #182
Part of epic #180 (scoring-stack modernization). Spike #181 confirmed `topiq_nr` is ready via pyiqa (range ~0–1, ~48 ms, 0.31 GB).

## Backlog hygiene

- [x] Card moved to `Stage = Review` on the Project board
- [ ] Cross-repo counterpart — n/a for this sub-issue (backend-only wrapper)
- [x] API contract / OpenAPI — no REST behavior change (model auto-appears in existing `GET /api/models`)
- [x] Plan docs skimmed — no track-status change

## Summary

**What changed:** Adds an all-PyTorch **TOPIQ-NR** scoring model behind the `IScoringModel` registry, mirroring the existing LIQE integration. Registered as **shadow** (runs + stores per-model scores, not fused), so it has zero effect on production fusion until enabled.

- `modules/topiq.py` — `TopiqScorer` backend loading pyiqa's `topiq_nr` metric (native range `0.0–1.0`), config-driven max dimension (`scoring.topiq_max_dimension`), uses `logging` per project guidelines.
- `modules/engines/topiq_model.py` — `TopiqModelWrapper(IScoringModel)`: `name="topiq"`, `framework="torch"`, `score_range=(0.0, 1.0)`, lazy `load()`/`predict()`.
- `modules/engines/__init__.py` — import/export `TopiqModelWrapper`; register one lazy instance at import time (the registry's documented registration point — no torch import until `load()`).
- `config.example.json` — `scoring.models.topiq = {enabled:false, shadow:true}`.
- `tests/test_engines_wrappers.py` — 4 focused wrapper unit tests (success / failed-status / not-loaded / normalize), no GPU/torch deps.

## Motivation

First wrapper deliverable of the QPT V2 + TOPIQ-NR + LIQE stack modernization (#180). No migration needed — per-model scores land in the existing `image_model_scores` table with `is_shadow=true`.

## How to test

```bash
python -m ruff check modules/topiq.py modules/engines/topiq_model.py modules/engines/__init__.py tests/test_engines_wrappers.py
python -m pytest tests/test_engines_wrappers.py tests/test_engines_registry.py -q
```

**Risk / testing notes:** All targeted tests pass (49 in isolation incl. clustering/registry; 56 across normalization + shadow + `/api/models`). ruff clean. Unrelated pre-existing failures in the full `not gpu and not db and not ml` subset (Postgres-dependent tests + a pre-existing `modules.db.get_images_paginated_with_count` AttributeError) are not touched by this PR — confirmed by stashing this change and reproducing them on the clean tree.

## Risk / rollout

Low. The model is **shadow-only** by default (not in the fusion set), so production scores are unchanged. Loading is lazy (pyiqa/torch only imported on first `load()`), so import-time registration is cheap. Enabling/fusing is downstream work (#185 calibration, #188 staged weights).

Note: the canonical fusion config in the proposal uses the key `topiq_nr`, while this model's registry name is `topiq` (as specified in #182). Reconciling fusion-key naming is intentionally deferred to #185/#188.

## SDLC checklist

- [x] Tests added
- [x] Lint pass (ruff)
- [x] No secrets
- [x] Docs — example config updated; no user-visible behavior change