### PR TITLE
fix(reconcile): extend salvage to culling phase and no-heartbeat path (#161)

### DIFF
--- a/modules/db_legacy.py
+++ b/modules/db_legacy.py
@@ -5519,9 +5519,52 @@ def reconcile_stale_running_image_phases(threshold_seconds: int | None = None, l
 
     chunk_size = 900
     updated_total = 0
+    salvaged_total = 0
     for i in range(0, len(ids), chunk_size):
         chunk = ids[i:i + chunk_size]
         placeholders = ",".join(["?"] * len(chunk))
+
+        # Issue #161: salvage scoring rows whose canonical outputs are already
+        # persisted — same logic as reconcile_stale_running_phases_for_jobs().
+        salvage_rc = get_connector().execute(
+            f"""
+            UPDATE image_phase_status
+            SET status = 'done',
+                last_error = 'reconcile_stale:no_heartbeat:outputs_present',
+                finished_at = ?,
+                updated_at = ?
+            WHERE id IN ({placeholders})
+              AND status = 'running'
+              AND phase_id = (SELECT id FROM pipeline_phases WHERE code = 'scoring')
+              AND image_id IN (
+                  SELECT id FROM images WHERE score IS NOT NULL AND scores_json IS NOT NULL
+              )
+            """,
+            (now, now, *chunk),
+        )
+        salvaged_total += int(salvage_rc) if isinstance(salvage_rc, int) else 0
+
+        # Salvage culling rows whose images were successfully clustered into a
+        # stack. Singletons (stack_id IS NULL) are still failed and re-run,
+        # which is a fast no-op that correctly resolves them as singletons.
+        cull_salvage_rc = get_connector().execute(
+            f"""
+            UPDATE image_phase_status
+            SET status = 'done',
+                last_error = 'reconcile_stale:no_heartbeat:outputs_present',
+                finished_at = ?,
+                updated_at = ?
+            WHERE id IN ({placeholders})
+              AND status = 'running'
+              AND phase_id = (SELECT id FROM pipeline_phases WHERE code = 'culling')
+              AND image_id IN (
+                  SELECT id FROM images WHERE stack_id IS NOT NULL
+              )
+            """,
+            (now, now, *chunk),
+        )
+        salvaged_total += int(cull_salvage_rc) if isinstance(cull_salvage_rc, int) else 0
+
         rc = get_connector().execute(
             f"""
             UPDATE image_phase_status
@@ -5539,12 +5582,14 @@ def reconcile_stale_running_image_phases(threshold_seconds: int | None = None, l
         else:
             updated_total += len(chunk)
 
-    if updated_total:
+    total = updated_total + salvaged_total
+    if total:
         logger.info(
             "reconcile_stale_running_image_phases: reaped %s row(s) "
-            "(threshold=%ss)", updated_total, threshold_seconds,
+            "(salvaged=%s, failed=%s, threshold=%ss)",
+            total, salvaged_total, updated_total, threshold_seconds,
         )
-    return updated_total
+    return total
 
 
 def get_recent_jobs(limit=50, offset=0):
@@ -6850,6 +6895,27 @@ def reconcile_stale_running_phases_for_jobs(job_ids, error_message=None, in_flig
         except (TypeError, ValueError):
             salvaged = 0
 
+        # Salvage culling rows whose images were successfully clustered into a
+        # stack. Singletons (stack_id IS NULL) still fail and re-run, which is
+        # a fast no-op that correctly resolves them as singletons.
+        cull_salvage_rc = get_connector().execute(
+            f"""
+            UPDATE image_phase_status
+            SET status = 'done', last_error = ?, finished_at = ?, updated_at = ?
+            WHERE job_id IN ({placeholders})
+              AND status = 'running'
+              AND phase_id = (SELECT id FROM pipeline_phases WHERE code = 'culling')
+              AND image_id IN (
+                  SELECT id FROM images WHERE stack_id IS NOT NULL
+              )
+            """,
+            salvage_params,
+        )
+        try:
+            salvaged += int(cull_salvage_rc) if cull_salvage_rc is not None else 0
+        except (TypeError, ValueError):
+            pass
+
         params = [msg, now, now] + job_ids
         rowcount = get_connector().execute(
             f"""
@@ -6865,7 +6931,7 @@ def reconcile_stale_running_phases_for_jobs(job_ids, error_message=None, in_flig
         rc = 0
     if salvaged:
         logger.info(
-            "reconcile_stale_running_phases_for_jobs: salvaged %s scoring row(s) "
+            "reconcile_stale_running_phases_for_jobs: salvaged %s row(s) "
             "with outputs already persisted (jobs=%s)", salvaged, job_ids,
         )
         rc += salvaged

--- a/tests/test_phase_reconcile.py
+++ b/tests/test_phase_reconcile.py
@@ -159,20 +159,26 @@ def test_reconcile_failed_salvages_scoring_rows_with_outputs(monkeypatch):
     )
 
     update_calls = [(s, p) for s, p in executed if "UPDATE IMAGE_PHASE_STATUS" in s.upper()]
-    assert len(update_calls) == 2, update_calls
+    # Expect 3 UPDATEs: scoring salvage, culling salvage, fail.
+    assert len(update_calls) == 3, update_calls
 
-    salvage_sql, salvage_params = update_calls[0]
-    assert "SET status = 'done'" in salvage_sql
-    assert "pipeline_phases" in salvage_sql.lower()
-    assert "score IS NOT NULL" in salvage_sql
-    assert "scores_json IS NOT NULL" in salvage_sql
+    scoring_salvage_sql, salvage_params = update_calls[0]
+    assert "SET status = 'done'" in scoring_salvage_sql
+    assert "code = 'scoring'" in scoring_salvage_sql
+    assert "score IS NOT NULL" in scoring_salvage_sql
+    assert "scores_json IS NOT NULL" in scoring_salvage_sql
     assert salvage_params[0] == "stale_running_reconciled:job_cancelled:outputs_present"
 
-    fail_sql, _ = update_calls[1]
+    culling_salvage_sql, _ = update_calls[1]
+    assert "SET status = 'done'" in culling_salvage_sql
+    assert "code = 'culling'" in culling_salvage_sql
+    assert "stack_id IS NOT NULL" in culling_salvage_sql
+
+    fail_sql, _ = update_calls[2]
     assert "SET status = 'failed'" in fail_sql
 
-    # Total = salvaged (17) + failed (3).
-    assert rc == 20
+    # Total = scoring salvaged (17) + culling salvaged (17) + failed (3).
+    assert rc == 37
 
 
 def test_reconcile_not_started_mode_skips_salvage(monkeypatch):

--- a/tests/test_reconcile_stale_running.py
+++ b/tests/test_reconcile_stale_running.py
@@ -14,10 +14,18 @@ from modules import db
 
 class _FakeConnector:
     """Connector double that records query()/execute() calls and lets tests
-    seed the candidate-id list returned by the SELECT."""
+    seed the candidate-id list returned by the SELECT.
 
-    def __init__(self, candidate_ids):
+    By default salvage UPDATEs (SET status='done') return 0 rows and fail
+    UPDATEs return the chunk size, matching the common case where no rows
+    qualify for salvage.  Pass ``salvage_scoring`` and/or ``salvage_culling``
+    to override the per-chunk count returned for each salvage pass.
+    """
+
+    def __init__(self, candidate_ids, *, salvage_scoring: int = 0, salvage_culling: int = 0):
         self.candidate_ids = list(candidate_ids)
+        self.salvage_scoring = salvage_scoring
+        self.salvage_culling = salvage_culling
         self.queries: list[tuple[str, tuple]] = []
         self.executes: list[tuple[str, tuple]] = []
 
@@ -27,11 +35,14 @@ class _FakeConnector:
 
     def execute(self, sql, params=None):
         self.executes.append((sql, tuple(params) if params else ()))
-        # Mimic real driver: rowcount = the number of ids touched in this
-        # batch. Two leading params (now, now) plus the chunk of ids.
-        if params and "UPDATE" in sql.upper():
-            return max(0, len(params) - 2)
-        return 0
+        if "UPDATE" not in sql.upper():
+            return 0
+        if "SET status = 'done'" in sql or "SET STATUS = 'DONE'" in sql.upper():
+            if "code = 'culling'" in sql or "CODE = 'CULLING'" in sql.upper():
+                return self.salvage_culling
+            return self.salvage_scoring
+        # Fail UPDATE: chunk size = params minus the two leading (now, now).
+        return max(0, len(params) - 2) if params else 0
 
     def query_one(self, *a, **kw):
         return None
@@ -48,19 +59,19 @@ def test_returns_zero_when_no_candidates(monkeypatch):
 
 def test_updates_in_chunks_and_returns_count(monkeypatch):
     ids = list(range(1, 1801))  # 1800 -> two chunks of 900
-    fake = _FakeConnector(ids)
+    fake = _FakeConnector(ids)  # salvage counts default to 0
     monkeypatch.setattr(db, "get_connector", lambda: fake)
     n = db.reconcile_stale_running_image_phases(threshold_seconds=60, limit=5000)
-    assert n == len(ids), n  # 900 + 900 = 1800 rows updated
-    # We expect at least 2 UPDATE batches (chunk_size=900):
+    assert n == len(ids), n  # 900 + 900 = 1800 rows updated (all via fail path)
+    # Expect 3 UPDATEs per chunk × 2 chunks = 6 total (2 salvage + 1 fail each).
     update_calls = [
         (sql, params) for sql, params in fake.executes
         if "UPDATE IMAGE_PHASE_STATUS" in sql.upper()
     ]
-    assert len(update_calls) == 2
-    # Each batch should set status='failed' and the no_heartbeat error.
-    for sql, params in update_calls:
-        assert "'failed'" in sql or "failed" in sql.lower()
+    assert len(update_calls) == 6, update_calls
+    fail_calls = [(s, p) for s, p in update_calls if "'failed'" in s]
+    assert len(fail_calls) == 2
+    for sql, _ in fail_calls:
         assert "reconcile_stale:no_heartbeat" in sql
 
 
@@ -97,3 +108,56 @@ def test_default_threshold_reads_config(monkeypatch):
     monkeypatch.setattr("modules.config.get_config_value", _gcv)
     db.reconcile_stale_running_image_phases(limit=100)
     assert "database.stale_running_threshold_seconds" in captured["keys"]
+
+
+# --- Issue #161: no-heartbeat salvage -------------------------------------------
+
+
+def test_no_heartbeat_salvages_scoring_rows_with_outputs(monkeypatch):
+    """Stale scoring rows whose outputs are persisted must be flipped to 'done',
+    not 'failed', even via the wall-clock (no-heartbeat) reconciler path.
+    """
+    fake = _FakeConnector([1, 2, 3, 4, 5], salvage_scoring=3, salvage_culling=0)
+    monkeypatch.setattr(db, "get_connector", lambda: fake)
+
+    n = db.reconcile_stale_running_image_phases(threshold_seconds=60, limit=100)
+
+    update_calls = [(s, p) for s, p in fake.executes if "UPDATE IMAGE_PHASE_STATUS" in s.upper()]
+    # Expect: salvage-scoring, salvage-culling, fail (one chunk).
+    assert len(update_calls) == 3, update_calls
+
+    salvage_sql, _ = update_calls[0]
+    assert "SET status = 'done'" in salvage_sql
+    assert "code = 'scoring'" in salvage_sql
+    assert "no_heartbeat:outputs_present" in salvage_sql
+    assert "score IS NOT NULL" in salvage_sql
+    assert "scores_json IS NOT NULL" in salvage_sql
+
+    fail_sql, _ = update_calls[2]
+    assert "SET status = 'failed'" in fail_sql
+    assert "reconcile_stale:no_heartbeat'" in fail_sql
+
+    # Total = salvaged scoring (3) + fail (5, fake returns chunk size).
+    assert n == 3 + 5
+
+
+def test_no_heartbeat_salvages_culling_rows_with_stack(monkeypatch):
+    """Stale culling rows for images that already have a stack_id must be
+    salvaged to 'done' rather than failed by the no-heartbeat reconciler.
+    """
+    fake = _FakeConnector([10, 11, 12], salvage_scoring=0, salvage_culling=2)
+    monkeypatch.setattr(db, "get_connector", lambda: fake)
+
+    n = db.reconcile_stale_running_image_phases(threshold_seconds=60, limit=100)
+
+    update_calls = [(s, p) for s, p in fake.executes if "UPDATE IMAGE_PHASE_STATUS" in s.upper()]
+    assert len(update_calls) == 3, update_calls
+
+    cull_salvage_sql, _ = update_calls[1]
+    assert "SET status = 'done'" in cull_salvage_sql
+    assert "code = 'culling'" in cull_salvage_sql
+    assert "no_heartbeat:outputs_present" in cull_salvage_sql
+    assert "stack_id IS NOT NULL" in cull_salvage_sql
+
+    # Total = salvaged culling (2) + fail (3, fake returns chunk size).
+    assert n == 2 + 3


### PR DESCRIPTION
The job-cancel reconciler already salvaged scoring rows whose outputs
were persisted. Two gaps remained:

1. reconcile_stale_running_image_phases() (wall-clock / no-heartbeat
   reaper) had no salvage logic at all — it bulk-failed every stale
   running row, producing the 356 culling and many scoring rows seen
   in production with last_error='reconcile_stale:no_heartbeat'.

2. Culling phase rows were never salvaged in either reconciler. Images
   successfully clustered into stacks (stack_id IS NOT NULL) were
   being flipped to failed on cancellation/stall, driving
   heal_workflow_culling loops alongside the scoring ones.

Fix: for each chunk in reconcile_stale_running_image_phases(), run two
salvage UPDATEs before the fail UPDATE — one for scoring rows with
score/scores_json present and one for culling rows with stack_id
set — mirroring the pattern in reconcile_stale_running_phases_for_jobs().
Add the same culling salvage pass to the job-cancel reconciler.

Singletons (stack_id IS NULL after culling) still fall through to the
fail path and get one cheap re-run that correctly resolves them.

Tests:
- Updated test_reconcile_failed_salvages_scoring_rows_with_outputs to
  assert the new 3-UPDATE shape (scoring salvage / culling salvage / fail).
- Reworked _FakeConnector in test_reconcile_stale_running.py to return
  configurable salvage counts per phase, fixing test_updates_in_chunks.
- Added test_no_heartbeat_salvages_scoring_rows_with_outputs and
  test_no_heartbeat_salvages_culling_rows_with_stack covering the
  previously untested no-heartbeat salvage path.

Closes #161

https://claude.ai/code/session_014jBrDamUYj5GPerS138VCo