### PR TITLE
feat(scoring): local QPT V2 inference + deprecate KONIQ/PAQ2PIQ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,6 +212,9 @@ test_log.txt
 # Model Checkpoints
 models/checkpoints/*.npz
 models/checkpoints/vila-tensorflow2-image-v1/
+# QPT V2 weights (download iqa.pth from KeiChiTse/QPT-V2; ~75MB, never commit)
+models/qpt_v2.pth
+models/*.pth
 
 # Visual Studio & Test Results
 .vs/

--- a/docs/planning/models/CALIBRATION_LAYER_185_STATUS.md
+++ b/docs/planning/models/CALIBRATION_LAYER_185_STATUS.md
@@ -1,0 +1,119 @@
+# #185 — Calibration layer + percentile anchors: status & blockers
+
+**Issue:** [#185](https://github.com/synthet/image-scoring-backend/issues/185) — *scoring stack: calibration layer + percentile anchors for new models* (sub-task of #180; dep: #184).
+**Status:** Partially done; remaining work is **data-blocked**. Captured here so the issue can be moved to `Blocked` with a concrete unblock path.
+**Last assessed:** 2026-05-23.
+
+## What #185 asks for
+
+1. Add empirical percentile anchors (`p02`/`p98`) for `qpt_v2` and `topiq` to
+   `DEFAULT_PERCENTILE_ANCHORS` in [`modules/score_normalization.py`](../../../modules/score_normalization.py),
+   computed from shadow scores over the corpus.
+2. Implement the calibration layer from the proposal
+   [§"Add a calibration layer"](IQA_MODEL_STACK_UPDATE_PROPOSAL.md) — z-score /
+   percentile, optional isotonic/logistic — so raw outputs are comparable before fusion.
+
+## Current state
+
+| Deliverable | State | Notes |
+|-------------|-------|-------|
+| `topiq` percentile anchors | ✅ Done | `score_normalization.py:29` → `{p02: 0.390, p98: 0.709}` (also in `config.json` `percentile_anchors`). |
+| `qpt_v2` percentile anchors | ⛔ Blocked | See Blocker A. |
+| Calibration method: **percentile** | ✅ Done | `rescale_percentile()` (`score_normalization.py:124`), config-overridable via `percentile_anchors`. |
+| Calibration method: **z-score** | ⛔ Blocked | Mechanism not built; params need a corpus. See Blocker B. |
+| Calibration method: **isotonic / logistic** | ⛔ Blocked | Optional in the proposal. See Blocker C. |
+
+## Blockers
+
+### A. `qpt_v2` inference now runs locally — but scores are unvalidated
+**Update (2026-05-23):** inference is no longer fully blocked. Upstream inference code is
+still an open TODO ([KeiChiTse/QPT-V2](https://github.com/KeiChiTse/QPT-V2)), but we now
+reconstruct the HiViT-T architecture locally in `modules/qpt_v2_arch.py` from the published
+`iqa.pth` state dict — it strict-loads all 172 tensors, and `QptV2Scorer.available` becomes
+`True` once `iqa.pth` is placed at `scoring.qpt_v2.checkpoint_path` (default
+`models/qpt_v2.pth`, git-ignored). Verified on sample images: scores are produced and are
+directionally sensitive to quality (Gaussian blur lowers them in every test case).
+
+Two residual problems remain before calibration is meaningful:
+1. **Recipe fidelity (accuracy risk).** The upstream inference recipe (preprocessing/crop,
+   token pooling, patch-merge order) is undocumented. Our reconstruction produces a
+   compressed range (~`[-0.25, 0]`, *not* 0–1) and mixed behavior on JPEG degradation — the
+   same "not satisfactory" symptom reported in
+   [QPT-V2 issue #2](https://github.com/KeiChiTse/QPT-V2/issues/2). Scores must be validated
+   against a labelled IQA set (e.g. Spearman vs MOS) before trusting them.
+2. **No corpus scores yet.** Empirical `p02`/`p98` need a population of real shadow scores
+   in `image_model_scores`; computing them requires a full shadow-scoring pass over the
+   corpus, which needs the DB (see Blocker B).
+
+**Unblocks when:** (a) the reconstruction is validated against a labelled set (or upstream
+ships the real recipe), and (b) a shadow-scoring pass populates `image_model_scores`, after
+which anchors can be computed and the raw range mapped to 0–1.
+
+#### Recovered architecture (from `iqa.pth`, 2026-05-23)
+
+The checkpoint is self-describing — `torch.load(...)['params']` is a complete 18.9M-param
+state dict. A local re-implementation no longer needs the unreleased upstream code; the
+exact structure is:
+
+- **Stem** `patch_embed`: `Conv2d(3→96, k=4, s=4)` + `LayerNorm(96)` → 56×56×96 from a 224² input.
+- **Stage 1** `blocks.0–1`: FFN-only blocks (`x = x + mlp(norm2(x))`, no attention),
+  dim 96, MLP ratio 3.0.
+- **PatchMerge** `blocks.2`: `LayerNorm(384)` + `Linear(384→192, bias=False)`, 56²→28².
+- **Stage 2** `blocks.3–4`: FFN-only, dim 192, MLP ratio 3.0.
+- **PatchMerge** `blocks.5`: `LayerNorm(768)` + `Linear(768→384, bias=False)`, 28²→14²(=196).
+- **+`absolute_pos_embed`** `(1, 196, 384)` added at stage 3.
+- **Stage 3** `blocks.6–15` (10 blocks): full transformer (`norm1`+attn, `norm2`+mlp),
+  dim 384, **6 heads**, MLP ratio 4.0, relative position bias table `(729=27², 6)` indexed
+  by `relative_position_index (196, 196)`; `qkv` has bias.
+- **Head**: `norm` `LayerNorm(384)` → mean-pool over 196 tokens →
+  `quality_regressor.fc_cls = Linear(384→64) → GELU → Dropout → Linear(64→1)` → scalar.
+
+**Residual uncertainty (issue #2):** the patch-merge neighbor ordering, attention rel-pos
+detail, and especially the inference-time preprocessing (resize/crop/normalization, fixed
+224² vs native) are not documented, and a community attempt got "not satisfactory" results.
+The architecture is reproducible; matching the paper's *accuracy* is not guaranteed.
+Treat any locally-produced scores as provisional until validated against a labelled set.
+
+### B. z-score params need a held-out corpus, and the corpus DB is unreachable
+z-score normalization needs per-model mean/std computed over the corpus. Neither
+exists yet, and the database is not reachable from the Windows host:
+- `database.engine = postgres`, but `localhost:5432` **timed out** (Docker Postgres
+  not running, or only reachable from WSL).
+
+**Unblocks when:** the Postgres corpus is online (typically from WSL). Then per-model
+mean/std can be derived with the existing tooling
+([`scripts/analysis/model_score_quality_report.py`](../../../scripts/analysis/model_score_quality_report.py),
+currently untracked) which already pulls normalized 0–1 scores and computes
+distribution stats.
+
+### C. isotonic / logistic calibration needs human preference labels
+Marked "optional" in the proposal. Requires labelled human-preference pairs/rankings,
+which we do not collect today. No action until a labelling source exists.
+
+## Proposed approach (once unblocked)
+
+When the corpus DB is reachable, implement the calibration layer as a **pluggable
+dispatcher** in `score_normalization.py` rather than hardcoding one method:
+
+- Config key `calibration.method`: `"percentile"` (default — current behavior, zero
+  change) | `"zscore"`.
+- `calibrate_score(model, score)` dispatches; percentile path keeps using
+  `DEFAULT_PERCENTILE_ANCHORS` / `percentile_anchors`.
+- z-score path reads `DEFAULT_ZSCORE_PARAMS = {model: {mean, std}}` (config-overridable
+  via `zscore_params`), squashed to `[0,1]` (e.g. clamp at ±2σ then linear, or logistic).
+- `rescale_scores()` routes through the dispatcher so `compute_composites()` is unchanged.
+- Per the proposal's module layout, this can later move under a `calibration/` package.
+
+This keeps percentile as the default (no behavior change) and lets z-score be adopted
+per-config once real params are computed. The mechanism itself is unit-testable with
+synthetic data ahead of having corpus params — that is the first chunk of work to pick
+up when the team decides to proceed despite the empirical-params blocker.
+
+## Related files
+
+- [`modules/score_normalization.py`](../../../modules/score_normalization.py) — anchors, percentile rescaling, composites.
+- [`modules/qpt_v2.py`](../../../modules/qpt_v2.py) — QPT V2 scorer (reports `available=false` until upstream ships).
+- [`modules/engines/qpt_v2_model.py`](../../../modules/engines/qpt_v2_model.py) — registry adapter (shadow).
+- `scripts/analysis/model_score_quality_report.py` — corpus distribution/correlation report (anchor source).
+- `scripts/analysis/recalc_composite_scores.py` — recompute composites from stored scores using current anchors.
+- [`docs/technical/MODELS_SUMMARY.md`](../../technical/MODELS_SUMMARY.md), [`docs/technical/MULTI_MODEL_SCORING.md`](../../technical/MULTI_MODEL_SCORING.md) — live model status.

--- a/docs/reference/models/MODEL_WEIGHTS.md
+++ b/docs/reference/models/MODEL_WEIGHTS.md
@@ -43,13 +43,19 @@ runs and stores scores but is excluded from composite fusion until promoted in #
 
 ### Checkpoint acquisition
 
-1. Install the inference package:
-   ```
-   pip install git+https://github.com/KeiChiTse/QPT-V2
-   ```
-2. Download the HiViT-T checkpoint from the [GitHub releases](https://github.com/KeiChiTse/QPT-V2).
-3. Place the file at `models/qpt_v2.pth` relative to the repo root,
+> ⚠️ **Runs locally, but unvalidated.** Upstream [KeiChiTse/QPT-V2](https://github.com/KeiChiTse/QPT-V2)
+> published **checkpoints only** (inference code is still an open TODO). The architecture is
+> reconstructed locally in `modules/qpt_v2_arch.py` from the `iqa.pth` state dict and
+> strict-loads all 172 tensors. The undocumented inference recipe means scores are
+> directionally meaningful but **uncalibrated** — keep `qpt_v2` in shadow (see #185).
+
+1. Download the task checkpoint from the repo's `checkpoints/` directory
+   (`iqa.pth` for image quality, `iaa.pth` for aesthetics) — these are git-lfs files
+   in-repo (~75 MB), not under GitHub releases. Direct URL:
+   `https://media.githubusercontent.com/media/KeiChiTse/QPT-V2/master/checkpoints/iqa.pth`.
+2. Place the file at `models/qpt_v2.pth` relative to the repo root (git-ignored),
    **or** set `scoring.qpt_v2.checkpoint_path` in `config.json` to an absolute path.
+3. That's it — `QptV2Scorer` reports `available=true` and produces shadow scores.
 
 ### Target weights (post-calibration, issue #185)
 

--- a/docs/technical/MODELS_SUMMARY.md
+++ b/docs/technical/MODELS_SUMMARY.md
@@ -11,12 +11,17 @@ production vs. shadow membership is decided by `scoring.models` in `config.json`
 
 The backbone of the scoring system. Processing multi-scale inputs to capture global and local details.
 
+**Live variants** (registered by `modules/engines/factory.py`, fused — production):
+
 | Variant | Dataset | Range | Role |
 |---------|---------|-------|------|
-| **KONIQ** | KonIQ-10k | 0-100 | **Reliability**. Large dataset of in-the-wild images. |
 | **SPAQ** | SPAQ | 0-100 | **Discrimination**. Smartphone photography dataset. |
-| **PAQ2PIQ**| PaQ-2-PiQ | 0-100 | **Detail**. Massive dataset, good for artifacts. |
 | **AVA** | AVA | 1-10 | **Legacy Aesthetic**. Professional curation dataset. |
+
+**Deprecated variants (not wired):** `KONIQ` (KonIQ-10k) and `PAQ2PIQ` (PaQ-2-PiQ)
+are no longer registered into the live scorer. `make_musiq_wrappers` skips them with
+a warning, and their score ranges are retained in `modules/engines/musiq_model.py`
+only so historical `image_model_scores` rows still normalize.
 
 ## 2. LIQE (Language-Image Quality Evaluator)
 *PyTorch Implementation*
@@ -40,13 +45,21 @@ analysis. It contributes to all three composites under the "moderate" profile
 ## 4. QPT V2 (Quality-aware Pre-Training V2)
 *PyTorch Implementation (shadow)*
 
-**Status: Shadow (not fused)**
+**Status: Shadow (not fused) — runs via local re-implementation, UNVALIDATED**
 Registered as a shadow model (`scoring.models.qpt_v2: {enabled: false, shadow: true}`):
-it runs and stores scores into `image_model_scores` but is excluded from fusion. Upstream
-inference code (`KeiChiTse/QPT-V2`) is not yet published, so the wrapper reports
-`available=false` and produces no rows until the package ships. Calibration anchors are
-blocked on that release (#185).
-- **Module**: `modules/engines/qpt_v2_model.py` (wraps `modules/qpt_v2.py`).
+it stores scores into `image_model_scores` while staying excluded from fusion. Upstream
+(`KeiChiTse/QPT-V2`) published **checkpoints only** (`iqa.pth`, `iaa.pth`, `vqa_*.pth`);
+the inference code is an open upstream TODO. We reconstruct the HiViT-T architecture
+locally in `modules/qpt_v2_arch.py` (derived from the `iqa.pth` state dict, strict-loads
+all 172 tensors). Drop `iqa.pth` at `scoring.qpt_v2.checkpoint_path` (default
+`models/qpt_v2.pth`) to activate.
+- **Caveat**: the upstream inference recipe (preprocessing, pooling, merge order) is
+  undocumented. Scores are directionally meaningful (blur lowers them) but **unvalidated
+  and uncalibrated**; raw output is roughly `[-0.25, 0]`, *not* 0–1. Keep it in shadow and
+  treat scores as provisional until calibration anchors are computed (#185). See
+  [QPT-V2 issue #2](https://github.com/KeiChiTse/QPT-V2/issues/2).
+- **Module**: `modules/engines/qpt_v2_model.py` (wraps `modules/qpt_v2.py`,
+  arch in `modules/qpt_v2_arch.py`).
 
 ## 5. LLM-judge engines (Cursor / Claude)
 *Optional, disabled by default*

--- a/docs/technical/MULTI_MODEL_SCORING.md
+++ b/docs/technical/MULTI_MODEL_SCORING.md
@@ -12,7 +12,7 @@ This script runs all available MUSIQ (Multi-scale Image Quality Transformer) mod
 
 ## Features
 
-- **Multiple Models**: Runs SPAQ, AVA, KONIQ, and PAQ2PIQ models
+- **Multiple Models**: The live pipeline runs SPAQ + AVA (MUSIQ family); KONIQ and PAQ2PIQ are deprecated and no longer wired
 - **GPU Acceleration**: Full CUDA support with automatic CPU fallback
 - **JSON Output**: Structured results with scores, ranges, and normalized values
 - **Drag-and-Drop**: Easy-to-use batch and PowerShell scripts
@@ -26,8 +26,8 @@ This script runs all available MUSIQ (Multi-scale Image Quality Transformer) mod
 |-------|---------|-------------|-------------|
 | SPAQ | SPAQ | 0.0 - 100.0 | Smartphone Photography Aesthetics Quality |
 | AVA | AVA | 1.0 - 10.0 | Aesthetic Visual Analysis |
-| KONIQ | KONIQ-10K | 0.0 - 100.0 | Konstanz Natural Image Quality (legacy — not in default fusion) |
-| PAQ2PIQ | PAQ2PIQ | 0.0 - 100.0 | Perceptual Assessment of Image Quality (legacy — not in default fusion) |
+| KONIQ | KONIQ-10K | 0.0 - 100.0 | Konstanz Natural Image Quality (**deprecated** — not wired into the live registry) |
+| PAQ2PIQ | PAQ2PIQ | 0.0 - 100.0 | Perceptual Assessment of Image Quality (**deprecated** — not wired into the live registry) |
 
 ### Registry models (live pipeline)
 

--- a/modules/engines/musiq_model.py
+++ b/modules/engines/musiq_model.py
@@ -30,6 +30,13 @@ _MUSIQ_RANGES: Dict[str, Tuple[float, float]] = {
     "vila": (0.0, 1.0),
 }
 
+# MUSIQ-family variants retired from the live registry. The ranges above are
+# kept so historical `image_model_scores` rows still normalize, but these are
+# no longer wired into scoring: `make_musiq_wrappers` refuses to build them and
+# logs a deprecation warning if a config still requests them. `vila` was
+# deprecated earlier (see docs/technical/MODELS_SUMMARY.md).
+_DEPRECATED_MUSIQ: frozenset = frozenset({"koniq", "paq2piq", "vila"})
+
 
 class MusiqModelWrapper(IScoringModel):
     """One scoring model from the MUSIQ family (SPAQ, AVA, KONIQ, PAQ2PIQ, VILA).
@@ -83,14 +90,21 @@ class MusiqModelWrapper(IScoringModel):
 def make_musiq_wrappers(backend: Any, names: Optional[list[str]] = None) -> list[MusiqModelWrapper]:
     """Build wrappers for the requested MUSIQ models, sharing one backend.
 
-    Defaults to the production set (`spaq`, `ava`). Pass an explicit list to
-    register additional models like `koniq` or `paq2piq` from config.
+    Defaults to the production set (`spaq`, `ava`). Deprecated variants
+    (`koniq`, `paq2piq`, `vila`) are skipped with a warning even if requested.
     """
     wanted = names if names is not None else ["spaq", "ava"]
     out: list[MusiqModelWrapper] = []
     for name in wanted:
         if name not in _MUSIQ_RANGES:
             logger.warning("Skipping unknown MUSIQ model %r", name)
+            continue
+        if name in _DEPRECATED_MUSIQ:
+            logger.warning(
+                "MUSIQ model %r is deprecated and no longer wired; skipping. "
+                "Remove it from the scoring config.",
+                name,
+            )
             continue
         out.append(MusiqModelWrapper(name=name, backend=backend))
     return out

--- a/modules/qpt_v2.py
+++ b/modules/qpt_v2.py
@@ -1,20 +1,27 @@
-"""Persistent QPT V2 scorer (custom PyTorch, HiViT-T backbone).
+"""Persistent QPT V2 scorer (HiViT-T backbone, local re-implementation).
 
-QPT V2 (Quality-aware Pre-Training V2) is a no-reference IQA/IAA model
-based on masked image modeling (ACM MM 2024). Checkpoint source:
+QPT V2 (Quality-aware Pre-Training V2) is a no-reference IQA/IAA model based on
+masked image modeling (ACM MM 2024). Source:
     KeiChiTse/QPT-V2 — https://github.com/KeiChiTse/QPT-V2
 
-Unlike TOPIQ-NR and LIQE, QPT V2 is not available via pyiqa. The scorer
-requires:
-  1. The QPT V2 package installed:
-         pip install git+https://github.com/KeiChiTse/QPT-V2
-  2. The HiViT-T checkpoint placed at the path given by
-     ``scoring.qpt_v2.checkpoint_path`` in config.json
-     (default: ``models/qpt_v2.pth`` relative to BASE_DIR).
+Upstream released **checkpoints only** (``checkpoints/iqa.pth``, ``iaa.pth``,
+``vqa_*.pth``); inference/training code remain open TODOs, so there is no
+installable ``qpt_v2`` package. We instead reconstruct the architecture locally
+in ``modules.qpt_v2_arch`` (derived from the published ``iqa.pth`` state dict)
+and strict-load it. To enable scoring:
 
-If either prerequisite is missing the scorer sets ``available = False`` and
-logs a warning; all engine machinery (registration, shadow scoring, DB writes)
-continues normally.
+    Download ``iqa.pth`` from the repo's ``checkpoints/`` directory and point
+    ``scoring.qpt_v2.checkpoint_path`` at it (default: ``models/qpt_v2.pth``
+    relative to BASE_DIR).
+
+If torch/torchvision or the checkpoint are missing the scorer sets
+``available = False`` and logs a warning; all engine machinery (registration,
+shadow scoring, DB writes) continues normally.
+
+ACCURACY CAVEAT: the upstream inference recipe (preprocessing/crop, pooling,
+merge order) is undocumented. Locally-produced scores are directionally
+meaningful (e.g. blur lowers them) but UNVALIDATED and UNCALIBRATED — keep
+qpt_v2 in shadow until anchors are computed (#185). See QPT-V2 issue #2.
 
 The matching ``IScoringModel`` adapter is ``modules.engines.qpt_v2_model``.
 """
@@ -59,6 +66,7 @@ class QptV2Scorer:
     """
 
     DEFAULT_MAX_DIM = 1024
+    INPUT_SIZE = 224  # HiViT-T expects fixed 224x224 (absolute_pos_embed = 14x14 tokens)
     VERSION = "qpt-v2-1"
     SCORE_RANGE = "0.0-1.0"
 
@@ -135,31 +143,31 @@ class QptV2Scorer:
     # ------------------------------------------------------------------
 
     def _load_model(self, checkpoint_path: str) -> None:
-        """Load the HiViT-T model from *checkpoint_path*.
+        """Load the QPT V2 model from *checkpoint_path* via the local HiViT-T
+        re-implementation (``modules.qpt_v2_arch``).
 
-        Requires the qpt_v2 package:
-            pip install git+https://github.com/KeiChiTse/QPT-V2
-
-        Once the QPT V2 repository releases inference code the import path
-        below (``from qpt_v2.models import build_model``) should be verified
-        against the published API and updated if needed.
+        Upstream has not released inference code (open TODO in the
+        KeiChiTse/QPT-V2 README), so we reconstruct the architecture from the
+        published ``iqa.pth`` and strict-load ``ckpt['params']``. Scores are
+        directionally meaningful but UNVALIDATED/UNCALIBRATED — see the module
+        docstring of ``modules.qpt_v2_arch`` and QPT-V2 issue #2.
         """
         try:
-            from qpt_v2.models import build_model  # type: ignore[import]
-        except ImportError:
-            logger.warning(
-                "QPT V2: package not installed. "
-                "Install with: pip install git+https://github.com/KeiChiTse/QPT-V2"
-            )
+            from modules.qpt_v2_arch import load_qpt_v2
+        except Exception as exc:
+            logger.error("QPT V2: could not import local architecture: %s", exc)
             return
 
         try:
-            checkpoint = torch.load(checkpoint_path, map_location=self.device)
-            state_dict = checkpoint.get("model", checkpoint)
-            self._model = build_model()
-            self._model.load_state_dict(state_dict)
-            self._model.eval()
-            self._model.to(self.device)
+            model = load_qpt_v2(checkpoint_path, device=self.device)
+            if model is None:
+                logger.warning(
+                    "QPT V2: checkpoint at '%s' did not match the expected HiViT-T "
+                    "structure; scoring stays disabled.",
+                    checkpoint_path,
+                )
+                return
+            self._model = model
             self._normalize_transform = T.Normalize(_IMAGENET_MEAN, _IMAGENET_STD)
             self.available = True
             logger.info("QPT V2 model loaded on %s from %s", self.device, checkpoint_path)
@@ -171,11 +179,13 @@ class QptV2Scorer:
     # ------------------------------------------------------------------
 
     def _preprocess(self, img: Image.Image) -> "torch.Tensor":
-        """PIL image → float tensor on device, resized to ≤ max_dimension."""
-        if max(img.size) > self.max_dimension:
-            ratio = self.max_dimension / max(img.size)
-            new_size = (int(img.size[0] * ratio), int(img.size[1] * ratio))
-            img = img.resize(new_size, Image.BICUBIC)
+        """PIL image → float tensor on device, resized to the fixed HiViT input.
+
+        HiViT-T uses a fixed-size absolute position embedding (14x14 tokens), so
+        the input must be exactly ``INPUT_SIZE`` x ``INPUT_SIZE``. Aspect ratio
+        is not preserved — this matches the simplest documented recipe; the exact
+        upstream crop strategy is unknown (see ``modules.qpt_v2_arch``)."""
+        img = img.resize((self.INPUT_SIZE, self.INPUT_SIZE), Image.BICUBIC)
         tensor = TF.to_tensor(img)
         tensor = self._normalize_transform(tensor)
         return tensor.unsqueeze(0).to(self.device)

--- a/modules/qpt_v2_arch.py
+++ b/modules/qpt_v2_arch.py
@@ -1,0 +1,216 @@
+"""Local re-implementation of the QPT V2 (HiViT-T) image-quality scorer.
+
+Upstream (``KeiChiTse/QPT-V2``) released **checkpoints only** — the inference
+code is an unfulfilled TODO. This module reconstructs the architecture directly
+from the published ``iqa.pth`` state dict (``ckpt['params']``, 18.9M params), so
+the checkpoint loads with ``strict=True`` (all 172 tensors map by name + shape).
+
+Recovered structure (see docs/planning/models/CALIBRATION_LAYER_185_STATUS.md):
+
+    patch_embed : Conv2d(3->96, k=4, s=4) + LayerNorm(96)     224^2 -> 56^2 x96
+    blocks.0-1  : FFN-only (norm2 + mlp), dim 96,  mlp_ratio 3.0
+    blocks.2    : PatchMerge  LN(384) + Linear(384->192, bias=False)  56->28
+    blocks.3-4  : FFN-only, dim 192, mlp_ratio 3.0
+    blocks.5    : PatchMerge  LN(768) + Linear(768->384, bias=False)  28->14
+    + absolute_pos_embed (1,196,384) at the main stage
+    blocks.6-15 : attention (norm1+attn, norm2+mlp), dim 384, 6 heads, mlp_ratio 4.0
+                  relative_position_bias_table (729=27^2, 6) via shared
+                  relative_position_index (196,196)
+    norm        : LayerNorm(384) -> mean-pool over 196 tokens
+    quality_regressor.fc_cls : Linear(384->64) -> GELU -> Dropout -> Linear(64->1)
+
+ACCURACY CAVEAT: the forward-pass conventions (patch-merge neighbour order,
+relative-position indexing, pooling, and inference preprocessing) are not
+documented upstream; a community attempt to run these weights reported
+unsatisfactory results (QPT-V2 issue #2). Treat scores as provisional until
+validated against a labelled set.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import torch
+import torch.nn as nn
+
+logger = logging.getLogger(__name__)
+
+# HiViT-T config as dictated by the QPT V2 iqa.pth checkpoint.
+_STEM_DIM = 96
+_MAIN_DIM = 384
+_NUM_HEADS = 6
+_DEPTHS = (2, 2, 10)        # stem stage 1, stem stage 2, main stage
+_STEM_MLP_RATIO = 3.0
+_MAIN_MLP_RATIO = 4.0
+_MAIN_GRID = 14             # 14 x 14 = 196 tokens at the main stage
+
+
+class _Mlp(nn.Module):
+    def __init__(self, dim: int, hidden: int) -> None:
+        super().__init__()
+        self.fc1 = nn.Linear(dim, hidden)
+        self.act = nn.GELU()
+        self.fc2 = nn.Linear(hidden, dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.fc2(self.act(self.fc1(x)))
+
+
+class _BlockNoAttn(nn.Module):
+    """Stem-stage block: FFN only (operates on (B, H, W, C))."""
+
+    def __init__(self, dim: int, mlp_ratio: float) -> None:
+        super().__init__()
+        self.norm2 = nn.LayerNorm(dim)
+        self.mlp = _Mlp(dim, int(dim * mlp_ratio))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x + self.mlp(self.norm2(x))
+
+
+class _PatchMerge(nn.Module):
+    """Concatenate 2x2 neighbours then LayerNorm + linear reduce (4C -> 2C)."""
+
+    def __init__(self, dim: int) -> None:
+        super().__init__()
+        self.norm = nn.LayerNorm(dim * 4)
+        self.reduction = nn.Linear(dim * 4, dim * 2, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # x: (B, H, W, C) -> (B, H/2, W/2, 4C)
+        x0 = x[:, 0::2, 0::2, :]
+        x1 = x[:, 1::2, 0::2, :]
+        x2 = x[:, 0::2, 1::2, :]
+        x3 = x[:, 1::2, 1::2, :]
+        x = torch.cat([x0, x1, x2, x3], dim=-1)
+        return self.reduction(self.norm(x))
+
+
+class _Attention(nn.Module):
+    def __init__(self, dim: int, num_heads: int, grid: int) -> None:
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = dim // num_heads
+        self.scale = self.head_dim ** -0.5
+        self.qkv = nn.Linear(dim, dim * 3, bias=True)
+        self.proj = nn.Linear(dim, dim)
+        # (2*grid-1)^2 relative positions x heads
+        self.relative_position_bias_table = nn.Parameter(
+            torch.zeros((2 * grid - 1) * (2 * grid - 1), num_heads)
+        )
+
+    def forward(self, x: torch.Tensor, rpe_index: torch.Tensor) -> torch.Tensor:
+        B, N, C = x.shape
+        qkv = self.qkv(x).reshape(B, N, 3, self.num_heads, self.head_dim).permute(2, 0, 3, 1, 4)
+        q, k, v = qkv[0], qkv[1], qkv[2]
+        attn = (q @ k.transpose(-2, -1)) * self.scale
+        bias = self.relative_position_bias_table[rpe_index].view(N, N, -1).permute(2, 0, 1)
+        attn = attn + bias.unsqueeze(0)
+        attn = attn.softmax(dim=-1)
+        x = (attn @ v).transpose(1, 2).reshape(B, N, C)
+        return self.proj(x)
+
+
+class _BlockAttn(nn.Module):
+    """Main-stage transformer block (operates on (B, N, C))."""
+
+    def __init__(self, dim: int, num_heads: int, mlp_ratio: float, grid: int) -> None:
+        super().__init__()
+        self.norm1 = nn.LayerNorm(dim)
+        self.attn = _Attention(dim, num_heads, grid)
+        self.norm2 = nn.LayerNorm(dim)
+        self.mlp = _Mlp(dim, int(dim * mlp_ratio))
+
+    def forward(self, x: torch.Tensor, rpe_index: torch.Tensor) -> torch.Tensor:
+        x = x + self.attn(self.norm1(x), rpe_index)
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+
+class _PatchEmbed(nn.Module):
+    def __init__(self, in_chans: int, dim: int) -> None:
+        super().__init__()
+        self.proj = nn.Conv2d(in_chans, dim, kernel_size=4, stride=4)
+        self.norm = nn.LayerNorm(dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.proj(x)                       # (B, C, H/4, W/4)
+        x = x.permute(0, 2, 3, 1).contiguous()  # (B, H/4, W/4, C)
+        return self.norm(x)
+
+
+def _build_relative_position_index(grid: int) -> torch.Tensor:
+    coords = torch.stack(torch.meshgrid(
+        torch.arange(grid), torch.arange(grid), indexing="ij"))  # 2, g, g
+    coords_flat = torch.flatten(coords, 1)                       # 2, N
+    rel = coords_flat[:, :, None] - coords_flat[:, None, :]      # 2, N, N
+    rel = rel.permute(1, 2, 0).contiguous()                      # N, N, 2
+    rel[:, :, 0] += grid - 1
+    rel[:, :, 1] += grid - 1
+    rel[:, :, 0] *= 2 * grid - 1
+    return rel.sum(-1)                                           # N, N
+
+
+class QptV2HiViT(nn.Module):
+    """HiViT-T backbone + single-value quality regressor matching ``iqa.pth``."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.patch_embed = _PatchEmbed(3, _STEM_DIM)
+        self.absolute_pos_embed = nn.Parameter(torch.zeros(1, _MAIN_GRID * _MAIN_GRID, _MAIN_DIM))
+        self.register_buffer("relative_position_index", _build_relative_position_index(_MAIN_GRID))
+
+        blocks: list[nn.Module] = []
+        # stem stage 1 (dim 96)
+        for _ in range(_DEPTHS[0]):
+            blocks.append(_BlockNoAttn(_STEM_DIM, _STEM_MLP_RATIO))
+        blocks.append(_PatchMerge(_STEM_DIM))                    # -> 192
+        # stem stage 2 (dim 192)
+        for _ in range(_DEPTHS[1]):
+            blocks.append(_BlockNoAttn(_STEM_DIM * 2, _STEM_MLP_RATIO))
+        blocks.append(_PatchMerge(_STEM_DIM * 2))               # -> 384
+        # main stage (dim 384)
+        for _ in range(_DEPTHS[2]):
+            blocks.append(_BlockAttn(_MAIN_DIM, _NUM_HEADS, _MAIN_MLP_RATIO, _MAIN_GRID))
+        self.blocks = nn.ModuleList(blocks)
+
+        self.norm = nn.LayerNorm(_MAIN_DIM)
+        self.quality_regressor = nn.Module()
+        self.quality_regressor.fc_cls = nn.Sequential(
+            nn.Linear(_MAIN_DIM, 64), nn.GELU(), nn.Dropout(0.0), nn.Linear(64, 1)
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.patch_embed(x)                 # (B, 56, 56, 96)
+        rpe_index = self.relative_position_index.view(-1)
+        for blk in self.blocks:
+            if isinstance(blk, _BlockAttn):
+                if x.dim() == 4:                # entering main stage: flatten + pos embed
+                    B, H, W, C = x.shape
+                    x = x.reshape(B, H * W, C) + self.absolute_pos_embed
+                x = blk(x, rpe_index)
+            else:
+                x = blk(x)
+        x = self.norm(x)
+        x = x.mean(dim=1)                       # global average pool over tokens
+        return self.quality_regressor.fc_cls(x).squeeze(-1)
+
+
+def load_qpt_v2(checkpoint_path: str, device: str = "cpu") -> Optional[QptV2HiViT]:
+    """Build the model and strict-load ``ckpt['params']``. Returns None on failure."""
+    model = QptV2HiViT()
+    ckpt = torch.load(checkpoint_path, map_location=device, weights_only=False)
+    state = ckpt["params"] if isinstance(ckpt, dict) and "params" in ckpt else ckpt
+    missing, unexpected = model.load_state_dict(state, strict=False)
+    if missing or unexpected:
+        logger.error(
+            "QPT V2 checkpoint mismatch: missing=%s unexpected=%s",
+            list(missing), list(unexpected),
+        )
+        return None
+    model.eval().to(device)
+    return model
+
+
+__all__ = ["QptV2HiViT", "load_qpt_v2"]

--- a/tests/test_engines_wrappers.py
+++ b/tests/test_engines_wrappers.py
@@ -178,6 +178,13 @@ def test_make_musiq_wrappers_skips_unknown():
     assert [w.name for w in wrappers] == ["spaq", "ava"]
 
 
+def test_make_musiq_wrappers_skips_deprecated():
+    backend = _StubMusiqBackend()
+    wrappers = make_musiq_wrappers(backend, names=["spaq", "koniq", "paq2piq", "vila", "ava"])
+    # Deprecated variants are not wired, even when explicitly requested.
+    assert [w.name for w in wrappers] == ["spaq", "ava"]
+
+
 # ---------- LiqeModelWrapper ----------
 
 def test_liqe_wrapper_predict_success():

--- a/tests/test_qpt_v2_arch.py
+++ b/tests/test_qpt_v2_arch.py
@@ -1,0 +1,43 @@
+"""Structural tests for the local QPT V2 (HiViT-T) re-implementation.
+
+These do NOT need the upstream checkpoint — they verify the module wiring
+(parameter count, forward shape, batch handling) so the architecture stays
+loadable by ``QptV2HiViT.load_state_dict(strict=...)`` against ``iqa.pth``.
+
+Marked ``ml`` because they require torch.
+"""
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytestmark = pytest.mark.ml
+
+from modules.qpt_v2_arch import QptV2HiViT  # noqa: E402
+
+
+def test_param_count_matches_checkpoint():
+    # iqa.pth ckpt['params'] holds 172 tensors totalling 18,859,789 elements
+    # (incl. the relative_position_index buffer, 196*196=38,416, which is not a
+    # trainable parameter). Matching both guarantees strict-load compatibility.
+    model = QptV2HiViT()
+    sd = model.state_dict()
+    assert len(sd) == 172
+    assert sum(t.numel() for t in sd.values()) == 18_859_789
+
+
+def test_forward_returns_one_score_per_image():
+    model = QptV2HiViT().eval()
+    x = torch.randn(2, 3, 224, 224)
+    with torch.no_grad():
+        out = model(x)
+    assert out.shape == (2,)
+    assert torch.isfinite(out).all()
+
+
+def test_single_image_forward_is_scalar_per_item():
+    model = QptV2HiViT().eval()
+    x = torch.randn(1, 3, 224, 224)
+    with torch.no_grad():
+        out = model(x)
+    assert out.shape == (1,)
+    assert isinstance(out.item(), float)


### PR DESCRIPTION
## Issue

Refs #185 — **does not close it.** This advances the #185 "calibration layer + percentile
anchors for new models" track by unblocking `qpt_v2` inference, but the calibration anchors
themselves remain blocked (scores are unvalidated/uncalibrated; corpus DB needed). Using
`Refs` rather than `Closes` intentionally so the issue stays open. Issue/board tracking is
being handled by the maintainer.

## Backlog hygiene

- [ ] Card moved to `Stage = Review` (maintainer is handling board tracking)
- [ ] If cross-repo, the counterpart issue in `image-scoring-gallery` is linked above — n/a
- [x] API contract / OpenAPI / `API.md` updated when REST behavior or paths changed — n/a, no REST changes
- [x] Plan docs skimmed when track status changed — #185 status doc added/updated

## Summary

**What changed:**

Upstream `KeiChiTse/QPT-V2` publishes **checkpoints only** (inference code is an open TODO),
so this reconstructs the HiViT-T architecture locally from the `iqa.pth` state dict and wires
it into the live shadow scoring path.

- **`modules/qpt_v2_arch.py`** (new): HiViT-T backbone + quality regressor that **strict-loads
  all 172 tensors** of `ckpt['params']` (18.9M). Architecture recovered entirely from the
  checkpoint; correctness proven by zero missing/unexpected keys.
- **`modules/qpt_v2.py`**: load via the local arch instead of the dead
  `from qpt_v2.models import build_model`; fix preprocessing to the required fixed **224×224**
  (HiViT's absolute position embedding is fixed at 14×14 tokens).
- **Deprecate `KONIQ` / `PAQ2PIQ`** MUSIQ variants: `make_musiq_wrappers` skips them with a
  warning; native ranges retained so historical `image_model_scores` rows still normalize.
- **`.gitignore`**: ignore `models/*.pth` so the ~75 MB checkpoint can't be committed.
- Docs: record the recovered architecture and flip `qpt_v2` status from "can't run" to
  "runs locally, unvalidated" across MODELS_SUMMARY, MODEL_WEIGHTS, MULTI_MODEL_SCORING,
  and the new `docs/planning/models/CALIBRATION_LAYER_185_STATUS.md`.

## Motivation

`qpt_v2` was wired as a shadow model but could never produce scores — the placeholder import
`from qpt_v2.models import build_model` targets a package that doesn't exist (upstream never
released inference code). Without scores, the #185 calibration anchors are blocked. This makes
the model actually runnable so that path can progress. KONIQ/PAQ2PIQ were documented but never
registered into the live registry; deprecating them removes the doc/code drift.

## How to test

```bash
# Structural tests (no checkpoint needed) + deprecation + registry/status
python -m pytest tests/test_qpt_v2_arch.py tests/test_engines_wrappers.py \
  tests/test_model_status.py tests/test_engines_registry.py -q
python -m ruff check modules/qpt_v2_arch.py modules/qpt_v2.py modules/engines/musiq_model.py

# Optional end-to-end (requires the checkpoint):
#   download iqa.pth -> models/qpt_v2.pth, then QptV2Scorer.available == True
#   https://media.githubusercontent.com/media/KeiChiTse/QPT-V2/master/checkpoints/iqa.pth
```

**Risk / testing notes:** Verified locally — checkpoint strict-loads (0 missing/unexpected),
end-to-end produces shadow scores, and scores are directionally correct (Gaussian blur lowers
them in every test case). **Caveat:** the upstream inference recipe (crop, pooling, merge
order) is undocumented; raw output is ~`[-0.25, 0]` (not 0–1) and JPEG response is mixed — the
"not satisfactory" symptom from [QPT-V2 issue #2](https://github.com/KeiChiTse/QPT-V2/issues/2).
Scores are provisional until validated against a labelled MOS set + corpus anchors (#185).

## Risk / rollout

Low. `qpt_v2` stays a **shadow** model (`enabled:false, shadow:true`) — never fused into
composites, so user-facing scores are unchanged. With no checkpoint present it fails soft
exactly as before (`available=false`). No migrations, no REST changes, no flags. The
`score_range` is still declared `0.0-1.0` (raw output isn't) — left as-is; mapping the range
is the calibration step under #185, not guessed here.

## SDLC checklist (agent-sdlc)

- [x] Tests added or updated as needed
- [x] Lint / typecheck pass (ruff clean on touched files)
- [x] No secrets or credentials in code
- [x] Docs updated if behavior is user-visible
