### PR TITLE
feat(scoring): QPT V2 scoring engine wrapper (#183)

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -26,7 +26,12 @@
       "liqe":   { "enabled": true,  "shadow": false },
       "topiq":  { "enabled": true,  "shadow": false },
       "cursor": { "enabled": false, "shadow": false },
-      "claude": { "enabled": false, "shadow": false }
+      "claude": { "enabled": false, "shadow": false },
+      "qpt_v2": { "enabled": false, "shadow": true }
+    },
+    "qpt_v2": {
+      "checkpoint_path": "models/qpt_v2.pth",
+      "max_dimension": 1024
     },
     "cursor": {
       "model": "composer-2.5",

--- a/docs/reference/models/MODEL_WEIGHTS.md
+++ b/docs/reference/models/MODEL_WEIGHTS.md
@@ -23,6 +23,33 @@ Here are the models and weights currently used in your project to calculate the 
 
 *Note: These values are hardcoded defaults in `scripts/python/run_all_musiq_models.py` (and `modules/scoring.py`) since your `config.json` does not specify any overrides.*
 
+## QPT V2 (shadow — not yet in active ensemble)
+
+QPT V2 (Quality-aware Pre-Training V2, ACM MM 2024) uses a HiViT-T backbone
+(~19M parameters) pre-trained with masked image modeling. It is registered as a
+**shadow** model (`scoring.models.qpt_v2: {enabled: false, shadow: true}`) — it
+runs and stores scores but is excluded from composite fusion until promoted in #185.
+
+### Checkpoint acquisition
+
+1. Install the inference package:
+   ```
+   pip install git+https://github.com/KeiChiTse/QPT-V2
+   ```
+2. Download the HiViT-T checkpoint from the [GitHub releases](https://github.com/KeiChiTse/QPT-V2).
+3. Place the file at `models/qpt_v2.pth` relative to the repo root,
+   **or** set `scoring.qpt_v2.checkpoint_path` in `config.json` to an absolute path.
+
+### Target weights (post-calibration, issue #185)
+
+| Dimension | QPT V2 | TOPIQ-NR | LIQE |
+|-----------|--------|----------|------|
+| General   | 55%    | 30%      | 15%  |
+| Aesthetic | 75%    | —        | 25%  |
+| Technical | 35%    | 65%      | —    |
+
+Score range: **0.0 – 1.0** (verify empirically once inference code is released).
+
 ## Related Documents
 
 - [Docs index](../../README.md)

--- a/modules/engines/__init__.py
+++ b/modules/engines/__init__.py
@@ -23,6 +23,7 @@ from modules.engines.registry import (
     get_registry,
     reset_registry,
 )
+from modules.engines.qpt_v2_model import QptV2ModelWrapper
 from modules.engines.topiq_model import TopiqModelWrapper
 
 __all__ = [
@@ -42,6 +43,7 @@ __all__ = [
     "make_musiq_wrappers",
     "LiqeModelWrapper",
     "TopiqModelWrapper",
+    "QptV2ModelWrapper",
     "CursorModelWrapper",
     "ClaudeModelWrapper",
     "MultiModelHost",
@@ -51,6 +53,7 @@ __all__ = [
 # its pyiqa backend on first `load()`, so this is cheap (no torch import here).
 # Production vs. shadow membership is decided by `scoring.models` in config.
 get_registry().register(TopiqModelWrapper())
+get_registry().register(QptV2ModelWrapper())
 
 # LLM-judge engines (Cursor SDK, Claude Agent SDK). Both lazy-load their
 # optional SDKs on first `load()` and are disabled by default in config, so

--- a/modules/engines/qpt_v2_model.py
+++ b/modules/engines/qpt_v2_model.py
@@ -1,0 +1,85 @@
+"""IScoringModel wrapper around ``QptV2Scorer`` (modules/qpt_v2.py).
+
+``QptV2Scorer.predict()`` returns the dict shape we need:
+    {"score": float, "status": "success"|"failed", "score_range": "0.0-1.0"}
+
+The wrapper adapts that to the ``IScoringModel`` contract, lazy-loads the
+backend, and reports score_range (0.0, 1.0). It mirrors
+``modules.engines.topiq_model.TopiqModelWrapper``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+from modules.engines.base import IScoringModel
+
+logger = logging.getLogger(__name__)
+
+
+class QptV2ModelWrapper(IScoringModel):
+    """QPT V2 (HiViT-T, custom PyTorch). Score range: 0.0 – 1.0."""
+
+    name = "qpt_v2"
+    framework = "torch"
+    score_range = (0.0, 1.0)
+
+    def __init__(self, scorer: Optional[Any] = None, device: str = "cuda") -> None:
+        """`scorer` may be an existing ``QptV2Scorer`` (or duck-typed mock) for
+        sharing across the process; if ``None``, the backend is constructed
+        lazily on first ``load()``.
+        """
+        self._scorer = scorer
+        self._device = device
+        self._loaded = scorer is not None and getattr(scorer, "available", False)
+        if self._loaded:
+            self.load_status = "loaded"
+        self.version = getattr(scorer, "VERSION", None) or "qpt-v2-1"
+
+    def load(self) -> bool:
+        if self._loaded:
+            return True
+        if self._scorer is None:
+            try:
+                from modules.qpt_v2 import QptV2Scorer
+            except Exception as exc:
+                logger.error("Could not import QptV2Scorer: %s", exc)
+                self.load_status = "failed"
+                return False
+            try:
+                self._scorer = QptV2Scorer(device=self._device)
+            except Exception as exc:
+                logger.error("QptV2Scorer construction failed: %s", exc)
+                self.load_status = "failed"
+                return False
+        self._loaded = bool(getattr(self._scorer, "available", False))
+        self.load_status = "loaded" if self._loaded else "failed"
+        return self._loaded
+
+    def predict(self, image_path: str) -> Dict[str, Any]:
+        if not self._loaded or self._scorer is None:
+            return {"score": None, "status": "not_loaded", "error": "Model not loaded"}
+        try:
+            result = self._scorer.predict(image_path)
+        except Exception as exc:
+            logger.error("QPT V2 predict raised: %s", exc)
+            return {"score": None, "status": "failed", "error": str(exc)}
+
+        if not isinstance(result, dict) or result.get("status") != "success":
+            err = result.get("error") if isinstance(result, dict) else "unknown"
+            return {"score": None, "status": "failed", "error": err}
+
+        return {
+            "score": float(result.get("score", 0.0)),
+            "status": "success",
+            "error": None,
+        }
+
+    @property
+    def scorer(self) -> Optional[Any]:
+        """Expose the underlying ``QptV2Scorer`` (for sharing or shutdown)."""
+        return self._scorer
+
+
+__all__ = ["QptV2ModelWrapper"]

--- a/modules/qpt_v2.py
+++ b/modules/qpt_v2.py
@@ -1,0 +1,207 @@
+"""Persistent QPT V2 scorer (custom PyTorch, HiViT-T backbone).
+
+QPT V2 (Quality-aware Pre-Training V2) is a no-reference IQA/IAA model
+based on masked image modeling (ACM MM 2024). Checkpoint source:
+    KeiChiTse/QPT-V2 — https://github.com/KeiChiTse/QPT-V2
+
+Unlike TOPIQ-NR and LIQE, QPT V2 is not available via pyiqa. The scorer
+requires:
+  1. The QPT V2 package installed:
+         pip install git+https://github.com/KeiChiTse/QPT-V2
+  2. The HiViT-T checkpoint placed at the path given by
+     ``scoring.qpt_v2.checkpoint_path`` in config.json
+     (default: ``models/qpt_v2.pth`` relative to BASE_DIR).
+
+If either prerequisite is missing the scorer sets ``available = False`` and
+logs a warning; all engine machinery (registration, shadow scoring, DB writes)
+continues normally.
+
+The matching ``IScoringModel`` adapter is ``modules.engines.qpt_v2_model``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, Optional
+
+from PIL import Image
+
+logger = logging.getLogger(__name__)
+
+try:
+    import torch
+
+    TORCH_AVAILABLE = True
+except ImportError:
+    TORCH_AVAILABLE = False
+
+try:
+    import torchvision.transforms as T
+    from torchvision.transforms import functional as TF
+
+    TORCHVISION_AVAILABLE = True
+except ImportError:
+    TORCHVISION_AVAILABLE = False
+
+# ImageNet mean/std used by most ViT-family models including HiViT-T.
+_IMAGENET_MEAN = [0.485, 0.456, 0.406]
+_IMAGENET_STD = [0.229, 0.224, 0.225]
+
+
+class QptV2Scorer:
+    """Persistent QPT V2 scorer to avoid re-loading the model per image.
+
+    On construction the HiViT-T checkpoint is loaded from
+    ``scoring.qpt_v2.checkpoint_path`` (config) or ``models/qpt_v2.pth``.
+    If the qpt_v2 package or checkpoint is unavailable ``self.available``
+    is ``False`` and ``predict()`` returns a ``"failed"`` status.
+    """
+
+    DEFAULT_MAX_DIM = 1024
+    VERSION = "qpt-v2-1"
+    SCORE_RANGE = "0.0-1.0"
+
+    def __init__(self, device: str = "cuda", max_dimension: Optional[int] = None) -> None:
+        self.device = device
+        self.available = False
+        self._model = None
+        self._normalize_transform = None
+        self.max_dimension = (
+            int(max_dimension) if max_dimension is not None else self._load_max_dimension()
+        )
+
+        if not TORCH_AVAILABLE:
+            logger.warning("QPT V2: PyTorch not installed. QPT V2 scoring will be unavailable.")
+            return
+
+        if not TORCHVISION_AVAILABLE:
+            logger.warning(
+                "QPT V2: torchvision not installed. QPT V2 scoring will be unavailable."
+            )
+            return
+
+        if self.device == "cuda" and not torch.cuda.is_available():
+            logger.info("QPT V2: CUDA not available, falling back to CPU")
+            self.device = "cpu"
+
+        checkpoint_path = self._load_checkpoint_path()
+        if not checkpoint_path or not os.path.isfile(checkpoint_path):
+            logger.warning(
+                "QPT V2: checkpoint not found at '%s'. "
+                "Download from https://github.com/KeiChiTse/QPT-V2 and set "
+                "scoring.qpt_v2.checkpoint_path in config.json.",
+                checkpoint_path or "<unset>",
+            )
+            return
+
+        self._load_model(checkpoint_path)
+
+    # ------------------------------------------------------------------
+    # Config helpers
+    # ------------------------------------------------------------------
+
+    def _load_checkpoint_path(self) -> str:
+        """Return checkpoint path from config or the repo-relative default."""
+        try:
+            from modules.config import get_config_value
+
+            v = get_config_value("scoring.qpt_v2.checkpoint_path")
+            if v:
+                return str(v)
+        except Exception:
+            pass
+        try:
+            from modules.config import BASE_DIR
+
+            return os.path.join(BASE_DIR, "models", "qpt_v2.pth")
+        except Exception:
+            return os.path.join(os.path.dirname(__file__), "..", "models", "qpt_v2.pth")
+
+    def _load_max_dimension(self) -> int:
+        """Read QPT V2 max dimension from config (``scoring.qpt_v2.max_dimension``)."""
+        try:
+            from modules.config import get_config_value
+
+            v = get_config_value("scoring.qpt_v2.max_dimension")
+            if v is not None:
+                return max(224, min(2048, int(v)))
+        except Exception:
+            pass
+        return self.DEFAULT_MAX_DIM
+
+    # ------------------------------------------------------------------
+    # Model loading
+    # ------------------------------------------------------------------
+
+    def _load_model(self, checkpoint_path: str) -> None:
+        """Load the HiViT-T model from *checkpoint_path*.
+
+        Requires the qpt_v2 package:
+            pip install git+https://github.com/KeiChiTse/QPT-V2
+
+        Once the QPT V2 repository releases inference code the import path
+        below (``from qpt_v2.models import build_model``) should be verified
+        against the published API and updated if needed.
+        """
+        try:
+            from qpt_v2.models import build_model  # type: ignore[import]
+        except ImportError:
+            logger.warning(
+                "QPT V2: package not installed. "
+                "Install with: pip install git+https://github.com/KeiChiTse/QPT-V2"
+            )
+            return
+
+        try:
+            checkpoint = torch.load(checkpoint_path, map_location=self.device)
+            state_dict = checkpoint.get("model", checkpoint)
+            self._model = build_model()
+            self._model.load_state_dict(state_dict)
+            self._model.eval()
+            self._model.to(self.device)
+            self._normalize_transform = T.Normalize(_IMAGENET_MEAN, _IMAGENET_STD)
+            self.available = True
+            logger.info("QPT V2 model loaded on %s from %s", self.device, checkpoint_path)
+        except Exception as exc:
+            logger.error("QPT V2: failed to load model from %s: %s", checkpoint_path, exc)
+
+    # ------------------------------------------------------------------
+    # Inference
+    # ------------------------------------------------------------------
+
+    def _preprocess(self, img: Image.Image) -> "torch.Tensor":
+        """PIL image → float tensor on device, resized to ≤ max_dimension."""
+        if max(img.size) > self.max_dimension:
+            ratio = self.max_dimension / max(img.size)
+            new_size = (int(img.size[0] * ratio), int(img.size[1] * ratio))
+            img = img.resize(new_size, Image.BICUBIC)
+        tensor = TF.to_tensor(img)
+        tensor = self._normalize_transform(tensor)
+        return tensor.unsqueeze(0).to(self.device)
+
+    def predict(self, image_path: str) -> Dict[str, Any]:
+        """Score a single image. Returns a dict with score/status/score_range."""
+        if not self.available or self._model is None:
+            return {"error": "Model not loaded", "status": "failed"}
+
+        try:
+            img = Image.open(image_path).convert("RGB")
+            tensor = self._preprocess(img)
+
+            with torch.no_grad():
+                output = self._model(tensor)
+                # Handle both scalar tensors and 1-element batch outputs.
+                score = output.squeeze().item() if output.numel() > 1 else output.item()
+
+            return {
+                "score": float(score),
+                "status": "success",
+                "device": self.device,
+                "score_range": self.SCORE_RANGE,
+            }
+        except Exception as exc:
+            return {"error": str(exc), "status": "failed"}
+
+
+__all__ = ["QptV2Scorer"]

--- a/tests/test_engines_wrappers.py
+++ b/tests/test_engines_wrappers.py
@@ -16,6 +16,7 @@ from modules.engines.host import MultiModelHost
 from modules.engines.liqe_model import LiqeModelWrapper
 from modules.engines.musiq_model import MusiqModelWrapper, make_musiq_wrappers
 from modules.engines.registry import ModelRegistry
+from modules.engines.qpt_v2_model import QptV2ModelWrapper
 from modules.engines.topiq_model import TopiqModelWrapper
 
 
@@ -90,6 +91,20 @@ class _StubTopiqScorer:
     VERSION = "topiq-stub-1"
 
     def __init__(self, score: float = 0.62, status: str = "success") -> None:
+        self._score = score
+        self._status = status
+
+    def predict(self, _path: str) -> Dict[str, Any]:
+        if self._status != "success":
+            return {"status": "failed", "error": "boom"}
+        return {"score": self._score, "status": "success", "score_range": "0.0-1.0"}
+
+
+class _StubQptV2Scorer:
+    available = True
+    VERSION = "qpt-v2-stub-1"
+
+    def __init__(self, score: float = 0.71, status: str = "success") -> None:
         self._score = score
         self._status = status
 
@@ -232,6 +247,42 @@ def test_topiq_normalize_matches_native_range():
     assert topiq.normalize(0.0) == pytest.approx(0.0)
     assert topiq.normalize(0.5) == pytest.approx(0.5)
     assert topiq.normalize(1.0) == pytest.approx(1.0)
+
+
+# ---------- QptV2ModelWrapper ----------
+
+def test_qpt_v2_wrapper_predict_success():
+    qpt = QptV2ModelWrapper(scorer=_StubQptV2Scorer(score=0.71))
+    assert qpt.name == "qpt_v2"
+    assert qpt.score_range == (0.0, 1.0)
+    assert qpt.framework == "torch"
+    assert qpt.load() is True
+    out = qpt.predict("/x.jpg")
+    assert out == {"score": 0.71, "status": "success", "error": None}
+
+
+def test_qpt_v2_wrapper_failed_status_propagates():
+    qpt = QptV2ModelWrapper(scorer=_StubQptV2Scorer(status="failed"))
+    qpt.load()
+    out = qpt.predict("/x.jpg")
+    assert out["status"] == "failed"
+    assert out["score"] is None
+
+
+def test_qpt_v2_wrapper_unloaded_returns_not_loaded():
+    class _Unavailable:
+        available = False
+
+    qpt = QptV2ModelWrapper(scorer=_Unavailable())
+    out = qpt.predict("/x.jpg")
+    assert out["status"] == "not_loaded"
+
+
+def test_qpt_v2_normalize_matches_native_range():
+    qpt = QptV2ModelWrapper(scorer=_StubQptV2Scorer())
+    assert qpt.normalize(0.0) == pytest.approx(0.0)
+    assert qpt.normalize(0.5) == pytest.approx(0.5)
+    assert qpt.normalize(1.0) == pytest.approx(1.0)
 
 
 # ---------- MultiModelHost ----------


### PR DESCRIPTION
Add QptV2Scorer backend and QptV2ModelWrapper IScoringModel adapter for
the QPT V2 HiViT-T model (KeiChiTse/QPT-V2). Registered shadow-only by
default (enabled:false, shadow:true) so scores are stored in
image_model_scores without affecting fusion until calibrated in #185.

- modules/qpt_v2.py: QptV2Scorer with lazy checkpoint load, graceful
  fallback when qpt_v2 package or checkpoint is absent, ImageNet
  preprocessing, configurable path/dimension via scoring.qpt_v2.*
- modules/engines/qpt_v2_model.py: QptV2ModelWrapper mirrors TopiqModelWrapper
- modules/engines/__init__.py: register QptV2ModelWrapper at import time
- config.example.json: qpt_v2 shadow entry + checkpoint_path/max_dimension
- docs/reference/models/MODEL_WEIGHTS.md: checkpoint acquisition steps
- tests/test_engines_wrappers.py: 4 unit tests via stub scorer (no GPU)

Closes #183

https://claude.ai/code/session_01AfB9nsxRnttcbJsCWfQRKD