### PR TITLE
feat(scoring): wire MultiModelHost as live scoring path

### DIFF
--- a/docs/features/implemented/02-scoring-and-models.md
+++ b/docs/features/implemented/02-scoring-and-models.md
@@ -28,11 +28,11 @@ metrics:
   `scoring.models` (fully inert). Set `shadow: true` to run them as shadow models
   (scored and stored, never fused), or `enabled: true, shadow: false` for
   production/fusion.
-- **How they run:** the pipeline injects active registry models that the legacy
-  MUSIQ backend doesn't produce — `ScoringWorker._run_registry_models()`
-  (`modules/pipeline.py`) mirrors the LIQE injection, so results flow through
-  `run_all_models` → `image_model_scores`. (The registry-driven `MultiModelHost`
-  carries the same shape via `_run_one` for when it becomes the live scorer.)
+- **How they run:** `ScoringRunner` uses registry-driven `MultiModelHost`
+  (`modules/engines/factory.py`) as the live scorer. Active registry models
+  (including shadow `topiq`, LLM judges, etc.) run in `MultiModelHost.run_all_models`
+  and persist to `image_model_scores`. Legacy `ScoringWorker._run_registry_models()`
+  injection remains only when a non-host scorer is injected (tests).
   The overall score lands in `image_model_scores`; the rubric rides in
   `scores_json` as `subscores`. Same path activates `topiq`.
 - **Read path / API:** `_image_detail_payload` / `_images_list_payload`

--- a/modules/engines/__init__.py
+++ b/modules/engines/__init__.py
@@ -15,6 +15,11 @@ from modules.engines.mock import (
 )
 from modules.engines.claude_model import ClaudeModelWrapper
 from modules.engines.cursor_model import CursorModelWrapper
+from modules.engines.factory import (
+    create_production_scoring_host,
+    ensure_production_registry,
+    load_production_models,
+)
 from modules.engines.host import MultiModelHost
 from modules.engines.liqe_model import LiqeModelWrapper
 from modules.engines.musiq_model import MusiqModelWrapper, make_musiq_wrappers
@@ -45,6 +50,9 @@ __all__ = [
     "CursorModelWrapper",
     "ClaudeModelWrapper",
     "MultiModelHost",
+    "create_production_scoring_host",
+    "ensure_production_registry",
+    "load_production_models",
 ]
 
 # Register one shadow-capable instance at import time. The wrapper lazy-loads

--- a/modules/engines/factory.py
+++ b/modules/engines/factory.py
@@ -1,0 +1,93 @@
+"""Factory for the production registry-driven scoring engine."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, List, Optional, Tuple
+
+from modules.engines.host import MultiModelHost
+from modules.engines.liqe_model import LiqeModelWrapper
+from modules.engines.musiq_model import make_musiq_wrappers
+from modules.engines.registry import ModelRegistry, get_registry
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_MUSIQ_NAMES: Tuple[str, ...] = ("spaq", "ava")
+
+
+def ensure_production_registry(
+    backend: Any,
+    *,
+    registry: Optional[ModelRegistry] = None,
+    musiq_names: Optional[List[str]] = None,
+    liqe_scorer: Optional[Any] = None,
+) -> ModelRegistry:
+    """Register MUSIQ-family and LIQE wrappers on the process registry.
+
+    Shadow / LLM models (e.g. ``topiq``, ``cursor``) register at import time in
+    ``modules.engines``. Idempotent for repeated calls with the same backend.
+    """
+    reg = registry or get_registry()
+    names = musiq_names if musiq_names is not None else list(_DEFAULT_MUSIQ_NAMES)
+    for wrapper in make_musiq_wrappers(backend, names=names):
+        reg.register(wrapper)
+
+    liqe = reg.get("liqe")
+    if liqe is None:
+        reg.register(LiqeModelWrapper(scorer=liqe_scorer))
+    elif liqe_scorer is not None and getattr(liqe, "_scorer", None) is not liqe_scorer:
+        reg.register(LiqeModelWrapper(scorer=liqe_scorer))
+    return reg
+
+
+def create_production_scoring_host(
+    *,
+    liqe_scorer: Optional[Any] = None,
+    registry: Optional[ModelRegistry] = None,
+) -> MultiModelHost:
+    """Build ``MultiModelHost`` backed by ``MultiModelMUSIQ`` and the model registry."""
+    from scripts.python.run_all_musiq_models import MultiModelMUSIQ
+
+    backend = MultiModelMUSIQ()
+    reg = ensure_production_registry(
+        backend,
+        registry=registry,
+        liqe_scorer=liqe_scorer,
+    )
+    version = getattr(backend, "VERSION", None)
+    return MultiModelHost(backend=backend, registry=reg, version=version)
+
+
+def load_production_models(
+    host: MultiModelHost,
+    *,
+    log: Optional[Callable[[str, str], None]] = None,
+) -> Tuple[bool, str]:
+    """Load every active registry model; fail only when a production model cannot load."""
+    def _emit(msg: str, level: str = "INFO") -> None:
+        if log is not None:
+            log(msg, level)
+        else:
+            logger.log(logging.WARNING if level == "WARNING" else logging.INFO, msg)
+
+    _emit("Loading scoring models from registry...")
+    statuses = host.load_enabled_and_shadow()
+    production = [m.name for m in host.registry.enabled()]
+    failed_prod = [n for n in production if not statuses.get(n)]
+    if failed_prod:
+        return False, f"Production model(s) failed to load: {', '.join(failed_prod)}"
+
+    for name, ok in sorted(statuses.items()):
+        if name in production:
+            continue
+        if not ok:
+            _emit(f"Shadow model {name} not loaded (scoring continues)", "WARNING")
+
+    return True, "ok"
+
+
+__all__ = [
+    "create_production_scoring_host",
+    "ensure_production_registry",
+    "load_production_models",
+]

--- a/modules/engines/host.py
+++ b/modules/engines/host.py
@@ -10,8 +10,8 @@ Composes:
 Produces the same output shape as `MultiModelMUSIQ.run_all_models()` so it
 can be swapped in without changing `ScoringWorker`/`ResultWorker`.
 
-Wiring into the pipeline happens in a later step; for now the host exists
-alongside the legacy path.
+Production wiring: ``modules/engines/factory.create_production_scoring_host()``
+is used by ``ScoringRunner`` as the live scorer (see ``modules/scoring.py``).
 """
 
 from __future__ import annotations
@@ -47,6 +47,11 @@ class MultiModelHost(IScoringEngine):
     @property
     def backend(self) -> Any:
         return self._backend
+
+    @property
+    def model_sources(self) -> Dict[str, Any]:
+        """Delegate to the MUSIQ backend for pipeline legacy-skip checks."""
+        return getattr(self._backend, "model_sources", {}) or {}
 
     def is_raw_file(self, file_path: str) -> bool:
         return bool(self._backend.is_raw_file(file_path))

--- a/modules/pipeline.py
+++ b/modules/pipeline.py
@@ -333,6 +333,21 @@ class ScoringWorker(PipelineWorker):
             self._liqe_scorer_lazy = LiqeScorer()
         return self._liqe_scorer_lazy
 
+    def _scorer_is_registry_host(self) -> bool:
+        try:
+            from modules.engines.host import MultiModelHost
+        except Exception:
+            return False
+        return isinstance(self.scorer, MultiModelHost)
+
+    def _host_runs_liqe(self) -> bool:
+        if not self._scorer_is_registry_host():
+            return False
+        try:
+            return any(m.name == "liqe" for m in self.scorer.registry.all_active())
+        except Exception:
+            return False
+
     def _run_registry_models(self, external: dict, image_path: str, log) -> None:
         """Run registry `IScoringModel`s the legacy backend doesn't produce.
 
@@ -341,10 +356,15 @@ class ScoringWorker(PipelineWorker):
         are stamped ``is_shadow=True``; ``ResultWorker`` excludes those from
         fusion. Inert unless a model is marked active in ``scoring.models``
         config, so it is a no-op by default.
+
+        Skipped when ``self.scorer`` is ``MultiModelHost`` (registry is already
+        the live inference path).
         """
+        if self._scorer_is_registry_host():
+            return
         try:
             from modules.engines.registry import get_registry
-        except Exception:  # engines package unavailable
+        except Exception:  # engines packages unavailable
             return
         registry = get_registry()
         try:
@@ -469,8 +489,8 @@ class ScoringWorker(PipelineWorker):
         except Exception as e:
             logger.warning("Preprocess failed, using original path: %s", e)
         
-        # Check/Run LIQE if missing
-        if "liqe" not in external:
+        # Check/Run LIQE if missing (host runs LIQE via LiqeModelWrapper when active)
+        if "liqe" not in external and not self._host_runs_liqe():
             try:
                 path = external.get("_liqe_preprocess_path") or job.process_path
                 liqe_result = self._get_liqe_scorer().predict(path)

--- a/modules/scoring.py
+++ b/modules/scoring.py
@@ -18,8 +18,10 @@ try:
     from scripts.python.run_all_musiq_models import MultiModelMUSIQ
     try:
         from modules.engines.base import IScoringEngine
+        from modules.engines.host import MultiModelHost
 
         IScoringEngine.register(MultiModelMUSIQ)
+        IScoringEngine.register(MultiModelHost)
     except Exception:
         pass
 except ImportError as exc:
@@ -34,7 +36,7 @@ class ScoringRunner:
     liqe_scorer: optional LIQE backend; None uses default LiqeScorer in the pipeline worker.
     """
     def __init__(self, scoring_engine=None, liqe_scorer=None):
-        # We hold the shared scorer here to persist it across runs (None = lazy MultiModelMUSIQ)
+        # We hold the shared scorer here to persist it across runs (None = lazy MultiModelHost)
         self.shared_scorer = scoring_engine
         self.liqe_scorer = liqe_scorer
         # We keep a ref to the current processor to stop it
@@ -60,6 +62,47 @@ class ScoringRunner:
         processor = self.current_processor
         depth = processor.get_pipeline_depth() if processor else 0
         return self.is_running, "\n".join(self.log_history), self.status_message, self.current_count, self.total_count, depth
+
+    def _init_shared_scorer(self, log) -> bool:
+        """Lazy-load ``MultiModelHost`` (registry-driven). Returns False on fatal load failure."""
+        if self.shared_scorer is not None:
+            log("Using injected scoring engine (no lazy model load).")
+            return True
+
+        if self._model_load_failures >= self._MODEL_LOAD_MAX_FAILURES:
+            msg = (
+                f"Model loading circuit breaker open: {self._model_load_failures} consecutive failures. "
+                f"Restart the WebUI to reset."
+            )
+            log(msg, "ERROR")
+            self.status_message = "Error loading models (circuit breaker open)"
+            return False
+
+        log("Initializing models first (this happens once)...")
+        try:
+            from modules.engines.factory import create_production_scoring_host, load_production_models
+
+            host = create_production_scoring_host(liqe_scorer=self.liqe_scorer)
+            ok, msg = load_production_models(host, log=log)
+            if not ok:
+                self._model_load_failures += 1
+                log(msg, "ERROR")
+                self.status_message = "Error loading models"
+                return False
+
+            self.shared_scorer = host
+            self._model_load_failures = 0
+            log("Models initialized successfully.")
+            return True
+        except Exception as exc:
+            self._model_load_failures += 1
+            msg = (
+                f"Error loading models (attempt {self._model_load_failures}/"
+                f"{self._MODEL_LOAD_MAX_FAILURES}): {exc}"
+            )
+            log(msg, "ERROR")
+            self.status_message = "Error loading models"
+            return False
 
     def start_batch(self, input_path, job_id, skip_existing=False, resolved_image_ids=None, target_phases=None, report_collector=None):
         """
@@ -145,56 +188,13 @@ class ScoringRunner:
             )
             return
         
-        # Checking/Loading Models (skip when a scorer was injected via constructor)
-        if self.shared_scorer is None:
-            # Circuit breaker: stop retrying after repeated failures
-            if self._model_load_failures >= self._MODEL_LOAD_MAX_FAILURES:
-                msg = (f"Model loading circuit breaker open: {self._model_load_failures} consecutive failures. "
-                       f"Restart the WebUI to reset.")
-                log(msg, "ERROR")
-                self.status_message = "Error loading models (circuit breaker open)"
-                db.update_job_status(job_id, "failed", msg)
-                event_manager.broadcast_threadsafe(
-                    "job_completed",
-                    {"job_id": job_id, "status": "failed", "error": msg},
-                )
-                return
-
-            log("Initializing models first (this happens once)...")
-            try:
-                new_scorer = MultiModelMUSIQ()
-                
-                # Load models
-                musiq_models = ['spaq', 'ava']
-                all_loaded = True
-                for model_name in musiq_models:
-                    log(f"Loading model: {model_name.upper()}...")
-                    success = new_scorer.load_model(model_name)
-                    if not success:
-                         log(f"Warning: Failed to load {model_name}", "WARNING")
-                         all_loaded = False
-
-                if not all_loaded:
-                    self._model_load_failures += 1
-                    msg = f"One or more models failed to load (attempt {self._model_load_failures}/{self._MODEL_LOAD_MAX_FAILURES})"
-                    log(msg, "ERROR")
-                    self.status_message = "Error loading models"
-                    db.update_job_status(job_id, "failed", msg)
-                    return
-
-                self.shared_scorer = new_scorer
-                self._model_load_failures = 0  # Reset on success
-                log("Models initialized successfully.")
-
-            except Exception as e:
-                self._model_load_failures += 1
-                msg = f"Error loading models (attempt {self._model_load_failures}/{self._MODEL_LOAD_MAX_FAILURES}): {str(e)}"
-                log(msg, "ERROR")
-                self.status_message = "Error loading models"
-                db.update_job_status(job_id, "failed", msg)
-                return
-        else:
-            log("Using injected scoring engine (no lazy model load).")
+        if not self._init_shared_scorer(log):
+            db.update_job_status(job_id, "failed", self.status_message)
+            event_manager.broadcast_threadsafe(
+                "job_completed",
+                {"job_id": job_id, "status": "failed", "error": self.status_message},
+            )
+            return
 
         def on_progress(cur, tot):
             self.current_count = cur
@@ -494,36 +494,16 @@ class ScoringRunner:
         log(f"Found {len(records)} incomplete records requiring fix.")
         self.status_message = "Fixing..."
 
-        # Checking/Loading Models (Same as run_batch)
-        if self.shared_scorer is None:
-            log("Initializing models...")
-            try:
-                new_scorer = MultiModelMUSIQ()
-                musiq_models = ['spaq', 'ava']
-                all_loaded = True
-                for model_name in musiq_models:
-                    success = new_scorer.load_model(model_name)
-                    if not success:
-                        log(f"Warning: Failed to load {model_name}")
-                        all_loaded = False
+        def _fix_log(msg, level="INFO"):
+            log(msg)
 
-                if not all_loaded:
-                    self._model_load_failures += 1
-                    msg = f"One or more models failed to load (attempt {self._model_load_failures}/{self._MODEL_LOAD_MAX_FAILURES})"
-                    log(msg)
-                    self.status_message = "Error loading models"
-                    db.update_job_status(job_id, "failed", msg)
-                    return
-
-                self.shared_scorer = new_scorer
-                self._model_load_failures = 0  # Reset on success
-            except Exception as e:
-                self._model_load_failures += 1
-                msg = f"Error loading models (attempt {self._model_load_failures}/{self._MODEL_LOAD_MAX_FAILURES}): {str(e)}"
-                log(msg)
-                self.status_message = "Error loading models"
-                db.update_job_status(job_id, "failed", msg)
-                return
+        if not self._init_shared_scorer(_fix_log):
+            db.update_job_status(job_id, "failed", self.status_message)
+            event_manager.broadcast_threadsafe(
+                "job_completed",
+                {"job_id": job_id, "status": "failed", "error": self.status_message},
+            )
+            return
 
         # Create Jobs
         jobs = []
@@ -757,28 +737,16 @@ class ScoringRunner:
 
         self.status_message = "Scoring (Manual)..."
 
-        # Initialize models if needed
-        if self.shared_scorer is None:
-            try:
-                # MultiModelMUSIQ is imported via canonical package path at module import time.
-                new_scorer = MultiModelMUSIQ()
-                all_loaded = True
-                for m in ['spaq', 'ava']:
-                    success = new_scorer.load_model(m)
-                    if not success:
-                        all_loaded = False
+        log_msgs = []
 
-                if not all_loaded:
-                    self._model_load_failures += 1
-                    return False, (f"One or more models failed to load (attempt {self._model_load_failures}/"
-                                  f"{self._MODEL_LOAD_MAX_FAILURES})")
+        def capture_log(msg):
+            log_msgs.append(msg)
 
-                self.shared_scorer = new_scorer
-                self._model_load_failures = 0  # Reset on success
-            except Exception as e:
-                self._model_load_failures += 1
-                return False, (f"Error initializing models (attempt {self._model_load_failures}/"
-                              f"{self._MODEL_LOAD_MAX_FAILURES}): {e}")
+        def _manual_log(msg, level="INFO"):
+            capture_log(msg)
+
+        if not self._init_shared_scorer(_manual_log):
+            return False, self.status_message
 
         # Create Job
         from modules import pipeline
@@ -788,11 +756,6 @@ class ScoringRunner:
             skip_existing=False
         )
 
-        # Capture logs
-        log_msgs = []
-        def capture_log(msg):
-            log_msgs.append(msg)
-            
         # Create temporary processor
         processor = BatchImageProcessor(
             scorer=self.shared_scorer,

--- a/tests/test_engines_factory.py
+++ b/tests/test_engines_factory.py
@@ -1,0 +1,95 @@
+"""Unit tests for production MultiModelHost factory (no GPU/TF)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from modules.engines.factory import (
+    create_production_scoring_host,
+    ensure_production_registry,
+    load_production_models,
+)
+from modules.engines.host import MultiModelHost
+from modules.engines.registry import ModelRegistry, reset_registry
+
+
+class _StubMusiqBackend:
+    VERSION = "stub-musiq"
+    model_sources = {"spaq": {}, "ava": {}}
+
+    def load_model(self, name: str) -> bool:
+        return name in ("spaq", "ava")
+
+    def predict_quality(self, image_path: str, name: str):
+        return 70.0 if name == "spaq" else 5.0
+
+    def is_raw_file(self, file_path: str) -> bool:
+        return False
+
+    def preprocess_image(self, file_path: str, **kwargs):
+        return file_path
+
+    def calculate_weighted_categories(self, normalized):
+        return {"general": 0.5, "technical": 0.5, "aesthetic": 0.5}
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    reset_registry()
+    yield
+    reset_registry()
+
+
+def test_ensure_production_registry_registers_musiq_and_liqe():
+    reg = ModelRegistry()
+    ensure_production_registry(_StubMusiqBackend(), registry=reg)
+    names = {m.name for m in reg.all_registered()}
+    assert {"spaq", "ava", "liqe"}.issubset(names)
+
+
+@patch("scripts.python.run_all_musiq_models.MultiModelMUSIQ", _StubMusiqBackend)
+def test_create_production_scoring_host_returns_host():
+    host = create_production_scoring_host(registry=ModelRegistry())
+    assert isinstance(host, MultiModelHost)
+    assert host.backend.VERSION == "stub-musiq"
+
+
+def test_load_production_models_fails_when_enabled_model_missing():
+    reg = ModelRegistry()
+
+    class _FailSpaq(_StubMusiqBackend):
+        def load_model(self, name: str) -> bool:
+            return name != "spaq"
+
+    backend = _FailSpaq()
+    ensure_production_registry(backend, registry=reg)
+    host = MultiModelHost(backend=backend, registry=reg)
+    ok, msg = load_production_models(host)
+    assert ok is False
+    assert "spaq" in msg
+
+
+def test_load_production_models_allows_shadow_only_failure():
+    from modules.engines.topiq_model import TopiqModelWrapper
+
+    reg = ModelRegistry()
+    ensure_production_registry(_StubMusiqBackend(), registry=reg)
+    reg.register(TopiqModelWrapper(scorer=MagicMock(available=False)))
+
+    object.__setattr__(
+        reg,
+        "_resolve_config",
+        staticmethod(
+            lambda _s: {
+                "spaq": {"enabled": True, "shadow": False},
+                "ava": {"enabled": True, "shadow": False},
+                "liqe": {"enabled": True, "shadow": False},
+                "topiq": {"enabled": False, "shadow": True},
+            }
+        ),
+    )
+    host = MultiModelHost(backend=_StubMusiqBackend(), registry=reg)
+    ok, _msg = load_production_models(host)
+    assert ok is True

--- a/tests/test_pipeline_registry_host_skip.py
+++ b/tests/test_pipeline_registry_host_skip.py
@@ -1,0 +1,35 @@
+"""ScoringWorker skips legacy registry injection when scorer is MultiModelHost."""
+
+from __future__ import annotations
+
+import queue
+import threading
+
+from modules.engines.host import MultiModelHost
+from modules.engines.registry import ModelRegistry
+from modules.pipeline import ScoringWorker
+
+
+class _FakeModel:
+    name = "topiq"
+    score_range = (0.0, 1.0)
+
+    def load(self) -> bool:
+        return True
+
+    def predict(self, _path):
+        return {"score": 0.5, "status": "success"}
+
+    def normalize(self, raw: float) -> float:
+        return raw
+
+
+def test_run_registry_models_noop_for_host(monkeypatch):
+    reg = ModelRegistry()
+    reg.register(_FakeModel())
+    backend = type("B", (), {"model_sources": {}})()
+    host = MultiModelHost(backend=backend, registry=reg)
+    worker = ScoringWorker(queue.Queue(), queue.Queue(), threading.Event(), host)
+    external = {}
+    worker._run_registry_models(external, "/x.jpg", lambda *a, **k: None)
+    assert external == {}

--- a/tests/test_scoring_host_init.py
+++ b/tests/test_scoring_host_init.py
@@ -1,0 +1,41 @@
+"""ScoringRunner uses MultiModelHost via factory (mocked, no ML)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from modules.scoring import ScoringRunner
+
+
+@patch("modules.scoring._musiq_import_error", None)
+def test_init_shared_scorer_builds_host():
+    runner = ScoringRunner()
+    host = MagicMock()
+    host.VERSION = "host-test"
+
+    with patch(
+        "modules.engines.factory.create_production_scoring_host",
+        return_value=host,
+    ) as create_mock, patch(
+        "modules.engines.factory.load_production_models",
+        return_value=(True, "ok"),
+    ) as load_mock:
+        logs = []
+        ok = runner._init_shared_scorer(lambda msg, level="INFO": logs.append(msg))
+
+    assert ok is True
+    assert runner.shared_scorer is host
+    create_mock.assert_called_once()
+    load_mock.assert_called_once()
+    assert load_mock.call_args[0][0] is host
+    assert any("Models initialized" in m for m in logs)
+
+
+@patch("modules.scoring._musiq_import_error", None)
+def test_init_shared_scorer_reuses_injected_engine():
+    injected = MagicMock()
+    runner = ScoringRunner(scoring_engine=injected)
+    logs = []
+    assert runner._init_shared_scorer(lambda msg, level="INFO": logs.append(msg)) is True
+    assert runner.shared_scorer is injected
+    assert any("injected" in m.lower() for m in logs)


### PR DESCRIPTION
## Summary

- ScoringRunner lazy-loads a registry-driven `MultiModelHost` (via `modules/engines/factory.py`) instead of calling `MultiModelMUSIQ` directly for batch, fix-db, and single-image scoring.
- `ScoringWorker` skips legacy `_run_registry_models` and duplicate LIQE when the host already runs active registry models, so shadow scores (e.g. `topiq` with `scoring.models` `shadow: true`) flow to `image_model_scores` without double inference.
- Unit tests cover the factory, runner init, and pipeline host skip behavior.

Part of epic #214 (post-wrapper next steps). QPT V2 shadow rows remain blocked on upstream inference code / wrapper merge.

## Test plan

- [x] `pytest tests/test_engines_factory.py tests/test_scoring_host_init.py tests/test_pipeline_registry_host_skip.py` (and related engine tests)
- [ ] Run scoring on a small folder with `scoring.models.topiq` set to `{ "enabled": false, "shadow": true }` and confirm `image_model_scores` rows for `topiq` with `is_shadow=true`
- [ ] Confirm fused `score_general` / `technical` / `aesthetic` unchanged (shadow excluded)

Closes #184
