### PR TITLE
fix(scoring): QPT V2 center-crop preprocessing + record validation

### DIFF
--- a/docs/planning/models/CALIBRATION_LAYER_185_STATUS.md
+++ b/docs/planning/models/CALIBRATION_LAYER_185_STATUS.md
@@ -45,6 +45,24 @@ Two residual problems remain before calibration is meaningful:
    in `image_model_scores`; computing them requires a full shadow-scoring pass over the
    corpus, which needs the DB (see Blocker B).
 
+#### Validation attempts (2026-05-24, 20–30 sample thumbnails)
+
+Offline checks (no labelled set / corpus available — thumbnails are a weak substrate):
+
+| Check | Result | Read |
+|-------|--------|------|
+| Graded blur monotonicity (σ 0→4), squash-resize | mean Spearman **−0.66** | correct sign, weak |
+| Same, **resize-short-256 + center-crop** (now the default) | mean Spearman **−0.81** | better — preprocessing matters; adopted |
+| QPT-V2 vs NIQE (same images) | Spearman **+0.36** (p≈0.05) | **wrong sign**, weak — NIQE unreliable on thumbnails, but not reassuring |
+
+**Read:** the reconstruction is structurally exact (172/172 tensors) and directionally
+sensitive to blur, but does **not** yet track quality reliably (target blur-Spearman ≤ −0.9;
+NIQE cross-check wrong sign). Center-crop preprocessing was adopted (`QptV2Scorer._preprocess`)
+as it both follows the standard eval recipe and measurably helps. Remaining gap is likely
+further recipe details (token pooling, exact crop/resolution) and/or the thumbnail substrate.
+**Do not trust scores yet; keep `qpt_v2` shadow.** Next: validate on full-resolution images
+against a labelled MOS set, or recover the upstream recipe.
+
 **Unblocks when:** (a) the reconstruction is validated against a labelled set (or upstream
 ships the real recipe), and (b) a shadow-scoring pass populates `image_model_scores`, after
 which anchors can be computed and the raw range mapped to 0–1.

--- a/modules/qpt_v2.py
+++ b/modules/qpt_v2.py
@@ -67,6 +67,7 @@ class QptV2Scorer:
 
     DEFAULT_MAX_DIM = 1024
     INPUT_SIZE = 224  # HiViT-T expects fixed 224x224 (absolute_pos_embed = 14x14 tokens)
+    RESIZE_SHORT = 256  # resize shortest side then center-crop (ImageNet eval recipe)
     VERSION = "qpt-v2-1"
     SCORE_RANGE = "0.0-1.0"
 
@@ -179,13 +180,17 @@ class QptV2Scorer:
     # ------------------------------------------------------------------
 
     def _preprocess(self, img: Image.Image) -> "torch.Tensor":
-        """PIL image → float tensor on device, resized to the fixed HiViT input.
+        """PIL image → float tensor on device at the fixed HiViT input size.
 
         HiViT-T uses a fixed-size absolute position embedding (14x14 tokens), so
-        the input must be exactly ``INPUT_SIZE`` x ``INPUT_SIZE``. Aspect ratio
-        is not preserved — this matches the simplest documented recipe; the exact
-        upstream crop strategy is unknown (see ``modules.qpt_v2_arch``)."""
-        img = img.resize((self.INPUT_SIZE, self.INPUT_SIZE), Image.BICUBIC)
+        the input must be exactly ``INPUT_SIZE`` x ``INPUT_SIZE``. We resize the
+        shortest side to ``RESIZE_SHORT`` (aspect-preserving) then center-crop —
+        the standard ImageNet eval recipe, which tracks quality degradation
+        notably better than a plain squashing resize (blur-Spearman -0.81 vs
+        -0.66 on sample images). The exact upstream recipe is still unknown, so
+        scores remain provisional (see ``modules.qpt_v2_arch``)."""
+        img = TF.resize(img, self.RESIZE_SHORT)
+        img = TF.center_crop(img, [self.INPUT_SIZE, self.INPUT_SIZE])
         tensor = TF.to_tensor(img)
         tensor = self._normalize_transform(tensor)
         return tensor.unsqueeze(0).to(self.device)


### PR DESCRIPTION
## Issue

Refs #185 — **does not close it.** Follow-up to #222 (local QPT V2 inference). Improves the
reconstruction's preprocessing and records validation findings; calibration anchors remain
blocked, so `qpt_v2` stays a shadow model and the issue stays open. Issue/board tracking is
handled by the maintainer.

## Backlog hygiene

- [ ] Card moved to `Stage = Review` (maintainer is handling board tracking)
- [x] If cross-repo, the counterpart issue in `image-scoring-gallery` is linked above — n/a
- [x] API contract / OpenAPI / `API.md` updated when REST behavior or paths changed — n/a, no REST changes
- [x] Plan docs skimmed when track status changed — #185 status doc updated

## Summary

**What changed:**

- **`QptV2Scorer._preprocess`**: replace the aspect-distorting squash resize
  (`Resize((224,224))`) with the standard ImageNet eval recipe — resize shortest side to 256
  (aspect-preserving) then center-crop 224. New `RESIZE_SHORT = 256` constant.
- **`docs/planning/models/CALIBRATION_LAYER_185_STATUS.md`**: record the offline validation
  attempts (graded-blur monotonicity, NIQE cross-check, preprocessing comparison).

## Motivation

After #222 landed local QPT V2 inference, I validated it offline. The reconstruction loads
exactly (172/172 tensors) and is directionally blur-sensitive, but quality tracking was weak
(blur-Spearman −0.66) and it disagreed with NIQE in sign — i.e. the undocumented inference
recipe isn't fully faithful. The single biggest lever was preprocessing: the standard
center-crop recipe improves blur tracking to **−0.81** (verified through the integrated
`predict()` path), and is better-justified than a squashing resize regardless.

## How to test

```bash
python -m pytest tests/test_qpt_v2_arch.py -q
python -m ruff check modules/qpt_v2.py

# Optional, with checkpoint at models/qpt_v2.pth: blur monotonicity through predict()
# should be ~ -0.8 (was ~ -0.66 before this change).
```

**Risk / testing notes:** Verified the change through the real `QptV2Scorer.predict()` path
(mean blur-Spearman −0.805, up from −0.66). Structural tests still pass; ruff clean.

## Risk / rollout

Low. `qpt_v2` remains **shadow** (`enabled:false, shadow:true`) — never fused, so no
user-facing score change. With no checkpoint it still fails soft. No migrations/REST/flags.
This is an incremental fidelity improvement, **not** a validation: scores are still
provisional (target blur-Spearman ≤ −0.9 not met; NIQE cross-check wrong sign on thumbnails).
Trustworthy scores need full-resolution + labelled-MOS validation or the upstream recipe —
tracked in the #185 status doc.

## SDLC checklist (agent-sdlc)

- [x] Tests added or updated as needed (existing structural tests cover the arch; preprocessing verified manually)
- [x] Lint / typecheck pass (ruff clean)
- [x] No secrets or credentials in code
- [x] Docs updated if behavior is user-visible
