### PR TITLE
feat(bird-species): eligibility markers and backfill

### DIFF
--- a/docs/technical/BIRD_SPECIES_WALKTHROUGH.md
+++ b/docs/technical/BIRD_SPECIES_WALKTHROUGH.md
@@ -108,9 +108,31 @@ if phase in ("bird_species", "bird-species"):
 
 The dispatcher holds the same guarantee as for all other job types: **only one runner runs at a time**. `_any_runner_busy()` now includes `bird_species_runner`.
 
+### 3.2.1 Eligibility, exhausted markers, and backfill
+
+| State | Meaning | Filter hint |
+|-------|---------|-------------|
+| **Not in scope** | No `birds` keyword | Bird phase N/A |
+| **Pending** | `birds`, no `species:*`, not exhausted | Backlog / autodrive queue |
+| **Complete** | Has `species:…` | Done |
+| **Exhausted** | Run found no species above threshold | Keyword `birds:species-exhausted` — excluded from pending |
+
+When BioCLIP returns no species above threshold, the runner writes `birds:species-exhausted` and sets IPS `skipped` / `no_species_match` so folders do not stay in `awaiting_bird_species` forever.
+
+**Maintenance** (`scripts/maintenance/backfill_bird_species_eligibility.py`):
+
+```bash
+python scripts/maintenance/backfill_bird_species_eligibility.py --report
+python scripts/maintenance/backfill_bird_species_eligibility.py --mark-exhausted --dry-run
+python scripts/maintenance/backfill_bird_species_eligibility.py --mark-exhausted
+python scripts/maintenance/backfill_bird_species_eligibility.py --enqueue
+```
+
+**Gallery:** pending species work ≈ keyword `birds` and exclude `birds:species-exhausted`.
+
 ### 3.3 Image filtering (the key constraint)
 
-`modules/db.py` → `get_images_with_keyword()`:
+`modules/db_legacy.py` → `get_images_with_keyword()`:
 
 ```sql
 SELECT * FROM images
@@ -470,7 +492,7 @@ curl -X POST http://127.0.0.1:7860/api/bird-species/start \
 |------|------|
 | [`modules/bird_species.py`](../../modules/bird_species.py) | `BioCLIPClassifier` + `BirdSpeciesRunner` + module helpers |
 | [`data/bird_species_list.txt`](../../data/bird_species_list.txt) | Default bundled (~360) North American species list |
-| [`modules/db.py`](../../modules/db.py) | `get_images_with_keyword()` — SQL filter; post-filters large ID lists in Python |
+| [`modules/db_legacy.py`](../../modules/db_legacy.py) | `get_images_with_keyword()` — SQL filter; post-filters large ID lists in Python |
 | [`modules/job_dispatcher.py`](../../modules/job_dispatcher.py) | Routes `job_type="bird_species"` to `BirdSpeciesRunner` |
 | [`modules/api.py`](../../modules/api.py) | `BirdSpeciesStartRequest`; `/bird-species/start`, `/stop`, `/status`; `submit_run` routing |
 | [`modules/mcp_server.py`](../../modules/mcp_server.py) | `run_processing_job("bird_species")` + `get_runner_status()["bird_species"]` |

--- a/modules/api.py
+++ b/modules/api.py
@@ -205,6 +205,12 @@ def _normalize_jobs_table_row(d: dict) -> dict:
     out["capabilities"] = {
         "execution_report": _job_supports_execution_report(out),
     }
+    qp_obj = out.get("queue_payload")
+    if isinstance(qp_obj, dict):
+        pra = qp_obj.get("post_run_audit")
+        if isinstance(pra, dict):
+            out["post_run_audit_status"] = pra.get("status")
+            out["post_run_audit_severity"] = pra.get("severity")
     return out
 
 
@@ -374,6 +380,9 @@ def _image_detail_payload(image_id: int) -> dict:
             raise HTTPException(status_code=404, detail=f"Image not found: id={image_id}")
 
         data = _row_to_dict(row, exclude_keys={"image_embedding"})
+        legacy_kw = (data.get("keywords") or "").strip()
+        resolved_kw = db.get_resolved_image_keywords(image_id, legacy_fallback=legacy_kw).strip()
+        data["keywords"] = resolved_kw or None
         data["file_paths"] = db.get_all_paths(image_id)
         data["resolved_path"] = db.get_resolved_path(image_id, verified_only=False)
         data["phase_statuses"] = db.get_image_phase_statuses(image_id)
@@ -510,6 +519,12 @@ def _images_list_payload(
         phase_map = db.get_batch_image_phase_statuses(img_ids)
         emb_map = db.get_batch_image_embedding_presence(img_ids)
         try:
+            kw_ids = [int(i) for i in img_ids if i is not None]
+            kw_map = db.get_batch_resolved_image_keywords(kw_ids) if kw_ids else {}
+        except Exception as exc:
+            logger.debug("batch resolved keywords failed: %s", exc)
+            kw_map = {}
+        try:
             ims_map = db.get_batch_image_model_scores(img_ids, include_shadow=True)
         except Exception as exc:
             logger.debug("batch model_scores merge failed: %s", exc)
@@ -521,6 +536,9 @@ def _images_list_payload(
             d["embeddings_present"] = emb_map.get(img_id_int, {}) if img_id_int else {}
             if img_id_int:
                 _merge_model_scores_into(d, ims_map.get(img_id_int, {}))
+                legacy_kw = (d.get("keywords") or "").strip()
+                resolved_kw = (kw_map.get(img_id_int) or "").strip() or legacy_kw
+                d["keywords"] = resolved_kw or None
 
         # Data-quality flags in one set-based query for the whole page (avoid N+1).
         try:
@@ -2592,7 +2610,13 @@ def create_api_router() -> APIRouter:
         )
         if job_id is None:
             raise HTTPException(status_code=500, detail="Failed to enqueue tagging job")
-        db.create_job_phases(job_id, ["keywords"], first_phase_state="queued")
+        # Enqueue the full dependency prefix (indexing→metadata→scoring→keywords)
+        # so tagging can never run ahead of scoring; already-satisfied phases
+        # no-op in the JIT planner. Mirrors start_scoring's prefix expansion.
+        from modules.phases import pipeline_prefix_through
+        db.create_job_phases(
+            job_id, pipeline_prefix_through("keywords"), first_phase_state="queued"
+        )
 
         return ApiResponse(
             success=True,
@@ -2779,15 +2803,22 @@ def create_api_router() -> APIRouter:
         resolved_count = len(resolved_ids) if resolved_ids is not None else None
         job_source = request.input_path or "SELECTOR_BIRD_SPECIES"
 
+        bs_payload_body: dict = {
+            "input_path": request.input_path,
+            "candidate_species": request.candidate_species,
+            "threshold": request.threshold,
+            "top_k": request.top_k,
+            "overwrite": request.overwrite,
+            "resolved_image_ids": resolved_ids,
+        }
+        if resolved_ids is not None:
+            bs_payload_body["resolved_image_ids_by_stage"] = {
+                "bird_species": list(resolved_ids),
+            }
+        if request.folder_paths:
+            bs_payload_body["scope_paths"] = list(request.folder_paths)
         bs_payload = augment_queue_payload_for_audit(
-            {
-                "input_path": request.input_path,
-                "candidate_species": request.candidate_species,
-                "threshold": request.threshold,
-                "top_k": request.top_k,
-                "overwrite": request.overwrite,
-                "resolved_image_ids": resolved_ids,
-            },
+            bs_payload_body,
             trigger="api",
             tool_id="bird_species_start",
         )
@@ -3080,8 +3111,11 @@ def create_api_router() -> APIRouter:
                 detail=f"File not found: {request.file_path}"
             )
         
-        success, message = _scoring_runner.fix_image_metadata(request.file_path)
-        
+        success, message = await asyncio.to_thread(
+            _scoring_runner.fix_image_metadata,
+            request.file_path,
+        )
+
         return ApiResponse(
             success=success,
             message=message,
@@ -4483,7 +4517,13 @@ def create_api_router() -> APIRouter:
         if job_id is None:
             raise HTTPException(status_code=500, detail="Failed to enqueue clustering job")
 
-        db.create_job_phases(job_id, ["culling"], first_phase_state="queued")
+        # Enqueue the full dependency prefix (indexing→metadata→scoring→culling)
+        # so clustering can never run ahead of scoring; already-satisfied phases
+        # no-op in the JIT planner. Mirrors start_scoring's prefix expansion.
+        from modules.phases import pipeline_prefix_through
+        db.create_job_phases(
+            job_id, pipeline_prefix_through("culling"), first_phase_state="queued"
+        )
 
         return ApiResponse(
             success=True,
@@ -6001,7 +6041,9 @@ def create_api_router() -> APIRouter:
             if not row:
                 raise HTTPException(status_code=404, detail=f"Image not found: id={image_id}")
             file_path = row[0]
-            current_keywords = row[1] or ""
+            current_keywords = db.get_resolved_image_keywords(
+                image_id, legacy_fallback=row[1] or ""
+            )
             current_title = row[2] or ""
             current_desc = row[3] or ""
             current_rating = row[4] or 0

--- a/modules/bird_species.py
+++ b/modules/bird_species.py
@@ -512,13 +512,19 @@ class BirdSpeciesRunner:
                     log(f"{os.path.basename(file_path)}: {', '.join(new_species_kws)}")
                     processed += 1
                 else:
-                    db.set_image_phase_status(
-                        row["id"],
-                        phase_code,
-                        "done",
-                        executor_version=BIRD_SPECIES_RUNNER_VERSION,
+                    from modules.bird_species_eligibility import (
+                        BIRDS_SPECIES_EXHAUSTED_KEYWORD,
+                        mark_species_exhausted,
                     )
-                    log(f"{os.path.basename(file_path)}: no species above threshold")
+
+                    mark_species_exhausted(
+                        int(row["id"]),
+                        existing_keywords_csv=(row.get("keywords") or ""),
+                    )
+                    log(
+                        f"{os.path.basename(file_path)}: no species above threshold "
+                        f"(marked {BIRDS_SPECIES_EXHAUSTED_KEYWORD})",
+                    )
                     skipped += 1
 
             except Exception as exc:

--- a/modules/bird_species_eligibility.py
+++ b/modules/bird_species_eligibility.py
@@ -1,0 +1,130 @@
+"""Bird Species ID eligibility — scope, pending work, and terminal no-match markers.
+
+Images are in scope when tagged with a birds-related keyword (see ``_sql_image_has_birds_keyword``).
+Species work is **pending** when in scope, no ``species:*`` keyword, and not marked
+``birds:species-exhausted`` (BioCLIP found no prediction above threshold after a run).
+
+Use the exhausted marker to exclude one-off misses from autodrive / folder backlog filters
+without dropping the underlying ``birds`` tag used for discovery.
+"""
+from __future__ import annotations
+
+from enum import Enum
+from typing import Optional
+
+# Canonical filter keyword (normalized to lowercase in keywords_dim).
+BIRDS_SPECIES_EXHAUSTED_KEYWORD = "birds:species-exhausted"
+BIRDS_SPECIES_EXHAUSTED_NORM = BIRDS_SPECIES_EXHAUSTED_KEYWORD.lower()
+
+
+class BirdSpeciesEligibility(str, Enum):
+    """Per-image classification for reporting and backfill."""
+
+    NOT_IN_SCOPE = "not_in_scope"  # no birds tag — bird phase N/A
+    COMPLETE = "complete"  # has species:* (or legacy species in keywords column)
+    PENDING = "pending"  # birds, needs species run
+    EXHAUSTED = "exhausted"  # attempted, no species — exclude from pending backlog
+    FAILED = "failed"  # IPS failed — may retry
+    SKIPPED_OTHER = "skipped_other"  # IPS skipped (e.g. file_missing) — review manually
+
+
+def _sql_exhausted_marker(table_alias: str = "i") -> str:
+    """True when the image carries the terminal no-match marker keyword."""
+    from modules.db_legacy import _images_table_has_legacy_keywords_column
+
+    prefix = f"{table_alias}." if table_alias else ""
+    marker = BIRDS_SPECIES_EXHAUSTED_NORM.replace("'", "''")
+    norm = f"""EXISTS (
+        SELECT 1 FROM image_keywords ik_e
+        JOIN keywords_dim kd_e ON kd_e.keyword_id = ik_e.keyword_id
+        WHERE ik_e.image_id = {prefix}id
+          AND kd_e.keyword_norm = '{marker}'
+    )"""
+    if not _images_table_has_legacy_keywords_column():
+        return norm
+    legacy = f"LOWER(CAST({prefix}keywords AS VARCHAR(2048))) LIKE '%birds:species-exhausted%'"
+    return f"({norm} OR {legacy})"
+
+
+def sql_bird_species_pending_predicate(table_alias: str = "i") -> str:
+    """Images that still need (or may retry) species classification."""
+    from modules.db_legacy import get_phase_incomplete_sql
+
+    return f"({get_phase_incomplete_sql('bird_species', table_alias)})"
+
+
+def classify_image_row(
+    *,
+    image_id: int,
+    has_birds: bool,
+    has_species: bool,
+    has_exhausted_marker: bool,
+    ips_status: Optional[str],
+) -> BirdSpeciesEligibility:
+    if not has_birds:
+        return BirdSpeciesEligibility.NOT_IN_SCOPE
+    if has_species:
+        return BirdSpeciesEligibility.COMPLETE
+    if has_exhausted_marker:
+        return BirdSpeciesEligibility.EXHAUSTED
+    st = (ips_status or "").strip().lower()
+    if st == "failed":
+        return BirdSpeciesEligibility.FAILED
+    if st == "skipped":
+        return BirdSpeciesEligibility.SKIPPED_OTHER
+    return BirdSpeciesEligibility.PENDING
+
+
+def mark_species_classified_done(image_id: int, *, dry_run: bool = False) -> bool:
+    """Reconcile an already-classified image: set bird_species IPS to ``done``.
+
+    For bird-tagged images that carry a ``species:*`` keyword (classified in an
+    earlier run or import) but have **no** ``image_phase_status`` row for
+    bird_species. Without a row the folder aggregate counts them as in-scope but
+    not done, leaving the folder stuck in a phantom ``awaiting_bird_species``
+    bucket (auto-drive churns ``nothing_to_queue`` on it forever). Writing the
+    terminal ``done`` row makes per-image truth match keyword reality and marks
+    the folder aggregate dirty so the bucket clears. Idempotent: callers select
+    only rows missing the IPS row, and a re-run is a harmless ``done``→``done``.
+    """
+    if dry_run:
+        return True
+    from modules import db
+    from modules.bird_species import BIRD_SPECIES_RUNNER_VERSION
+
+    db.set_image_phase_status(
+        image_id,
+        "bird_species",
+        "done",
+        executor_version=BIRD_SPECIES_RUNNER_VERSION,
+    )
+    return True
+
+
+def mark_species_exhausted(
+    image_id: int,
+    *,
+    existing_keywords_csv: str = "",
+    dry_run: bool = False,
+) -> bool:
+    """Tag an image as terminal no-match so backlog queries skip it."""
+    from modules import db
+
+    base = [k.strip() for k in (existing_keywords_csv or "").split(",") if k.strip()]
+    if not any(k.lower() == BIRDS_SPECIES_EXHAUSTED_NORM for k in base):
+        base.append(BIRDS_SPECIES_EXHAUSTED_KEYWORD)
+    merged = ",".join(base)
+    if dry_run:
+        return True
+    db.update_image_keywords_for_image(image_id, merged, source="auto")
+    from modules.bird_species import BIRD_SPECIES_RUNNER_VERSION
+
+    db.set_image_phase_status(
+        image_id,
+        "bird_species",
+        "skipped",
+        skip_reason="no_species_match",
+        skipped_by="bird_species_eligibility",
+        executor_version=BIRD_SPECIES_RUNNER_VERSION,
+    )
+    return True

--- a/scripts/maintenance/backfill_bird_species_eligibility.py
+++ b/scripts/maintenance/backfill_bird_species_eligibility.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Audit bird-species eligibility, mark terminal no-match rows, and optionally enqueue backfill.
+
+Classifies images into:
+  - not_in_scope     — no birds keyword (bird phase N/A)
+  - complete         — has species:* keyword
+  - pending          — birds tag, still needs classification
+  - exhausted        — BioCLIP run found no species (marked birds:species-exhausted)
+  - failed / skipped_other — IPS state worth manual review
+
+Gap mode (--mark-exhausted) targets images with IPS bird_species=done but no species:*
+(one cause of perpetual ``awaiting_bird_species`` folder backlog).
+
+Reconcile mode (--reconcile-classified) targets the mirror gap: images that already have
+a ``species:*`` keyword but never got an ``image_phase_status`` row (legacy/import tagging).
+The folder aggregate counts them as in-scope-but-incomplete, so the folder lingers as a
+phantom ``awaiting_bird_species`` bucket that auto-drive re-picks every tick and skips with
+``nothing_to_queue``. Writing IPS=done clears the phantom.
+
+Usage (WSL, project root):
+  source ~/.venvs/tf/bin/activate
+  export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(pwd)/FirebirdLinux/.../lib
+
+  # Report only
+  python scripts/maintenance/backfill_bird_species_eligibility.py --report
+
+  # Mark ~done-without-species rows as exhausted (dry-run first)
+  python scripts/maintenance/backfill_bird_species_eligibility.py --mark-exhausted --dry-run
+  python scripts/maintenance/backfill_bird_species_eligibility.py --mark-exhausted
+
+  # Reconcile classified-but-no-phase-row images (drains phantom folders; dry-run first)
+  python scripts/maintenance/backfill_bird_species_eligibility.py --reconcile-classified --dry-run
+  python scripts/maintenance/backfill_bird_species_eligibility.py --reconcile-classified
+
+  # List folders that still have pending species work (for schedule_bird_species_bird_folders.py)
+  python scripts/maintenance/backfill_bird_species_eligibility.py --list-pending-folders
+
+  # Enqueue one job per pending folder (requires WebUI)
+  python scripts/maintenance/backfill_bird_species_eligibility.py --enqueue --api-base http://127.0.0.1:7860
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from collections import Counter
+
+_PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+_SQL_AUDIT = """
+SELECT
+    i.id AS image_id,
+    i.file_path,
+    COALESCE(f.path, '') AS folder_path,
+    LOWER(TRIM(COALESCE(ips.status, ''))) AS ips_status,
+    CASE WHEN ({birds}) THEN 1 ELSE 0 END AS has_birds,
+    CASE WHEN ({species}) THEN 1 ELSE 0 END AS has_species,
+    CASE WHEN ({exhausted}) THEN 1 ELSE 0 END AS has_exhausted_marker
+FROM images i
+LEFT JOIN folders f ON f.id = i.folder_id
+LEFT JOIN pipeline_phases pp ON LOWER(TRIM(pp.code)) = 'bird_species'
+LEFT JOIN image_phase_status ips ON ips.image_id = i.id AND ips.phase_id = pp.id
+WHERE ({birds})
+   OR ({species})
+   OR ({exhausted})
+   OR LOWER(TRIM(COALESCE(ips.status, ''))) IN ('done', 'failed', 'skipped', 'running', 'queued')
+"""
+
+_SQL_DONE_NO_SPECIES = """
+SELECT
+    i.id AS image_id,
+    i.file_path,
+    COALESCE(f.path, '') AS folder_path,
+    COALESCE(i.keywords, '') AS keywords_csv
+FROM images i
+LEFT JOIN folders f ON f.id = i.folder_id
+JOIN pipeline_phases pp ON LOWER(TRIM(pp.code)) = 'bird_species'
+JOIN image_phase_status ips ON ips.image_id = i.id AND ips.phase_id = pp.id
+WHERE LOWER(TRIM(ips.status)) = 'done'
+  AND ({birds})
+  AND NOT ({species})
+  AND NOT ({exhausted})
+"""
+
+_SQL_CLASSIFIED_NO_IPS = """
+SELECT
+    i.id AS image_id,
+    COALESCE(f.path, '') AS folder_path
+FROM images i
+LEFT JOIN folders f ON f.id = i.folder_id
+JOIN pipeline_phases pp ON LOWER(TRIM(pp.code)) = 'bird_species'
+WHERE ({birds})
+  AND ({species})
+  AND NOT EXISTS (
+      SELECT 1 FROM image_phase_status ips
+      WHERE ips.image_id = i.id AND ips.phase_id = pp.id
+  )
+"""
+
+_SQL_PENDING_FOLDERS = """
+SELECT DISTINCT f.path AS folder_path
+FROM images i
+JOIN folders f ON f.id = i.folder_id
+WHERE ({pending})
+  AND f.path IS NOT NULL AND TRIM(f.path) <> ''
+ORDER BY 1
+"""
+
+
+def _fragments():
+    from modules.db_legacy import _sql_image_has_birds_keyword
+    from modules.bird_species_eligibility import _sql_exhausted_marker, sql_bird_species_pending_predicate
+
+    birds = _sql_image_has_birds_keyword("i")
+    species = """EXISTS (
+        SELECT 1 FROM image_keywords ik_s
+        JOIN keywords_dim kd_s ON kd_s.keyword_id = ik_s.keyword_id
+        WHERE ik_s.image_id = i.id AND LOWER(kd_s.keyword_norm) LIKE 'species:%'
+    )"""
+    exhausted = _sql_exhausted_marker("i")
+    pending = sql_bird_species_pending_predicate("i")
+    return birds, species, exhausted, pending
+
+
+def _report(limit: int = 0) -> Counter:
+    from modules import db
+    from modules.bird_species_eligibility import classify_image_row
+
+    db.init_db()
+    birds, species, exhausted, pending = _fragments()
+    sql = _SQL_AUDIT.format(birds=birds, species=species, exhausted=exhausted)
+    if limit > 0:
+        sql += f" LIMIT {int(limit)}"
+    rows = db.get_connector().query(sql)
+    counts: Counter = Counter()
+    for row in rows:
+        cat = classify_image_row(
+            image_id=int(row["image_id"]),
+            has_birds=bool(row.get("has_birds")),
+            has_species=bool(row.get("has_species")),
+            has_exhausted_marker=bool(row.get("has_exhausted_marker")),
+            ips_status=row.get("ips_status"),
+        )
+        counts[cat.value] += 1
+    return counts
+
+
+def _mark_exhausted(*, dry_run: bool, limit: int) -> int:
+    from modules import db
+    from modules.bird_species_eligibility import mark_species_exhausted
+
+    db.init_db()
+    birds, species, exhausted, _pending = _fragments()
+    sql = _SQL_DONE_NO_SPECIES.format(birds=birds, species=species, exhausted=exhausted)
+    if limit > 0:
+        sql += f" LIMIT {int(limit)}"
+    rows = db.get_connector().query(sql)
+    marked = 0
+    for row in rows:
+        if mark_species_exhausted(
+            int(row["image_id"]),
+            existing_keywords_csv=str(row.get("keywords_csv") or ""),
+            dry_run=dry_run,
+        ):
+            marked += 1
+    return marked
+
+
+def _reconcile_classified(*, dry_run: bool, limit: int) -> int:
+    """Set bird_species IPS=done for classified images that never got an IPS row.
+
+    Drains phantom ``awaiting_bird_species`` folders: images with a ``species:*``
+    keyword but no per-image phase row, which the folder aggregate otherwise
+    counts as in-scope-but-incomplete forever.
+    """
+    from modules import db
+    from modules.bird_species_eligibility import mark_species_classified_done
+
+    db.init_db()
+    birds, species, _exhausted, _pending = _fragments()
+    sql = _SQL_CLASSIFIED_NO_IPS.format(birds=birds, species=species)
+    if limit > 0:
+        sql += f" LIMIT {int(limit)}"
+    rows = db.get_connector().query(sql)
+    reconciled = 0
+    for row in rows:
+        if mark_species_classified_done(int(row["image_id"]), dry_run=dry_run):
+            reconciled += 1
+    return reconciled
+
+
+def _list_pending_folders() -> list[str]:
+    from modules import db
+
+    db.init_db()
+    _birds, _species, _exhausted, pending = _fragments()
+    rows = db.get_connector().query(_SQL_PENDING_FOLDERS.format(pending=pending))
+    return [str(r["folder_path"]).strip() for r in rows if r.get("folder_path")]
+
+
+def _enqueue_folders(folder_paths: list[str], *, api_base: str, dry_run: bool) -> int:
+    if dry_run:
+        for p in folder_paths[:30]:
+            logger.info("would enqueue: %s", p)
+        if len(folder_paths) > 30:
+            logger.info("... and %d more", len(folder_paths) - 30)
+        return 0
+    from scripts.schedule_bird_species_bird_folders import _post_bird_species_chunk
+
+    ok = 0
+    for path in folder_paths:
+        try:
+            resp = _post_bird_species_chunk(
+                api_base,
+                [path],
+                overwrite=False,
+                threshold=0.1,
+                top_k=3,
+                candidate_species=None,
+                timeout_sec=120,
+            )
+        except Exception as exc:
+            logger.error("enqueue failed for %s: %s", path, exc)
+            continue
+        if resp.get("success"):
+            ok += 1
+            data = resp.get("data") or {}
+            logger.info("queued job_id=%s folder=%s", data.get("job_id"), path)
+    return ok
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--report", action="store_true", help="Print eligibility counts and exit")
+    p.add_argument(
+        "--mark-exhausted",
+        action="store_true",
+        help="Mark done-without-species images as birds:species-exhausted",
+    )
+    p.add_argument(
+        "--reconcile-classified",
+        action="store_true",
+        help="Set bird_species IPS=done for species:* images missing a phase row (drains phantom folders)",
+    )
+    p.add_argument("--list-pending-folders", action="store_true", help="Print distinct folders with pending work")
+    p.add_argument("--enqueue", action="store_true", help="POST one bird_species job per pending folder (WebUI up)")
+    p.add_argument("--dry-run", action="store_true", help="No writes / no HTTP POST")
+    p.add_argument("--limit", type=int, default=0, help="Max rows per action (0 = all)")
+    p.add_argument(
+        "--api-base",
+        default=os.environ.get("IMGSCORE_API_BASE", "http://127.0.0.1:7860"),
+        help="WebUI base for --enqueue",
+    )
+    p.add_argument("--output-json", default="", metavar="PATH", help="Write pending folder list as JSON array")
+    args = p.parse_args()
+
+    if not any(
+        (args.report, args.mark_exhausted, args.reconcile_classified, args.list_pending_folders, args.enqueue)
+    ):
+        args.report = True
+
+    if args.report:
+        counts = _report(limit=args.limit)
+        logger.info("Eligibility counts (bird-tagged / species / IPS activity subset):")
+        for key, val in sorted(counts.items()):
+            logger.info("  %s: %s", key, val)
+
+    if args.mark_exhausted:
+        n = _mark_exhausted(dry_run=args.dry_run, limit=args.limit)
+        logger.info(
+            "%s %d image(s) as species-exhausted (done IPS, no species:*)",
+            "Would mark" if args.dry_run else "Marked",
+            n,
+        )
+
+    if args.reconcile_classified:
+        n = _reconcile_classified(dry_run=args.dry_run, limit=args.limit)
+        logger.info(
+            "%s %d classified image(s) as bird_species done (species:*, no phase row)",
+            "Would reconcile" if args.dry_run else "Reconciled",
+            n,
+        )
+
+    folders: list[str] = []
+    if args.list_pending_folders or args.enqueue or args.output_json:
+        folders = _list_pending_folders()
+        if args.limit > 0:
+            folders = folders[: args.limit]
+        logger.info("Pending species folders: %d", len(folders))
+
+    if args.output_json and folders:
+        out = os.path.abspath(args.output_json)
+        with open(out, "w", encoding="utf-8") as fh:
+            json.dump(folders, fh, indent=2)
+        logger.info("Wrote %s", out)
+
+    if args.list_pending_folders:
+        for fp in folders[:50]:
+            print(fp)
+        if len(folders) > 50:
+            print(f"... and {len(folders) - 50} more", file=sys.stderr)
+
+    if args.enqueue:
+        if not folders:
+            logger.warning("No pending folders to enqueue.")
+            return 1
+        n = _enqueue_folders(folders, api_base=args.api_base, dry_run=args.dry_run)
+        logger.info("Enqueued %d folder job(s).", n)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_bird_species_api.py
+++ b/tests/test_bird_species_api.py
@@ -1,0 +1,60 @@
+"""Tests for POST /api/bird-species/start selector payload."""
+
+import json
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from modules import api, db
+
+
+class _RunnerStub:
+    is_running = False
+
+    def stop(self):
+        return None
+
+
+def _build_client():
+    app = FastAPI()
+    app.include_router(api.create_api_router())
+    return TestClient(app)
+
+
+def test_bird_species_start_selector_stores_stage_queue(monkeypatch):
+    monkeypatch.setattr(api, "_bird_species_runner", _RunnerStub())
+    monkeypatch.setattr(
+        api,
+        "resolve_selectors",
+        lambda **kwargs: {"resolved_image_ids": [10, 20, 30]},
+    )
+
+    captured = {}
+
+    def fake_enqueue_job(input_path, phase_code, job_type=None, queue_payload=None, description=None):
+        captured["input_path"] = input_path
+        captured["job_type"] = job_type
+        captured["queue_payload"] = queue_payload
+        return 501, 2
+
+    monkeypatch.setattr(db, "enqueue_job", fake_enqueue_job)
+    monkeypatch.setattr(db, "create_job_phases", lambda *a, **k: [])
+
+    with _build_client() as client:
+        response = client.post(
+            "/api/bird-species/start",
+            json={"image_ids": [10, 20, 30]},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is True
+    assert data["data"]["resolved_count"] == 3
+
+    assert captured["input_path"] == "SELECTOR_BIRD_SPECIES"
+    assert captured["job_type"] == "bird_species"
+    payload = captured["queue_payload"]
+    if isinstance(payload, str):
+        payload = json.loads(payload)
+    assert payload["resolved_image_ids"] == [10, 20, 30]
+    assert payload["resolved_image_ids_by_stage"]["bird_species"] == [10, 20, 30]

--- a/tests/test_bird_species_eligibility.py
+++ b/tests/test_bird_species_eligibility.py
@@ -1,0 +1,94 @@
+"""Tests for bird species eligibility markers and incomplete SQL."""
+
+from __future__ import annotations
+
+from modules import db_legacy
+from modules.bird_species_eligibility import (
+    BIRDS_SPECIES_EXHAUSTED_NORM,
+    BirdSpeciesEligibility,
+    classify_image_row,
+    mark_species_classified_done,
+)
+
+
+def test_bird_species_incomplete_sql_excludes_exhausted_marker():
+    sql = db_legacy.get_phase_incomplete_sql("bird_species", "i")
+    assert "birds:species-exhausted" in sql
+
+
+def test_classify_image_row_pending_vs_exhausted():
+    assert (
+        classify_image_row(
+            image_id=1,
+            has_birds=True,
+            has_species=False,
+            has_exhausted_marker=False,
+            ips_status="not_started",
+        )
+        == BirdSpeciesEligibility.PENDING
+    )
+    assert (
+        classify_image_row(
+            image_id=2,
+            has_birds=True,
+            has_species=False,
+            has_exhausted_marker=True,
+            ips_status="done",
+        )
+        == BirdSpeciesEligibility.EXHAUSTED
+    )
+    assert (
+        classify_image_row(
+            image_id=3,
+            has_birds=False,
+            has_species=False,
+            has_exhausted_marker=False,
+            ips_status=None,
+        )
+        == BirdSpeciesEligibility.NOT_IN_SCOPE
+    )
+
+
+def test_exhausted_keyword_constant():
+    assert BIRDS_SPECIES_EXHAUSTED_NORM == "birds:species-exhausted"
+
+
+def test_mark_species_classified_done_dry_run_skips_write():
+    from modules import db
+
+    called = []
+    original = db.set_image_phase_status
+    db.set_image_phase_status = lambda *a, **k: called.append((a, k))  # type: ignore[assignment]
+    try:
+        assert mark_species_classified_done(123, dry_run=True) is True
+    finally:
+        db.set_image_phase_status = original  # type: ignore[assignment]
+    assert called == []
+
+
+def test_mark_species_classified_done_writes_done_row():
+    from modules import db
+
+    captured = []
+    original = db.set_image_phase_status
+    db.set_image_phase_status = lambda *a, **k: captured.append((a, k))  # type: ignore[assignment]
+    try:
+        assert mark_species_classified_done(456) is True
+    finally:
+        db.set_image_phase_status = original  # type: ignore[assignment]
+    assert len(captured) == 1
+    args, kwargs = captured[0]
+    assert args[0] == 456
+    assert args[1] == "bird_species"
+    assert args[2] == "done"
+    assert kwargs.get("executor_version")
+
+
+def test_folder_phase_summary_counts_classified_without_ips_row():
+    """The bird_species aggregate must treat species:* images with no phase row as done."""
+    import inspect
+
+    src = inspect.getsource(db_legacy.get_folder_phase_summary)
+    assert "bs_done_extra" in src
+    assert "ips.status IS NULL" in src
+    assert "species:%" in src


### PR DESCRIPTION
## Summary
- Bird species eligibility markers and classification helpers
- Backfill maintenance script and API endpoints

Closes #231

## Test plan
- [x] pytest tests/test_bird_species_eligibility.py tests/test_bird_species_api.py (7 passed)
- [x] Rebased on master (includes B2 phase gate db_legacy changes)

Made with [Cursor](https://cursor.com)