### PR TITLE
feat(scoring): ARNIQA shadow engine (#220 phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **ARNIQA shadow scorer** (#220 phase 2): no-reference, distortion-focused IQA via `pyiqa`
+  (`modules/arniqa.py` + `modules/engines/arniqa_model.py`). Registered at import time and
+  runs in **shadow** by default (`scoring.models.arniqa: {enabled: false, shadow: true}`) —
+  scores persist to `image_model_scores` but are excluded from fusion until calibrated.
+  Head selectable via `scoring.arniqa.metric` (default `arniqa`, KonIQ head).
+
 ### Roadmap (not yet released)
 
 Phase 4c keyword legacy column soft deprecation (target a future release; see `docs/planning/database/PHASE4_KEYWORDS_DEPRECATION.md`):

--- a/config.example.json
+++ b/config.example.json
@@ -25,8 +25,13 @@
       "ava":    { "enabled": true,  "shadow": false },
       "liqe":   { "enabled": true,  "shadow": false },
       "topiq":  { "enabled": true,  "shadow": false },
+      "arniqa": { "enabled": false, "shadow": true  },
       "cursor": { "enabled": false, "shadow": false },
       "claude": { "enabled": false, "shadow": false }
+    },
+    "arniqa": {
+      "metric": "arniqa",
+      "max_dimension": 1024
     },
     "qpt_v2": {
       "checkpoint_path": "models/qpt_v2.pth",

--- a/docs/MODEL_RECOMMENDATIONS_PIPELINES.md
+++ b/docs/MODEL_RECOMMENDATIONS_PIPELINES.md
@@ -219,7 +219,7 @@ Models below are **new or newly emphasized** in this roadmap. Existing productio
 |-------|--------|-----------------|-------|
 | 0 | This doc + ingested CLIP report + wiki links | N/A | Docs only (done) |
 | 1 | `clustering.embedding_space` → existing `clip_vit_b32_image`; threshold tuning harness | **Switch** culling input to existing CLIP vectors (no new model). MobileNet path and data **kept** as fallback. | Yes |
-| 2 | ARNIQA shadow engine → `image_model_scores` | **Add** shadow scorer. MUSIQ/LIQE/TOPIQ **unchanged** until promotion. | Yes |
+| 2 | ARNIQA shadow engine → `image_model_scores` | **Add** shadow scorer. MUSIQ/LIQE/TOPIQ **unchanged** until promotion. | **Done** ✅ (calibration pending) |
 | 3 | DINOv2-reg base space, backfill, culling default after validation | **Add** embedding space; **replace default** culling space after validation. MobileNet + CLIP data **kept**. | Yes |
 | 4 | SigLIP2 keyword scorer (shadow → production), vocabulary expansion | **Add** scorer; shadow then **replace default** tag writer. CLIP + BLIP **kept** behind config. | Yes |
 | 5 | Optional OpenCLIP L/14 unified track if A/B requires | **Add** space/model; **replace** DINO/SigLIP defaults only if A/B wins. | Yes |
@@ -227,6 +227,13 @@ Models below are **new or newly emphasized** in this roadmap. Existing productio
 ## Recommended Models
 
 ### Scoring Pipeline: ARNIQA
+
+**Status: implemented as a shadow engine** (#220 phase 2). ARNIQA is registered at
+import time in `modules/engines/__init__.py` and runs via `pyiqa` (`modules/arniqa.py`
++ `modules/engines/arniqa_model.py`). Default config `scoring.models.arniqa:
+{enabled: false, shadow: true}` — scores persist to `image_model_scores` but are
+**not fused**. Remaining work is the calibration phase below (percentile anchors on
+the local corpus) before any promotion into composites.
 
 Add ARNIQA as a technical/no-reference image quality signal.
 

--- a/docs/NEW_MODELS_SUMMARY.md
+++ b/docs/NEW_MODELS_SUMMARY.md
@@ -28,7 +28,7 @@ flowchart LR
     MUSIQ[MUSIQ SPAQ + AVA]
     LIQE[LIQE]
     TOPIQ[TOPIQ-NR]
-    QPT[QPT-V2 shadow only]
+    ARNIQA[ARNIQA shadow only]
   end
   subgraph culling [Culling phase]
     MN[MobileNetV2 1280-d]
@@ -46,7 +46,8 @@ flowchart LR
 | Pipeline | Models | Notes |
 |----------|--------|-------|
 | **Scoring** | MUSIQ (SPAQ, AVA), LIQE, TOPIQ-NR | Fused into composites; KONIQ/PAQ2PIQ deprecated from registry |
-| **Scoring (shadow)** | QPT-V2 | Runs locally via reconstructed HiViT-T; **not fused**, unvalidated |
+| **Scoring (shadow)** | ARNIQA | pyiqa no-reference IQA; runs + stores to `image_model_scores`, **not fused**, uncalibrated |
+| **Scoring (disabled)** | QPT-V2 | Reconstructed HiViT-T; **not registered** until validation (#185) |
 | **Culling** | MobileNetV2 ImageNet GAP | Default embedding space `mobilenet_v2_imagenet_gap` |
 | **Keywords** | CLIP B/32, BLIP, BioCLIP 2 | CLIP for tags; BLIP for captions; BioCLIP for bird species |
 
@@ -54,13 +55,18 @@ flowchart LR
 
 ## New / roadmap models (by pipeline)
 
-### Scoring — ARNIQA (recommended add)
+### Scoring — ARNIQA (implemented — shadow)
 
-- **What:** No-reference IQA (distortion-focused), Apache-2.0, PyTorch
+- **What:** No-reference IQA (distortion-focused), Apache-2.0, PyTorch (via `pyiqa`)
 - **Role:** Technical quality signal — blur, noise, compression
-- **Posture:** Shadow first → calibrate on local corpus → optional composite input
+- **Posture:** **Shadow now** (`scoring.models.arniqa: {enabled: false, shadow: true}`) →
+  calibrate on local corpus → optional composite input
+- **Status:** Registered at import time in `modules/engines/__init__.py`; scores persist
+  to `image_model_scores` but are **excluded from fusion**. No percentile anchors yet.
+- **Head:** pyiqa default `arniqa` (KonIQ head); switchable via `scoring.arniqa.metric`
+- **Modules:** `modules/arniqa.py` + `modules/engines/arniqa_model.py`
 - **Not a replacement** for MUSIQ/LIQE/TOPIQ until validated
-- **Phase:** 2 in [#220](https://github.com/synthet/image-scoring-backend/issues/220)
+- **Phase:** 2 in [#220](https://github.com/synthet/image-scoring-backend/issues/220) — **done**
 
 ### Scoring — QPT-V2 (exists in code, not promoted)
 
@@ -168,7 +174,7 @@ flowchart LR
 |-------|--------|------------|
 | **0** | Docs + CLIP report ingest | No |
 | **1** | Culling reads `clip_vit_b32_image`; threshold harness | No new loader |
-| **2** | ARNIQA shadow → `image_model_scores` | Yes |
+| **2** | ARNIQA shadow → `image_model_scores` ✅ done | Yes |
 | **3** | DINOv2 space, backfill, culling default | Yes |
 | **4** | SigLIP2 keyword scorer shadow → production | Yes |
 | **5** | Optional OpenCLIP L/14 unified track if A/B wins | Yes |

--- a/docs/technical/MODELS_SUMMARY.md
+++ b/docs/technical/MODELS_SUMMARY.md
@@ -42,7 +42,23 @@ analysis. It contributes to all three composites under the "moderate" profile
 - **Range**: 0.0 - 1.0 (percentile anchors `p02≈0.39 / p98≈0.71`)
 - **Module**: `modules/engines/topiq_model.py` (wraps `modules/topiq.py`).
 
-## 4. QPT V2 (Quality-aware Pre-Training V2)
+## 4. ARNIQA (no-reference distortion-focused IQA)
+*PyTorch Implementation (via `pyiqa`) — shadow*
+
+**Status: Shadow (not fused) — runs and stores, excluded from fusion**
+Registered as a shadow model (`scoring.models.arniqa: {enabled: false, shadow: true}`):
+it scores every image into `image_model_scores` while staying out of the composites
+until calibrated against the local corpus (#220 phase 2, #185). ARNIQA targets
+*technical* distortions — blur, noise, compression — complementing the existing
+LIQE/TOPIQ/MUSIQ signals.
+- **Range**: 0.0 - 1.0 (higher is better). No percentile anchors yet — they are
+  computed during the calibration phase before any promotion to fusion.
+- **Head**: pyiqa default `arniqa` (KonIQ in-the-wild regression head, best fit for
+  general photography); switchable via `scoring.arniqa.metric` (e.g. `arniqa-spaq`).
+- **License**: Apache-2.0.
+- **Module**: `modules/engines/arniqa_model.py` (wraps `modules/arniqa.py`).
+
+## 5. QPT V2 (Quality-aware Pre-Training V2)
 *PyTorch implementation (disabled — not registered)*
 
 **Status: Disabled (WIP) — not in the live registry until #185**
@@ -61,14 +77,14 @@ all 172 tensors). Drop `iqa.pth` at `scoring.qpt_v2.checkpoint_path` (default
 - **Module**: `modules/engines/qpt_v2_model.py` (wraps `modules/qpt_v2.py`,
   arch in `modules/qpt_v2_arch.py`).
 
-## 5. LLM-judge engines (Cursor / Claude)
+## 6. LLM-judge engines (Cursor / Claude)
 *Optional, disabled by default*
 
 `cursor` and `claude` are LLM-as-judge scoring engines that lazy-load their optional SDKs
 and are disabled by default (`enabled: false`). When enabled they return an overall score
 plus an optional multi-dimensional rubric carried in `scores_json`.
 
-## 6. Model Correlation
+## 7. Model Correlation
 *Based on internal testing (v2.5.0)*
 
 - **High Correlation**: KONIQ <-> SPAQ (They generally agree).

--- a/modules/engines/__init__.py
+++ b/modules/engines/__init__.py
@@ -64,6 +64,12 @@ __all__ = [
 # shadow membership is decided by `scoring.models` in config.
 get_registry().register(TopiqModelWrapper())
 
+# ARNIQA registers as a shadow scorer (#220 phase 2). Like TOPIQ it lazy-loads
+# its pyiqa backend on first `load()`, so import stays cheap. It runs and stores
+# to `image_model_scores` but is excluded from fusion (config default
+# `scoring.models.arniqa: {enabled: false, shadow: true}`) until calibrated.
+get_registry().register(ArniqaModelWrapper())
+
 # QPT V2 is not registered until validation/calibration (#185) is complete.
 # Re-enable: get_registry().register(QptV2ModelWrapper())
 

--- a/tests/test_engines_wrappers.py
+++ b/tests/test_engines_wrappers.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, Optional
 
 import pytest
 
+from modules.engines.arniqa_model import ArniqaModelWrapper
 from modules.engines.host import MultiModelHost
 from modules.engines.liqe_model import LiqeModelWrapper
 from modules.engines.musiq_model import MusiqModelWrapper, make_musiq_wrappers
@@ -105,6 +106,20 @@ class _StubQptV2Scorer:
     VERSION = "qpt-v2-stub-1"
 
     def __init__(self, score: float = 0.71, status: str = "success") -> None:
+        self._score = score
+        self._status = status
+
+    def predict(self, _path: str) -> Dict[str, Any]:
+        if self._status != "success":
+            return {"status": "failed", "error": "boom"}
+        return {"score": self._score, "status": "success", "score_range": "0.0-1.0"}
+
+
+class _StubArniqaScorer:
+    available = True
+    VERSION = "arniqa-stub-1"
+
+    def __init__(self, score: float = 0.58, status: str = "success") -> None:
         self._score = score
         self._status = status
 
@@ -290,6 +305,42 @@ def test_qpt_v2_normalize_matches_native_range():
     assert qpt.normalize(0.0) == pytest.approx(0.0)
     assert qpt.normalize(0.5) == pytest.approx(0.5)
     assert qpt.normalize(1.0) == pytest.approx(1.0)
+
+
+# ---------- ArniqaModelWrapper ----------
+
+def test_arniqa_wrapper_predict_success():
+    arniqa = ArniqaModelWrapper(scorer=_StubArniqaScorer(score=0.58))
+    assert arniqa.name == "arniqa"
+    assert arniqa.score_range == (0.0, 1.0)
+    assert arniqa.framework == "torch"
+    assert arniqa.load() is True
+    out = arniqa.predict("/x.jpg")
+    assert out == {"score": 0.58, "status": "success", "error": None}
+
+
+def test_arniqa_wrapper_failed_status_propagates():
+    arniqa = ArniqaModelWrapper(scorer=_StubArniqaScorer(status="failed"))
+    arniqa.load()
+    out = arniqa.predict("/x.jpg")
+    assert out["status"] == "failed"
+    assert out["score"] is None
+
+
+def test_arniqa_wrapper_unloaded_returns_not_loaded():
+    class _Unavailable:
+        available = False
+
+    arniqa = ArniqaModelWrapper(scorer=_Unavailable())
+    out = arniqa.predict("/x.jpg")
+    assert out["status"] == "not_loaded"
+
+
+def test_arniqa_normalize_matches_native_range():
+    arniqa = ArniqaModelWrapper(scorer=_StubArniqaScorer())
+    assert arniqa.normalize(0.0) == pytest.approx(0.0)
+    assert arniqa.normalize(0.5) == pytest.approx(0.5)
+    assert arniqa.normalize(1.0) == pytest.approx(1.0)
 
 
 # ---------- MultiModelHost ----------


### PR DESCRIPTION
## Summary

Wires **ARNIQA** (no-reference, distortion-focused IQA via `pyiqa`, Apache-2.0) into the registry-driven scorer as a **shadow** model — it runs per image and persists to `image_model_scores` but is **excluded from fusion** until calibrated on the local corpus. This is **Phase 2** of the pipeline model-upgrade roadmap.

Mirrors the existing TOPIQ pyiqa wrapper pattern, so no changes to `MultiModelHost`, fusion, or the DB layer were needed — shadow membership is config-driven.

## Changes

- **`modules/arniqa.py`** — `ArniqaScorer` (lazy `pyiqa` load, configurable head via `scoring.arniqa.metric`, max-dim downscale). *(already in HEAD via d7737cd)*
- **`modules/engines/arniqa_model.py`** — `ArniqaModelWrapper` (`IScoringModel`, range 0–1). *(already in HEAD via d7737cd)*
- **`modules/engines/__init__.py`** — register `ArniqaModelWrapper()` at import time + export.
- **`config.json` / `config.example.json`** — `scoring.models.arniqa: {enabled: false, shadow: true}` and a `scoring.arniqa` section (head + max_dimension). *(`config.json` is gitignored; only the example is in this PR)*
- **Tests** — ARNIQA wrapper cases in `tests/test_engines_wrappers.py`.
- **Docs/CHANGELOG** — mark ARNIQA implemented-as-shadow; roadmap Phase 2 done.

## Verification

- `pytest tests/test_engines_wrappers.py tests/test_engines_shadow_mode.py tests/test_engines_factory.py tests/test_engines_registry.py` → **54 passed**
- `pytest tests/test_model_status.py tests/test_image_model_scores_dual_write.py tests/test_engines_pipeline_injection.py` → **22 passed**
- Runtime check: ARNIQA registers, resolves `is_shadow=True`, appears in shadow+active sets; config default picked up.
- `ruff check` clean on touched files; both config JSONs valid.
- Confirmed `pyiqa` exposes `arniqa` with `score_range=(0,1)`, NR, higher-better — no QPT-style clamp bug.

## Scope / follow-up

- **No fusion impact.** No percentile anchors added yet — calibration on the local corpus is the follow-up (#185) before any promotion into composites.
- **Refs #220 (phase 2).** Intentionally does **not** `Closes #220` — that's a multi-phase epic (phases 3–5: DINOv2 culling, SigLIP2 keywords, OpenCLIP) and should stay open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)