### PR TITLE
feat(mcp): dispatch support.export_debug_bundle + vocabulary lint CI

### DIFF
--- a/.agent/mcp_tools_reference.md
+++ b/.agent/mcp_tools_reference.md
@@ -4,9 +4,9 @@ This document tracks the tools registered in [`modules/mcp_server.py`](../module
 
 ## Connection modes
 
-- **`image-scoring-backend-stdio`**, **`image-scoring-backend-webui`**, **`image-scoring-backend-postgres`**: backend [`.cursor/mcp.json`](../.cursor/mcp.json)
-- **`image-scoring-gallery-stdio`**, **`image-scoring-gallery-live`**: gallery `.cursor/mcp.json`
-- **`execute_code`**: requires **`image-scoring-backend-webui`** and `ENABLE_MCP_EXECUTE_CODE=1` on the WebUI process.
+- **Backend:** **`is-be-mcp`** (preferred), **`is-be-diag`**, **`is-be-jobs`**, **`is-be-data`**, **`is-be-webui`**, optional **`is-be-pg`** — see [`.cursor/mcp.pair.example.json`](../.cursor/mcp.pair.example.json)
+- **Gallery (sibling repo):** **`is-ui-router`**, **`is-ui-local`**, **`is-ui-api`**, **`is-ui-live`** — see gallery `mcp.example.json`
+- **`execute_code`**: requires **`is-be-webui`** and `ENABLE_MCP_EXECUTE_CODE=1` on the WebUI process.
 
 ## Postgres query patterns (operators)
 

--- a/.agent/skills/image-scoring-mcp/SKILL.md
+++ b/.agent/skills/image-scoring-mcp/SKILL.md
@@ -22,7 +22,7 @@ Example: `search("why did scoring fail")` → `dispatch("diagnostics.get_error_s
 | **`is-be-*`** | backend | Legacy domain tools |
 | **`is-ui-*`** | gallery | **`ui_find`** on **`is-ui-router`** |
 
-Do not use `imgscore-py-*`, `image-scoring-backend-*`, `is-ga-*`.
+Use **`is-be-*`** and **`is-ui-*`** keys only; drop legacy MCP server names from user configs.
 
 ## Server keys (backend)
 

--- a/.claude/agents/imgscore-mcp-debug.md
+++ b/.claude/agents/imgscore-mcp-debug.md
@@ -14,9 +14,9 @@ You are the **image-scoring MCP debug** specialist for **image-scoring-backend**
 
 ## MCP server keys
 
-- This repo's stdio MCP: **`imgscore-py-stdio`**.
-- Electron workspace with backend as sibling: **`imgscore-el-stdio`**.
-- WebUI + optional `execute_code`: **`imgscore-py-sse`** / **`imgscore-el-sse`** when relevant and `ENABLE_MCP_EXECUTE_CODE=1`—see **`AGENTS.md`**.
+- This repo's compact MCP: **`is-be-mcp`** (`search`, `dispatch`).
+- Legacy domain stdio: **`is-be-diag`**, **`is-be-jobs`**, **`is-be-data`**.
+- WebUI + optional `execute_code`: **`is-be-webui`** when relevant and `ENABLE_MCP_EXECUTE_CODE=1`—see **`AGENTS.md`**.
 
 ## First-pass triage (stop when the answer is clear)
 

--- a/.claude/rules/image-scoring-mcp.mdc
+++ b/.claude/rules/image-scoring-mcp.mdc
@@ -5,15 +5,4 @@ alwaysApply: true
 
 # Vexlum Scoring MCP
 
-When the user asks about **debugging**, **investigating failures**, **database health**, **scoring/tagging/clustering jobs** (batch rows in `jobs`), or **Gradio / WebUI state**, use the image-scoring MCP servers.
-
-## Server Selection (project keys)
-
-| Server key | Transport | When to use |
-|------------|-----------|-------------|
-| **`image-scoring-backend-stdio`** | stdio | DB/jobs offline; WSL `~/.venvs/tf`. |
-| **`image-scoring-backend-webui`** | SSE | Live WebUI; `execute_code` when `ENABLE_MCP_EXECUTE_CODE=1`. |
-| **`image-scoring-gallery-stdio`** | stdio | Gallery logs, `api_*`. |
-| **`image-scoring-gallery-live`** | SSE | Electron `cdp_*`. |
-
-See backend [`.cursor/rules/image-scoring-mcp.mdc`](../../.cursor/rules/image-scoring-mcp.mdc) for full tables and triage flows.
+Mirror of [`.cursor/rules/image-scoring-mcp.mdc`](../../.cursor/rules/image-scoring-mcp.mdc). **Preferred:** **`is-be-mcp`** → **`search`** / **`dispatch`**. Gallery: **`is-ui-*`**. See backend **`AGENTS.md`** and [MCP_SEARCH_DISPATCH.md](../../docs/technical/MCP_SEARCH_DISPATCH.md).

--- a/.claude/skills/imgscore-mcp-debug/SKILL.md
+++ b/.claude/skills/imgscore-mcp-debug/SKILL.md
@@ -29,9 +29,9 @@ Investigate **image-scoring-backend** issues using the Vexlum Scoring MCP **read
 
 ## MCP server selection
 
-- **Python workspace (this repo):** `imgscore-py-stdio` for stdio MCP.
-- **Electron workspace with backend as sibling:** `imgscore-el-stdio` (same tools; PYTHONPATH points at backend).
-- **WebUI live / `execute_code`:** `imgscore-py-sse` or `imgscore-el-sse` only when needed and when enabled—see `AGENTS.md`.
+- **Backend workspace (this repo):** **`is-be-mcp`** → **`search`** / **`dispatch`** (preferred); legacy **`is-be-diag`**, **`is-be-jobs`**, **`is-be-data`**.
+- **Gallery workspace:** **`is-ui-local`**, **`is-ui-api`**, **`is-ui-live`**; backend triage via sibling **`is-be-mcp`**.
+- **WebUI live / `execute_code`:** **`is-be-webui`** only when needed and when enabled—see `AGENTS.md`.
 
 ## Investigation order (align with AGENTS.md)
 

--- a/.claude/skills/mcp-debugging-workflow/SKILL.md
+++ b/.claude/skills/mcp-debugging-workflow/SKILL.md
@@ -18,7 +18,7 @@ Apply this skill when the user asks to:
 
 ### 1. Get Error Overview
 
-Call `get_error_summary` (Vexlum Scoring MCP: **`imgscore-py-stdio`** in the Python workspace, **`imgscore-el-stdio`** in the Electron workspace) to identify scope of failures: failed jobs, missing scores, orphaned records.
+Call **`search("scoring failures")`** then **`dispatch("diagnostics.get_error_summary", {})`** on **`is-be-mcp`** (or legacy **`get_error_summary`** on **`is-be-diag`**) to identify scope of failures: failed jobs, missing scores, orphaned records.
 
 ### 2. Check Database Health
 
@@ -42,8 +42,9 @@ Call `read_debug_log` with optional `lines` to see recent error messages.
 
 ## Server Selection
 
-- **stdio (DB/jobs, no WebUI)**: `imgscore-py-stdio` if workspace is **image-scoring**; `imgscore-el-stdio` if workspace is **electron-image-scoring**
-- **WebUI / `execute_code`**: `imgscore-py-sse` or `imgscore-el-mcp-sse` (same endpoint; use the key from your open workspace)
+- **Compact dispatch (preferred):** **`is-be-mcp`** → **`search`** / **`dispatch`**
+- **Legacy domain stdio:** **`is-be-diag`**, **`is-be-jobs`**, **`is-be-data`**
+- **WebUI / `execute_code`:** **`is-be-webui`** (requires `ENABLE_MCP_EXECUTE_CODE=1`)
 
 ## Terminology
 

--- a/.github/workflows/mcp-tool-doc-sync.yml
+++ b/.github/workflows/mcp-tool-doc-sync.yml
@@ -44,6 +44,6 @@ jobs:
         run: |
           python scripts/generate_mcp_tool_inventory.py --check-action-registry
 
-      - name: Lint MCP doc vocabulary (warn-only)
+      - name: Lint MCP doc vocabulary
         run: |
-          python scripts/lint_mcp_doc_vocabulary.py || true
+          python scripts/lint_mcp_doc_vocabulary.py --error

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ Legacy: **`is-be-router`** exposes `search`/`dispatch` plus deprecated **`be_fin
 
 Example templates: [`.cursor/mcp.pair.example.json`](.cursor/mcp.pair.example.json) (backend), gallery [`.cursor/mcp.pair.example.json`](https://github.com/synthet/image-scoring-gallery/blob/main/.cursor/mcp.pair.example.json).
 
-**Legacy keys** (`image-scoring-backend-*`, `imgscore-py-*`, `is-ga-*`): remove from user MCP configs; use **`is-be-*`** / **`is-ui-*`**.
+**Legacy MCP keys:** remove obsolete server names from user `~/.cursor/mcp.json`; use **`is-be-*`** (backend) and **`is-ui-*`** (gallery) from each repo's `mcp.example.json` / `.cursor/mcp.json`.
 
 For backend WebUI SSE, start the WebUI first (`run_webui.bat`). Confirm URL with **`GET /mcp-status`** → `expected_sse_url`. For **`execute_code`**, set **`ENABLE_MCP_EXECUTE_CODE=1`** on **`is-be-webui`**. Gallery live port: **`gallery-mcp.lock`** (default `9373`).
 
@@ -361,7 +361,7 @@ Agent: "How fast is the system processing images?"
 
 ### Duplicate MCP servers in Cursor (same name twice)
 
-If you still see duplicate or legacy keys (`scoring`, `webui`, `imgscore-py-*`), remove them from **`%USERPROFILE%\.cursor\mcp.json`**. Project keys belong only in each repo’s `.cursor/mcp.json`.
+If you still see duplicate or legacy keys (`scoring`, `webui`, old `imgscore-*` prefixes), remove them from **`%USERPROFILE%\.cursor\mcp.json`**. Project keys belong only in each repo’s `.cursor/mcp.json`.
 
 ## Pytest E2E vocabulary (agents)
 

--- a/docs/ai/LLM_CONTEXT.md
+++ b/docs/ai/LLM_CONTEXT.md
@@ -72,4 +72,4 @@ This project includes an MCP server exposing debugging tools to Cursor and agent
 
 **Similarity & tagging:** `search_similar_images`, `find_near_duplicates`, `propagate_tags`, `find_outliers`
 
-**Gradio debug:** Cursor server `imgscore-py-sse` or `imgscore-el-sse` + `ENABLE_MCP_EXECUTE_CODE=1` → tool `execute_code`
+**Gradio debug:** Cursor server **`is-be-webui`** + `ENABLE_MCP_EXECUTE_CODE=1` → tool `execute_code`

--- a/docs/guides/CULLING_EMBEDDING_BACKFILL.md
+++ b/docs/guides/CULLING_EMBEDDING_BACKFILL.md
@@ -184,7 +184,7 @@ culling tower and embedding coverage is < 90%, the script logs a **LOW EMBEDDING
 COVERAGE** warning (those stacks collapse to one leaf = whole-stack cap) — finish
 Step 4 first.
 
-Verify afterward (Windows host or `mcp__imgscore-py-sse__execute_sql`):
+Verify afterward (Windows host or **`is-be-data`** `execute_sql` / compact **`dispatch`** when enabled):
 
 ```sql
 -- multi-image stacks still missing sub_stacks (expect ~0 after a full run)

--- a/docs/log.md
+++ b/docs/log.md
@@ -6,6 +6,10 @@ Parse with: `grep "^## \[" docs/log.md | tail -10`
 
 ---
 
+## [2026-06-06] feature | MCP support.export_debug_bundle dispatch
+
+First side-effecting compact action: `support.export_debug_bundle` with code allowlist, path safety, `confirmation_required`, and metadata-only response ([technical/MCP_SEARCH_DISPATCH.md](technical/MCP_SEARCH_DISPATCH.md)).
+
 ## [2026-06-06] feature | MCP search + dispatch PR1
 
 Shipped compact backend MCP **`is-be-mcp`** with **`search`** and **`dispatch`** over a curated action registry ([technical/MCP_SEARCH_DISPATCH.md](technical/MCP_SEARCH_DISPATCH.md), [mcp/action_registry.json](../mcp/action_registry.json)). Planning: [planning/mcp-search-dispatch.md](planning/mcp-search-dispatch.md).

--- a/docs/technical/AGENT_COORDINATION.md
+++ b/docs/technical/AGENT_COORDINATION.md
@@ -104,7 +104,7 @@ Local pointers (not authoritative): [design/DESIGN_SYSTEM.md](../design/DESIGN_S
 
 ## 🔍 Troubleshooting with MCP
 
-Agents use **stdio** MCP against the Python backend: **`imgscore-py-stdio`** in the **image-scoring-backend** workspace; **`imgscore-el-stdio`** in **image-scoring-gallery** (same server, different `cwd`). For WebUI / **`execute_code`**, enable **`imgscore-py-sse`** or **`imgscore-el-sse`** (unique keys, same URL). Use these to diagnose cross-project issues:
+Agents use MCP against the Python backend: **`is-be-mcp`** (`search` / `dispatch`) in **image-scoring-backend**; **`is-ui-*`** in **image-scoring-gallery**. For WebUI / **`execute_code`**, enable **`is-be-webui`**. Use these to diagnose cross-project issues:
 
 | Tool | Usage in Coordination |
 |------|------------------------|

--- a/docs/technical/EXTERNAL_CLI_REVIEWS.md
+++ b/docs/technical/EXTERNAL_CLI_REVIEWS.md
@@ -17,7 +17,7 @@ Optional **review-only** second opinions from **Codex** or **Gemini CLI**, orche
 
 ## Duplicate MCP servers
 
-Cursor merges **project** [`.cursor/mcp.json`](../../.cursor/mcp.json) with **user-level** MCP config. If you also have a global `subagent-orchestrator` or `user-subagent-orchestrator` entry, **disable one** — prefer the project key `imgscore-subagent-orchestrator` so `WORKSPACE_ROOT` is this repository and tool names stay prefixed consistently with other `imgscore-py-*` servers.
+Cursor merges **project** [`.cursor/mcp.json`](../../.cursor/mcp.json) with **user-level** MCP config. If you also have a global `subagent-orchestrator` or `user-subagent-orchestrator` entry, **disable one** — prefer the project key `imgscore-subagent-orchestrator` so `WORKSPACE_ROOT` is this repository.
 
 ## MCP in this repo
 

--- a/docs/technical/MCP_DEBUGGING_TOOLS.md
+++ b/docs/technical/MCP_DEBUGGING_TOOLS.md
@@ -35,15 +35,15 @@ Add the following to your Cursor MCP settings (Settings → MCP → Add Server):
 
 ```json
 {
-  "name": "imgscore-py-stdio",
+  "name": "is-be-mcp",
   "command": "python",
-  "args": ["-m", "modules.mcp_server"],
+  "args": ["-m", "modules.mcp.router_server", "--profile", "compact"],
   "cwd": "${workspaceFolder}",
-  "env": { "PYTHONPATH": "${workspaceFolder}" }
+  "env": { "PYTHONPATH": "${workspaceFolder}", "MCP_TOOL_PROFILE": "compact" }
 }
 ```
 
-When the Cursor workspace is **image-scoring-gallery**, use the same `command` / `args` but name the server **`imgscore-el-stdio`** and set `cwd` / `PYTHONPATH` to your **image-scoring-backend** checkout path. For WebUI / `execute_code`, register **`imgscore-el-sse`** (or **`imgscore-py-sse`** in the Python workspace) with the `url` from `GET /mcp-status`.
+See [`.cursor/mcp.pair.example.json`](../../.cursor/mcp.pair.example.json) for domain-split servers. When the Cursor workspace is **image-scoring-gallery**, use **`is-ui-*`** keys from gallery `mcp.example.json`. For WebUI / `execute_code`, register **`is-be-webui`** with the `url` from `GET /mcp-status`.
 
 ### Option 2: Project Config File
 
@@ -439,7 +439,7 @@ Start a background scoring, tagging, or clustering job (requires the correspondi
 Embedding-assisted tools for duplicate pairs, keyword propagation, and outlier detection. See tool docstrings in `modules/mcp_server.py`.
 
 #### `execute_code`
-Execute Python in the **WebUI process** over SSE. Requires **`ENABLE_MCP_EXECUTE_CODE=1`** and a Cursor SSE server (**`imgscore-py-sse`** or **`imgscore-el-sse`**). Assign to `result` to return a value.
+Execute Python in the **WebUI process** over SSE. Requires **`ENABLE_MCP_EXECUTE_CODE=1`** and **`is-be-webui`**. Assign to `result` to return a value.
 
 #### `get_pipeline_stats`
 Get statistics about the processing pipeline and active jobs.

--- a/docs/technical/MCP_SEARCH_DISPATCH.md
+++ b/docs/technical/MCP_SEARCH_DISPATCH.md
@@ -74,9 +74,11 @@ dispatch(
 
 ### Error envelope
 
-`status: "error"`, `code` (`unknown_action`, `validation_error`, `policy_rejected`, …), `message`, `request_id`.
+`status: "error"`, `code` (`unknown_action`, `validation_error`, `policy_rejected`, `confirmation_required`, `unsupported_dry_run`, …), `message`, `request_id`.
 
-## PR1 dispatchable actions
+## Dispatchable actions
+
+### Read-only (PR1)
 
 | action_id | Example arguments |
 |-----------|-----------------|
@@ -94,6 +96,12 @@ dispatch(
 | `jobs.get_failed_images` | `{"limit": 20}` |
 | `jobs.get_run_diagnostics` | `{"run_id": 123}` |
 | `data.get_embedding_stats` | `{}` |
+
+### Side-effecting (confirmation required)
+
+| action_id | Example arguments | Notes |
+|-----------|-------------------|-------|
+| `support.export_debug_bundle` | `{"confirmed": true}` via dispatch | Writes redacted zip; `output_path` optional (`.zip` only); returns metadata + `review_reminder` |
 
 ## Legacy tool mapping
 
@@ -129,9 +137,19 @@ dispatch("diagnostics.validate_config", {})
 dispatch("diagnostics.run_doctor", {"no_gpu": true})
 ```
 
-### Unsupported in PR1
+### Export debug bundle (writes_files)
 
-Writes, `execute_sql`, debug bundle export, and thumbnail generation should return **`low_confidence: true`**.
+```text
+search("export debug bundle")
+dispatch("support.export_debug_bundle", {}, confirmed=True)
+# optional: {"output_path": "exports/debug-bundles/my-bundle.zip"}
+```
+
+Review the zip before sharing. `secrets.json` is never included.
+
+### Still unsupported via compact dispatch
+
+`execute_sql`, `execute_code`, maintenance writes/jobs, and other side-effecting actions unless listed above and in `ALLOWED_SIDE_EFFECT_ACTIONS`.
 
 ## Vocabulary (do not use)
 

--- a/docs/technical/MCP_SEARCH_DISPATCH.md
+++ b/docs/technical/MCP_SEARCH_DISPATCH.md
@@ -153,7 +153,7 @@ Review the zip before sharing. `secrets.json` is never included.
 
 ## Vocabulary (do not use)
 
-- `imgscore-py-*`, `image-scoring-backend-*`, `is-ga-*`
+Use **`is-be-*`** and **`is-ui-*`** keys only; remove legacy MCP server names from user configs.
 - Calling 50+ legacy tools from **new** agent configs (use `is-be-mcp` instead)
 
 ## Gallery

--- a/mcp/action_registry.json
+++ b/mcp/action_registry.json
@@ -15,7 +15,8 @@
     "data": 1,
     "diagnostics": 7,
     "jobs": 2,
-    "logs": 3
+    "logs": 3,
+    "support": 1
   },
   "actions": [
     {
@@ -709,6 +710,60 @@
       },
       "legacy_tool_name": "search_logs",
       "action_id": "logs.search_logs"
+    },
+    {
+      "title": "Export redacted debug bundle",
+      "description": "Write a redacted support zip (config, environment, doctor JSON, log tails). Same as scripts/export_debug_bundle.py.",
+      "category": "support",
+      "tags": [
+        "support",
+        "diagnostics",
+        "bundle",
+        "export"
+      ],
+      "aliases": [
+        "export debug bundle",
+        "support zip",
+        "debug bundle"
+      ],
+      "intent_examples": [
+        "export debug bundle",
+        "create support zip",
+        "redacted diagnostics bundle"
+      ],
+      "side_effect_level": "writes_files",
+      "confirmation_required": true,
+      "dry_run_supported": false,
+      "dispatch_enabled": true,
+      "review_required": true,
+      "compact_profile_exposure": true,
+      "version": 1,
+      "deprecated": false,
+      "canonical_docs": [
+        "docs/DIAGNOSTICS.md"
+      ],
+      "api_contract_refs": [],
+      "auth_or_policy_requirements": [],
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "output_path": {
+            "type": "string",
+            "description": "Optional absolute or repo-relative .zip path; default exports/debug-bundles/"
+          }
+        },
+        "additionalProperties": false
+      },
+      "canonical_backend_handler": {
+        "kind": "python_function",
+        "module": "modules.debug_bundle_export",
+        "function": "write_redacted_debug_bundle"
+      },
+      "legacy_tool_name": "export_debug_bundle",
+      "test_refs": [
+        "tests/test_mcp_dispatch.py::test_dispatch_export_debug_bundle_confirmed"
+      ],
+      "action_id": "support.export_debug_bundle"
     }
   ]
 }

--- a/mcp/actions/overlay.yaml
+++ b/mcp/actions/overlay.yaml
@@ -481,3 +481,38 @@ actions:
       module: modules.mcp_server
       function: get_embedding_stats
     legacy_tool_name: get_embedding_stats
+
+  support.export_debug_bundle:
+    title: Export redacted debug bundle
+    description: Write a redacted support zip (config, environment, doctor JSON, log tails). Same as scripts/export_debug_bundle.py.
+    category: support
+    tags: [support, diagnostics, bundle, export]
+    aliases: [export debug bundle, support zip, debug bundle]
+    intent_examples:
+      - export debug bundle
+      - create support zip
+      - redacted diagnostics bundle
+    side_effect_level: writes_files
+    confirmation_required: true
+    dry_run_supported: false
+    dispatch_enabled: true
+    review_required: true
+    compact_profile_exposure: true
+    version: 1
+    deprecated: false
+    canonical_docs: [docs/DIAGNOSTICS.md]
+    api_contract_refs: []
+    auth_or_policy_requirements: []
+    input_schema:
+      type: object
+      properties:
+        output_path:
+          type: string
+          description: Optional absolute or repo-relative .zip path; default exports/debug-bundles/
+      additionalProperties: false
+    canonical_backend_handler:
+      kind: python_function
+      module: modules.debug_bundle_export
+      function: write_redacted_debug_bundle
+    legacy_tool_name: export_debug_bundle
+    test_refs: [tests/test_mcp_dispatch.py::test_dispatch_export_debug_bundle_confirmed]

--- a/modules/mcp/actions/dispatch.py
+++ b/modules/mcp/actions/dispatch.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import logging
 import time
 import uuid
+from pathlib import Path
 from typing import Any
 
 from modules.mcp.actions.envelope import dry_run_envelope, success_envelope
-from modules.mcp.actions.errors import McpActionError
+from modules.mcp.actions.errors import McpActionError, ValidationError
 from modules.mcp.actions.handlers import invoke_handler
+from modules.mcp.actions.path_safety import validate_debug_bundle_output_path
 from modules.mcp.actions.policy import (
     check_dispatchable,
     check_side_effect_policy,
@@ -28,6 +30,54 @@ def _sanitize(data: Any) -> Any:
         return _sanitize_for_mcp(data)
     except Exception:
         return data
+
+
+_REVIEW_REMINDER = (
+    "Review the zip before sharing. secrets.json is excluded. See docs/DIAGNOSTICS.md."
+)
+
+
+def _dispatch_export_debug_bundle(
+    record: dict[str, Any],
+    validated: dict[str, Any],
+    *,
+    request_id: str,
+    warnings: list[str],
+) -> dict[str, Any]:
+    from modules.debug_bundle_export import write_redacted_debug_bundle
+
+    output_path = validated.get("output_path")
+    if output_path is not None and not isinstance(output_path, str):
+        raise ValidationError("output_path must be a string", details={"field": "output_path"})
+
+    resolved = validate_debug_bundle_output_path(
+        output_path if isinstance(output_path, str) else None,
+    )
+    raw = write_redacted_debug_bundle(output_zip=resolved)
+    if not raw.get("success"):
+        raise McpActionError(
+            str(raw.get("error") or "export failed"),
+            details={"path": raw.get("path")},
+        )
+
+    zip_path = Path(str(raw["path"])).resolve()
+    size_bytes = zip_path.stat().st_size if zip_path.is_file() else 0
+    data = {
+        "artifact": {
+            "kind": "debug_bundle",
+            "path": str(zip_path),
+            "size_bytes": size_bytes,
+        }
+    }
+    return success_envelope(
+        record,
+        request_id=request_id,
+        data=data,
+        summary="Redacted debug bundle written.",
+        dry_run=False,
+        warnings=warnings,
+        review_reminder=_REVIEW_REMINDER,
+    )
 
 
 def dispatch_action(
@@ -61,6 +111,9 @@ def dispatch_action(
                 validated_args=validated,
                 warnings=warnings + ["dry_run has no effect for read-only actions"],
             )
+
+        if action_id == "support.export_debug_bundle":
+            return _dispatch_export_debug_bundle(record, validated, request_id=rid, warnings=warnings)
 
         raw = invoke_handler(record, validated)
         data = _sanitize(raw)

--- a/modules/mcp/actions/envelope.py
+++ b/modules/mcp/actions/envelope.py
@@ -16,8 +16,9 @@ def success_envelope(
     errors: list[str] | None = None,
     artifacts: list[dict[str, Any]] | None = None,
     logs_ref: str | None = None,
+    review_reminder: str | None = None,
 ) -> dict[str, Any]:
-    return {
+    out: dict[str, Any] = {
         "action_id": record.get("action_id"),
         "action_version": int(record.get("version") or 1),
         "request_id": request_id,
@@ -32,6 +33,9 @@ def success_envelope(
         "logs_ref": logs_ref,
         "canonical_docs": list(record.get("canonical_docs") or []),
     }
+    if review_reminder:
+        out["review_reminder"] = review_reminder
+    return out
 
 
 def dry_run_envelope(

--- a/modules/mcp/actions/errors.py
+++ b/modules/mcp/actions/errors.py
@@ -38,6 +38,14 @@ class PolicyError(McpActionError):
     code = "policy_rejected"
 
 
+class ConfirmationRequiredError(McpActionError):
+    code = "confirmation_required"
+
+
+class UnsupportedDryRunError(McpActionError):
+    code = "unsupported_dry_run"
+
+
 class ValidationError(McpActionError):
     code = "validation_error"
 

--- a/modules/mcp/actions/path_safety.py
+++ b/modules/mcp/actions/path_safety.py
@@ -1,0 +1,68 @@
+"""Safe output paths for side-effecting MCP actions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from modules.mcp.actions.errors import PolicyError, ValidationError
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+_BLOCKED_WRITE_PREFIXES = (
+    _REPO_ROOT / "modules",
+    _REPO_ROOT / "docs",
+    _REPO_ROOT / "tests",
+    _REPO_ROOT / "mcp",
+    _REPO_ROOT / "frontend",
+    _REPO_ROOT / "scripts",
+    _REPO_ROOT / "migrations",
+    _REPO_ROOT / "webui",
+)
+
+
+def validate_debug_bundle_output_path(
+    output_path: str | None,
+    *,
+    repo_root: Path | None = None,
+) -> Path | None:
+    """Return resolved zip path or None for default safe directory."""
+    root = repo_root or _REPO_ROOT
+    if output_path is None or not str(output_path).strip():
+        return None
+
+    raw = str(output_path).strip()
+    if ".." in Path(raw).parts:
+        raise PolicyError(
+            "output_path must not contain parent-directory segments",
+            details={"output_path": raw, "policy": "path_traversal"},
+        )
+
+    candidate = Path(raw).expanduser()
+    if not candidate.is_absolute():
+        candidate = (root / candidate).resolve()
+    else:
+        candidate = candidate.resolve()
+
+    if candidate.suffix.lower() != ".zip":
+        raise ValidationError(
+            "output_path must end with .zip",
+            details={"output_path": str(candidate)},
+        )
+
+    if candidate.exists():
+        raise PolicyError(
+            "output_path already exists; refusing to overwrite",
+            details={"output_path": str(candidate), "policy": "no_overwrite"},
+        )
+
+    for blocked in _BLOCKED_WRITE_PREFIXES:
+        try:
+            candidate.relative_to(blocked.resolve())
+            raise PolicyError(
+                "output_path must not write into repository source directories",
+                details={"output_path": str(candidate), "policy": "blocked_prefix"},
+            )
+        except ValueError:
+            continue
+
+    return candidate

--- a/modules/mcp/actions/policy.py
+++ b/modules/mcp/actions/policy.py
@@ -6,12 +6,20 @@ from typing import Any
 
 from modules.mcp.actions.errors import (
     ActionNotDispatchableError,
+    ConfirmationRequiredError,
     DeprecatedActionError,
     PolicyError,
+    UnsupportedDryRunError,
     VersionMismatchError,
 )
 
 READ_ONLY = "read_only"
+
+ALLOWED_SIDE_EFFECT_ACTIONS = frozenset(
+    {
+        "support.export_debug_bundle",
+    }
+)
 
 
 def check_dispatchable(record: dict[str, Any], *, allow_deprecated: bool = False) -> None:
@@ -46,21 +54,31 @@ def check_side_effect_policy(
     *,
     confirmed: bool,
     dry_run: bool,
-    pr1_read_only_only: bool = True,
 ) -> None:
     level = str(record.get("side_effect_level") or READ_ONLY)
-    if pr1_read_only_only and level != READ_ONLY:
-        raise PolicyError(
-            f"Action {record.get('action_id')} has side_effect_level={level}; not enabled in PR1",
-            details={"side_effect_level": level, "policy": "pr1_read_only_only"},
+    action_id = str(record.get("action_id") or "")
+
+    if level != READ_ONLY:
+        if action_id not in ALLOWED_SIDE_EFFECT_ACTIONS:
+            raise PolicyError(
+                f"Action {action_id} has side_effect_level={level}; not in ALLOWED_SIDE_EFFECT_ACTIONS",
+                details={"side_effect_level": level, "policy": "side_effect_allowlist"},
+            )
+
+    if dry_run and level != READ_ONLY and not record.get("dry_run_supported"):
+        raise UnsupportedDryRunError(
+            f"Action {action_id} does not support dry_run",
+            details={"action_id": action_id, "dry_run_supported": False},
         )
+
     if record.get("confirmation_required") and not confirmed and level != READ_ONLY:
-        raise PolicyError(
+        raise ConfirmationRequiredError(
             "confirmation_required=true; pass confirmed=True",
-            details={"action_id": record.get("action_id")},
+            details={"action_id": action_id},
         )
+
     if level != READ_ONLY and not dry_run and record.get("dry_run_supported"):
         raise PolicyError(
             "dry_run_supported; call dispatch with dry_run=True first",
-            details={"action_id": record.get("action_id")},
+            details={"action_id": action_id},
         )

--- a/scripts/lint_mcp_doc_vocabulary.py
+++ b/scripts/lint_mcp_doc_vocabulary.py
@@ -24,12 +24,16 @@ SKIP_GLOBS = (
     "docs/archive/**",
     "notebooklm_docs.md",
     "docs/technical/MCP_SEARCH_DISPATCH_PR1_SUMMARY.md",
+    ".claude/settings.local.json",
+    "docs/log.md",
 )
 
 STALE_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
     ("imgscore-py-*", re.compile(r"imgscore-py[-_]")),
     ("imgscore-el-gallery", re.compile(r"imgscore-el-gallery")),
+    ("imgscore-el-stdio", re.compile(r"imgscore-el-stdio")),
     ("image-scoring-backend-stdio", re.compile(r"image-scoring-backend-(stdio|webui|postgres)")),
+    ("image-scoring-gallery-stdio", re.compile(r"image-scoring-gallery-(stdio|live)")),
     ("is-ga-*", re.compile(r"\bis-ga-")),
     ("ga_find", re.compile(r"\bga_find\b")),
     ("mcp__imgscore-py", re.compile(r"mcp__imgscore-py")),

--- a/tests/test_mcp_dispatch.py
+++ b/tests/test_mcp_dispatch.py
@@ -57,3 +57,80 @@ def test_dispatch_run_diagnostics_requires_run_id():
     result = dispatch_action("jobs.get_run_diagnostics", {})
     assert result.get("status") == "error"
     assert result.get("code") == "validation_error"
+
+
+def test_dispatch_export_debug_bundle_requires_confirmation():
+    with patch("modules.debug_bundle_export.write_redacted_debug_bundle") as mock_write:
+        result = dispatch_action("support.export_debug_bundle", {})
+    assert result.get("status") == "error"
+    assert result.get("code") == "confirmation_required"
+    mock_write.assert_not_called()
+
+
+def test_dispatch_export_debug_bundle_rejects_dry_run():
+    with patch("modules.debug_bundle_export.write_redacted_debug_bundle") as mock_write:
+        result = dispatch_action(
+            "support.export_debug_bundle",
+            {},
+            dry_run=True,
+            confirmed=True,
+        )
+    assert result.get("status") == "error"
+    assert result.get("code") == "unsupported_dry_run"
+    mock_write.assert_not_called()
+
+
+def test_dispatch_export_debug_bundle_confirmed(tmp_path):
+    zip_path = tmp_path / "bundle.zip"
+    with patch("modules.debug_bundle_export.write_redacted_debug_bundle") as mock_write:
+        mock_write.return_value = {"success": True, "path": str(zip_path)}
+        zip_path.write_bytes(b"fake")
+        result = dispatch_action(
+            "support.export_debug_bundle",
+            {},
+            confirmed=True,
+        )
+    assert result.get("status") == "success"
+    assert result.get("review_reminder")
+    artifact = result.get("data", {}).get("artifact", {})
+    assert artifact.get("kind") == "debug_bundle"
+    assert artifact.get("path") == str(zip_path.resolve())
+    assert artifact.get("size_bytes") == 4
+    mock_write.assert_called_once()
+
+
+def test_dispatch_export_debug_bundle_bad_extension():
+    result = dispatch_action(
+        "support.export_debug_bundle",
+        {"output_path": "bundle.txt"},
+        confirmed=True,
+    )
+    assert result.get("status") == "error"
+    assert result.get("code") == "validation_error"
+
+
+def test_dispatch_export_debug_bundle_rejects_traversal():
+    result = dispatch_action(
+        "support.export_debug_bundle",
+        {"output_path": "../bundle.zip"},
+        confirmed=True,
+    )
+    assert result.get("status") == "error"
+    assert result.get("code") == "policy_rejected"
+
+
+def test_dispatch_side_effect_not_in_allowlist_even_if_dispatch_enabled():
+    """Overlay-only write actions stay blocked without code allowlist entry."""
+    fake_record = {
+        "action_id": "maintenance.prune_missing_files",
+        "dispatch_enabled": True,
+        "side_effect_level": "destructive",
+        "confirmation_required": True,
+        "dry_run_supported": True,
+        "version": 1,
+        "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
+    }
+    with patch("modules.mcp.actions.dispatch.require_action", return_value=fake_record):
+        result = dispatch_action("maintenance.prune_missing_files", {}, confirmed=True)
+    assert result.get("status") == "error"
+    assert result.get("code") == "policy_rejected"

--- a/tests/test_mcp_search.py
+++ b/tests/test_mcp_search.py
@@ -24,6 +24,7 @@ EVAL_FIXTURE = Path(__file__).resolve().parent / "fixtures" / "mcp_search_eval.y
         ("database health", "diagnostics.check_database_health"),
         ("images without embeddings", "data.get_embedding_stats"),
         ("search logs for error", "logs.search_logs"),
+        ("export debug bundle", "support.export_debug_bundle"),
     ],
 )
 def test_search_finds_expected_action(query, expected_in_top):


### PR DESCRIPTION
## Summary

- Adds `support.export_debug_bundle` as the first side-effecting dispatch action with a code allowlist (`ALLOWED_SIDE_EFFECT_ACTIONS`), confirmation gate, output path safety (`.zip` only, no traversal/overwrite), and metadata-only artifact responses.
- Sweeps stale MCP server names from agent/docs to `is-be-*` / `is-ui-*` vocabulary and enforces `scripts/lint_mcp_doc_vocabulary.py --error` in the MCP doc sync workflow.

## Test plan

- [x] `pytest tests/test_mcp_dispatch.py tests/test_mcp_action_registry.py`
- [x] `python scripts/generate_mcp_tool_inventory.py --check-action-registry`
- [x] `python scripts/lint_mcp_doc_vocabulary.py --error`

Closes #240