### PR TITLE
fix(scoring): finalize phantom-scored images by backfilling composite from model rows

### DIFF
--- a/modules/phantom_score_finalize.py
+++ b/modules/phantom_score_finalize.py
@@ -1,0 +1,202 @@
+"""Finalize *phantom-scored* images.
+
+A "phantom-scored" image is one whose per-model rows already exist in
+``image_model_scores`` (the ML inference ran and succeeded) but whose composite
+``images.score_general`` was never written and whose ``scoring`` phase row is not
+terminal-complete. This happens when a scoring job is interrupted **between**
+``ScoringWorker`` (which persists the per-model rows) and the ``ResultWorker`` finalize
+step (``upsert_image`` writing ``score_general`` + ``set_image_phase_status(DONE)``).
+
+The result is a self-perpetuating wedge:
+  * ``is_image_scoring_complete()`` returns True (per-model rows exist), so the JIT
+    re-planner sees *no scoring work* and skips the phase, and
+  * the folder bucketer reads ``image_phase_status = not_started`` and keeps
+    re-bucketing the folder as ``awaiting_scoring`` — auto-drive re-enqueues it
+    forever while never actually finalizing anything.
+
+This module recomputes the composite (``score_general`` / ``score_technical`` /
+``score_aesthetic`` / ``rating`` / ``label``) **from the already-stored model rows**
+— no re-inference — and flips the scoring phase to ``done``. It is the missing
+companion to :func:`modules.db.reconcile_phantom_complete_image_phases`, which only
+flips the phase status and never backfills the composite columns.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional, Sequence
+
+from modules import db
+from modules import score_normalization as snorm
+
+logger = logging.getLogger(__name__)
+
+
+def _scope_clause(scope_path: Optional[str]) -> tuple[str, tuple]:
+    """Return (sql_fragment, params) restricting to a folder subtree, or ("", ())."""
+    if not scope_path or not str(scope_path).strip():
+        return "", ()
+    from modules import utils
+
+    wsl = utils.convert_path_to_wsl(scope_path) if hasattr(utils, "convert_path_to_wsl") else scope_path
+    target = wsl or scope_path
+    return " AND (f.path = ? OR f.path LIKE ? OR f.path LIKE ?)", (target, target + "/%", target + "\\%")
+
+
+def _find_candidates(
+    scope_path: Optional[str],
+    image_ids: Optional[Sequence[int]],
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Images that are scoring-*complete* (per-model rows present) but not finalized:
+    either ``score_general IS NULL`` or the scoring phase row is not ``done``/``skipped``."""
+    incomplete_sql = db.get_phase_incomplete_sql("scoring", "i")
+    if image_ids:
+        ids = [int(i) for i in image_ids if i is not None]
+        if not ids:
+            return []
+        placeholders = ",".join("?" for _ in ids)
+        sql = f"""
+            SELECT i.id, i.score_general, ips.status AS scoring_status
+            FROM images i
+            LEFT JOIN pipeline_phases pp ON LOWER(TRIM(pp.code)) = 'scoring'
+            LEFT JOIN image_phase_status ips ON ips.image_id = i.id AND ips.phase_id = pp.id
+            WHERE i.id IN ({placeholders})
+              AND NOT ({incomplete_sql})
+        """
+        rows = db.get_connector().query(sql, tuple(ids))
+        return [dict(r) for r in rows or []]
+
+    scope_frag, scope_params = _scope_clause(scope_path)
+    sql = f"""
+        SELECT i.id, i.score_general, ips.status AS scoring_status
+        FROM images i
+        JOIN folders f ON f.id = i.folder_id
+        LEFT JOIN pipeline_phases pp ON LOWER(TRIM(pp.code)) = 'scoring'
+        LEFT JOIN image_phase_status ips ON ips.image_id = i.id AND ips.phase_id = pp.id
+        WHERE NOT ({incomplete_sql})
+          AND (
+              i.score_general IS NULL
+              OR ips.status IS NULL
+              OR LOWER(TRIM(ips.status)) NOT IN ('done', 'skipped')
+          ){scope_frag}
+        FETCH FIRST ? ROWS ONLY
+    """
+    rows = db.get_connector().query(sql, scope_params + (max(1, int(limit)),))
+    return [dict(r) for r in rows or []]
+
+
+def _model_scores_by_image(image_ids: Sequence[int]) -> dict[int, dict[str, float]]:
+    """Production (non-shadow) normalized model scores keyed by image_id then model."""
+    ids = [int(i) for i in image_ids if i is not None]
+    if not ids:
+        return {}
+    placeholders = ",".join("?" for _ in ids)
+    rows = db.get_connector().query(
+        f"""
+        SELECT image_id, model_name, normalized, raw_score
+        FROM image_model_scores
+        WHERE image_id IN ({placeholders})
+          AND status = 'success'
+          AND is_shadow = FALSE
+        """,
+        tuple(ids),
+    )
+    out: dict[int, dict[str, float]] = {}
+    for r in rows or []:
+        iid = r["image_id"]
+        # Fusion anchors operate on the normalized 0-1 value; fall back to raw_score
+        # only if normalized is absent (older rows).
+        val = r.get("normalized")
+        if val is None:
+            val = r.get("raw_score")
+        if val is None:
+            continue
+        out.setdefault(iid, {})[str(r["model_name"]).strip().lower()] = float(val)
+    return out
+
+
+def finalize_phantom_scores(
+    *,
+    scope_path: Optional[str] = None,
+    image_ids: Optional[Sequence[int]] = None,
+    dry_run: bool = True,
+    limit: int = 5000,
+) -> dict[str, Any]:
+    """Backfill composite scores from stored per-model rows and finalize the scoring phase.
+
+    For each phantom candidate: recompute ``score_general``/``score_technical``/
+    ``score_aesthetic``/``rating``/``label`` via :func:`score_normalization.compute_all`
+    (only writing composites when ``score_general`` is currently NULL), then flip the
+    ``scoring`` phase to ``done``.
+
+    Returns a summary dict: ``candidates``, ``composites_backfilled``, ``phase_finalized``,
+    ``no_model_scores``, ``dry_run``, and a small ``samples`` list.
+    """
+    candidates = _find_candidates(scope_path, image_ids, limit)
+    summary: dict[str, Any] = {
+        "candidates": len(candidates),
+        "composites_backfilled": 0,
+        "phase_finalized": 0,
+        "no_model_scores": 0,
+        "dry_run": bool(dry_run),
+        "samples": [],
+    }
+    if not candidates:
+        return summary
+
+    ids = [c["id"] for c in candidates]
+    scores_by_image = _model_scores_by_image(ids)
+    conn = db.get_connector()
+
+    for cand in candidates:
+        iid = cand["id"]
+        model_scores = scores_by_image.get(iid)
+        if not model_scores:
+            # Should not happen (candidates are scoring-complete) but guard anyway.
+            summary["no_model_scores"] += 1
+            continue
+
+        needs_composite = cand.get("score_general") is None
+        computed = None
+        if needs_composite:
+            computed = snorm.compute_all(model_scores)
+            if not dry_run:
+                conn.execute(
+                    "UPDATE images SET score_general = ?, score_aesthetic = ?, "
+                    "score_technical = ?, rating = ?, label = ? WHERE id = ?",
+                    (
+                        computed["general"],
+                        computed["aesthetic"],
+                        computed["technical"],
+                        computed["rating"],
+                        computed["label"],
+                        iid,
+                    ),
+                )
+            summary["composites_backfilled"] += 1
+
+        # Flip the scoring phase to done (mirrors reconcile_phantom_complete_image_phases).
+        if not dry_run:
+            try:
+                db.set_image_phase_status(iid, "scoring", "done")
+            except Exception:
+                logger.debug("finalize_phantom_scores: phase flip failed for image %s", iid, exc_info=True)
+        summary["phase_finalized"] += 1
+
+        if len(summary["samples"]) < 10:
+            summary["samples"].append({
+                "image_id": iid,
+                "was_score_general_null": needs_composite,
+                "score_general": (computed or {}).get("general") if needs_composite else cand.get("score_general"),
+                "prev_phase_status": cand.get("scoring_status"),
+            })
+
+    logger.info(
+        "finalize_phantom_scores: scope=%s candidates=%d composites=%d phase=%d (dry_run=%s)",
+        scope_path or f"ids[{len(ids)}]",
+        summary["candidates"],
+        summary["composites_backfilled"],
+        summary["phase_finalized"],
+        dry_run,
+    )
+    return summary

--- a/scripts/maintenance/finalize_phantom_scores.py
+++ b/scripts/maintenance/finalize_phantom_scores.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Finalize phantom-scored images: backfill composite scores from stored per-model rows
+and flip the scoring phase to ``done`` — no re-inference.
+
+A phantom-scored image has ``image_model_scores`` rows (inference succeeded) but a NULL
+``images.score_general`` and a non-terminal ``scoring`` phase row, because a scoring job
+was interrupted between persisting per-model scores and the ResultWorker finalize step.
+The folder then churns in auto-drive (``awaiting_scoring`` forever) while the JIT planner
+sees no work. See ``modules/phantom_score_finalize.py`` for the full rationale.
+
+Dry-run by default; pass --apply to write.
+
+Usage (WSL, project root):
+  source ~/.venvs/tf/bin/activate
+  export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(pwd)/FirebirdLinux/.../lib
+
+  # Preview a single folder (no writes)
+  python scripts/maintenance/finalize_phantom_scores.py --scope /mnt/d/Photos/Z8/180-600mm/2026/2026-05-24
+  # Apply it
+  python scripts/maintenance/finalize_phantom_scores.py --scope /mnt/d/Photos/Z8/180-600mm/2026/2026-05-24 --apply
+  # Whole library preview
+  python scripts/maintenance/finalize_phantom_scores.py --all
+  # Specific images
+  python scripts/maintenance/finalize_phantom_scores.py --image-ids 176827,176828 --apply
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+
+_PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    target = parser.add_mutually_exclusive_group(required=True)
+    target.add_argument("--scope", help="Folder subtree to finalize (e.g. /mnt/d/Photos/.../2026-05-24)")
+    target.add_argument("--all", action="store_true", help="Scan the whole library")
+    target.add_argument("--image-ids", help="Comma-separated image ids to finalize")
+    parser.add_argument("--apply", action="store_true", help="Write changes (default: dry-run preview)")
+    parser.add_argument("--limit", type=int, default=5000, help="Max candidates per run (default 5000)")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON only")
+    args = parser.parse_args()
+
+    from modules.phantom_score_finalize import finalize_phantom_scores
+
+    image_ids = None
+    if args.image_ids:
+        image_ids = [int(x) for x in args.image_ids.split(",") if x.strip()]
+
+    summary = finalize_phantom_scores(
+        scope_path=None if (args.all or image_ids) else args.scope,
+        image_ids=image_ids,
+        dry_run=not args.apply,
+        limit=args.limit,
+    )
+
+    if args.json:
+        print(json.dumps(summary, indent=2, default=str))
+        return 0
+
+    mode = "APPLY" if args.apply else "DRY-RUN"
+    print(f"[{mode}] phantom-score finalize")
+    print(f"  candidates:            {summary['candidates']}")
+    print(f"  composites backfilled: {summary['composites_backfilled']}")
+    print(f"  phase finalized:       {summary['phase_finalized']}")
+    if summary.get("no_model_scores"):
+        print(f"  skipped (no model rows): {summary['no_model_scores']}")
+    for s in summary.get("samples", []):
+        print(
+            f"    img {s['image_id']}: prev_phase={s['prev_phase_status']} "
+            f"null_general={s['was_score_general_null']} -> score_general={s['score_general']}"
+        )
+    if not args.apply and summary["candidates"]:
+        print("  (dry-run — re-run with --apply to write)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_phantom_score_finalize.py
+++ b/tests/test_phantom_score_finalize.py
@@ -1,0 +1,117 @@
+"""Unit tests for modules.phantom_score_finalize.finalize_phantom_scores (no DB required).
+
+Patches the connector + get_phase_incomplete_sql + set_image_phase_status so the
+orchestration (candidate selection, composite backfill, phase flip, dry-run) is verified
+without a live database. ``score_normalization.compute_all`` runs for real (pure function).
+"""
+from __future__ import annotations
+
+from modules import phantom_score_finalize as psf
+
+
+class _FakeConn:
+    def __init__(self, candidate_rows, model_rows):
+        self._candidates = candidate_rows
+        self._models = model_rows
+        self.executed = []
+
+    def query(self, sql, params=None):
+        # Route by SQL content: the model-score fetch is the only one hitting that table.
+        if "image_model_scores" in sql:
+            return self._models
+        return self._candidates
+
+    def execute(self, sql, params=None):
+        self.executed.append((sql, params))
+
+
+def _patch(monkeypatch, candidate_rows, model_rows):
+    fake = _FakeConn(candidate_rows, model_rows)
+    monkeypatch.setattr(psf.db, "get_connector", lambda: fake)
+    monkeypatch.setattr(psf.db, "get_phase_incomplete_sql", lambda code, alias="": "1=0")
+    flips = []
+    monkeypatch.setattr(psf.db, "set_image_phase_status", lambda iid, code, status: flips.append((iid, code, status)))
+    return fake, flips
+
+
+_MODEL_ROWS = [
+    {"image_id": 1, "model_name": "liqe", "normalized": 0.55, "raw_score": 3.2},
+    {"image_id": 1, "model_name": "spaq", "normalized": 0.52, "raw_score": 52.0},
+    {"image_id": 1, "model_name": "ava", "normalized": 0.43, "raw_score": 4.9},
+    {"image_id": 1, "model_name": "topiq", "normalized": 0.54, "raw_score": 0.54},
+    {"image_id": 1, "model_name": "arniqa", "normalized": 0.63, "raw_score": 0.63},
+]
+
+
+def test_dry_run_computes_but_writes_nothing(monkeypatch):
+    fake, flips = _patch(
+        monkeypatch,
+        candidate_rows=[{"id": 1, "score_general": None, "scoring_status": "not_started"}],
+        model_rows=_MODEL_ROWS,
+    )
+    summary = psf.finalize_phantom_scores(scope_path="/mnt/d/x", dry_run=True)
+
+    assert summary["candidates"] == 1
+    assert summary["composites_backfilled"] == 1
+    assert summary["phase_finalized"] == 1
+    assert fake.executed == []      # no UPDATE in dry-run
+    assert flips == []              # no phase flip in dry-run
+    assert summary["samples"][0]["score_general"] is not None
+
+
+def test_apply_backfills_composite_and_flips_phase(monkeypatch):
+    fake, flips = _patch(
+        monkeypatch,
+        candidate_rows=[{"id": 1, "score_general": None, "scoring_status": "not_started"}],
+        model_rows=_MODEL_ROWS,
+    )
+    summary = psf.finalize_phantom_scores(scope_path="/mnt/d/x", dry_run=False)
+
+    assert summary["composites_backfilled"] == 1
+    assert summary["phase_finalized"] == 1
+    # One UPDATE images ... SET score_general=... and a phase flip to done.
+    assert len(fake.executed) == 1
+    update_sql, update_params = fake.executed[0]
+    assert "UPDATE images" in update_sql and "score_general" in update_sql
+    assert update_params[-1] == 1  # WHERE id = 1
+    assert flips == [(1, "scoring", "done")]
+
+
+def test_phase_flip_without_backfill_when_general_present(monkeypatch):
+    """An image already carrying score_general (only the phase row is stale) is flipped,
+    not re-backfilled."""
+    fake, flips = _patch(
+        monkeypatch,
+        candidate_rows=[{"id": 1, "score_general": 0.71, "scoring_status": "not_started"}],
+        model_rows=_MODEL_ROWS,
+    )
+    summary = psf.finalize_phantom_scores(scope_path="/mnt/d/x", dry_run=False)
+
+    assert summary["composites_backfilled"] == 0
+    assert summary["phase_finalized"] == 1
+    assert fake.executed == []                      # no composite UPDATE
+    assert flips == [(1, "scoring", "done")]
+
+
+def test_no_candidates_is_noop(monkeypatch):
+    fake, flips = _patch(monkeypatch, candidate_rows=[], model_rows=[])
+    summary = psf.finalize_phantom_scores(scope_path="/mnt/d/x", dry_run=False)
+
+    assert summary["candidates"] == 0
+    assert summary["phase_finalized"] == 0
+    assert fake.executed == []
+    assert flips == []
+
+
+def test_candidate_without_model_rows_is_skipped(monkeypatch):
+    fake, flips = _patch(
+        monkeypatch,
+        candidate_rows=[{"id": 9, "score_general": None, "scoring_status": "failed"}],
+        model_rows=[],  # no model scores for image 9
+    )
+    summary = psf.finalize_phantom_scores(scope_path="/mnt/d/x", dry_run=False)
+
+    assert summary["no_model_scores"] == 1
+    assert summary["phase_finalized"] == 0
+    assert fake.executed == []
+    assert flips == []


### PR DESCRIPTION
## What

Adds a reconcile path for **phantom-scored** images: per-model rows exist in `image_model_scores` (ML inference succeeded) but `images.score_general` was never written and the `scoring` phase row never went terminal — because the job was interrupted between `ScoringWorker` (persists model rows) and `ResultWorker` (writes composite + flips phase to `done`).

This wedges folders: `is_image_scoring_complete()` returns True (model rows present) so the JIT planner skips scoring, while the bucketer sees `phase=not_started` and re-enqueues the folder forever in auto-drive. The existing `reconcile_phantom_complete_image_phases()` only flips the phase row — it never backfills the composite, so the image still reads NULL `score_general`.

## How

`finalize_phantom_scores()` recomputes `score_general`/`score_technical`/`score_aesthetic`/`rating`/`label` **from the already-stored per-model rows** via `score_normalization.compute_all()` (no re-inference; only when `score_general` is NULL), then flips the `scoring` phase to `done`. It is the missing companion to `reconcile_phantom_complete_image_phases`.

- `modules/phantom_score_finalize.py`
- `scripts/maintenance/finalize_phantom_scores.py` — CLI, dry-run by default (`--scope`/`--all`/`--image-ids`, `--apply` to write)
- `tests/test_phantom_score_finalize.py` — DB-free unit tests (dry-run writes nothing, apply backfills + flips, phase-only flip when composite present, no-candidate noop, skip when no model rows)

## Validation

Applied to the live wedged folder `2026-05-24` (258 images):

```
candidates:            258
composites backfilled: 258
phase finalized:       258
```

Post-apply DB check on that folder: `null_general=0`, `phase_done=258`, `phase_not_done=0`. Composites sane (0.77–0.90).

## Notes

Idempotent recovery for already-stranded images. Hardening the worker handoff so the composite write + phase flip are atomic (closing the interruption window at the source) is tracked as follow-up in #245.

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)
