### PR TITLE
fix(security): block pg_read_file/dblink in read validator; validate /transaction statements; fix bare-semicolon bypass

### DIFF
--- a/modules/api_db.py
+++ b/modules/api_db.py
@@ -153,6 +153,9 @@ def raw_transaction(
             params = stmt.get("params") or []
             if not sql:
                 continue
+            err = db.validate_write_sql_for_api(sql)
+            if err:
+                raise ValueError(f"Statement rejected: {err}")
             if stmt.get("returning"):
                 tx.execute_returning(sql, params)
             else:

--- a/modules/db_legacy.py
+++ b/modules/db_legacy.py
@@ -463,6 +463,15 @@ def validate_readonly_sql_for_api(query: str) -> str | None:
         r"\bCOPY\b",    # PostgreSQL COPY (can write to file)
         r"\bLOAD\b",    # MySQL LOAD (can read files)
         r"\bINTO\s+OUTFILE\b",  # MySQL INTO OUTFILE
+        # PostgreSQL server-side file/exec functions (file exfiltration via CTEs)
+        r"\bPG_READ_FILE\b",
+        r"\bPG_READ_BINARY_FILE\b",
+        r"\bPG_LS_DIR\b",
+        r"\bPG_STAT_FILE\b",
+        r"\bLO_EXPORT\b",
+        r"\bLO_IMPORT\b",
+        r"\bDBLINK\b",
+        r"\bPG_EXECUTE_SERVER_PROGRAM\b",
     ]
     for pattern in dangerous_patterns:
         if re.search(pattern, upper):
@@ -528,6 +537,7 @@ def execute_readonly_sql_for_api(
 
         pg_sql = _translate_fb_to_pg(sql)
         with db_postgres.PGConnectionManager() as conn:
+            conn.set_session(readonly=True)
             with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
                 cur.execute(pg_sql, tuple(params) if params else None)
                 rows = cur.fetchmany(max_rows)
@@ -573,7 +583,9 @@ def validate_write_sql_for_api(query: str) -> str | None:
         r"\bTRUNCATE\b",
         r"\bGRANT\b",
         r"\bREVOKE\b",
-        r";--",
+        r";",    # multi-statement separator
+        r"--",   # line comment
+        r"/\*",  # block comment start
     ]
     for pattern in dangerous_patterns:
         if re.search(pattern, upper):

--- a/tests/test_sql_validators.py
+++ b/tests/test_sql_validators.py
@@ -1,0 +1,146 @@
+"""Tests for validate_readonly_sql_for_api and validate_write_sql_for_api (issues #209, #210, #211)."""
+import pytest
+from modules.db import validate_readonly_sql_for_api, validate_write_sql_for_api
+
+
+class TestReadonlyValidator:
+    """validate_readonly_sql_for_api — issue #209 and #216."""
+
+    def test_plain_select_allowed(self):
+        assert validate_readonly_sql_for_api("SELECT id FROM images") is None
+
+    def test_cte_select_allowed(self):
+        assert validate_readonly_sql_for_api("WITH t AS (SELECT 1) SELECT * FROM t") is None
+
+    def test_empty_blocked(self):
+        assert validate_readonly_sql_for_api("") is not None
+        assert validate_readonly_sql_for_api("   ") is not None
+
+    def test_non_select_blocked(self):
+        assert validate_readonly_sql_for_api("UPDATE images SET score=0") is not None
+        assert validate_readonly_sql_for_api("INSERT INTO images VALUES (1)") is not None
+
+    def test_semicolon_blocked(self):
+        assert validate_readonly_sql_for_api("SELECT 1; DROP TABLE images") is not None
+
+    def test_comment_blocked(self):
+        assert validate_readonly_sql_for_api("SELECT 1 -- comment") is not None
+        assert validate_readonly_sql_for_api("SELECT /* comment */ 1") is not None
+
+    # issue #209: file-exfiltration functions must be blocked
+    @pytest.mark.parametrize("fn", [
+        "pg_read_file",
+        "pg_read_binary_file",
+        "pg_ls_dir",
+        "pg_stat_file",
+        "lo_export",
+        "lo_import",
+        "dblink",
+        "pg_execute_server_program",
+    ])
+    def test_pg_file_functions_blocked(self, fn):
+        assert validate_readonly_sql_for_api(f"SELECT {fn}('/etc/passwd')") is not None
+
+    def test_pg_read_file_via_cte_blocked(self):
+        # The CTE wrapper must not bypass the deny-list
+        sql = "WITH s AS (SELECT pg_read_file('/etc/passwd')) SELECT * FROM s"
+        assert validate_readonly_sql_for_api(sql) is not None
+
+    def test_dblink_via_cte_blocked(self):
+        sql = "WITH d AS (SELECT dblink('host=evil','SELECT 1')) SELECT * FROM d"
+        assert validate_readonly_sql_for_api(sql) is not None
+
+    def test_pg_file_case_insensitive(self):
+        assert validate_readonly_sql_for_api("SELECT PG_READ_FILE('/tmp/x')") is not None
+        assert validate_readonly_sql_for_api("SELECT Pg_Read_File('/tmp/x')") is not None
+
+
+class TestWriteValidator:
+    """validate_write_sql_for_api — issue #211."""
+
+    def test_insert_allowed(self):
+        assert validate_write_sql_for_api("INSERT INTO images (file_path) VALUES ('/a')") is None
+
+    def test_update_allowed(self):
+        assert validate_write_sql_for_api("UPDATE images SET rating=3 WHERE id=1") is None
+
+    def test_delete_allowed(self):
+        assert validate_write_sql_for_api("DELETE FROM images WHERE id=1") is None
+
+    def test_empty_blocked(self):
+        assert validate_write_sql_for_api("") is not None
+
+    def test_select_blocked(self):
+        assert validate_write_sql_for_api("SELECT 1") is not None
+
+    def test_ddl_blocked(self):
+        assert validate_write_sql_for_api("DROP TABLE images") is not None
+        assert validate_write_sql_for_api("ALTER TABLE images ADD COLUMN x INT") is not None
+        assert validate_write_sql_for_api("CREATE TABLE evil (id INT)") is not None
+        assert validate_write_sql_for_api("TRUNCATE images") is not None
+
+    # issue #211: bare ";" must be blocked (previously only ";--" was blocked)
+    def test_multi_statement_blocked(self):
+        assert validate_write_sql_for_api("UPDATE images SET score=0; DROP TABLE stacks") is not None
+
+    def test_bare_semicolon_blocked(self):
+        assert validate_write_sql_for_api("UPDATE images SET score=0;") is not None
+
+    def test_line_comment_blocked(self):
+        assert validate_write_sql_for_api("UPDATE images SET score=0 -- comment") is not None
+
+    def test_block_comment_blocked(self):
+        assert validate_write_sql_for_api("UPDATE images SET score=0 /* comment */") is not None
+
+
+class TestTransactionEndpoint:
+    """POST /api/db/transaction must validate each statement — issue #210."""
+
+    def _client(self):
+        fastapi = pytest.importorskip("fastapi")
+        pytest.importorskip("fastapi.testclient")
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        from modules import api_db
+
+        app = FastAPI()
+        app.include_router(api_db.router)
+        return TestClient(app)
+
+    def _cfg_patch(self):
+        from unittest.mock import patch
+
+        return patch(
+            "modules.api_db._cfg" if False else "modules.config.get_config_section",
+            return_value={"query_token": "test-token"},
+        )
+
+    def test_ddl_statement_rejected(self):
+        from unittest.mock import patch
+
+        client = self._client()
+        with patch("modules.config.get_config_section", return_value={"query_token": "tok"}):
+            resp = client.post(
+                "/api/db/transaction",
+                headers={"X-DB-Write-Token": "tok"},
+                json={"statements": [{"sql": "DROP TABLE images", "params": []}]},
+            )
+        # Should be rejected before hitting the DB
+        assert resp.status_code in (400, 500)
+
+    def test_valid_statements_pass_validation(self):
+        from unittest.mock import patch, MagicMock
+
+        client = self._client()
+        mock_connector = MagicMock()
+        mock_connector.run_transaction.side_effect = lambda fn: fn(MagicMock())
+
+        with patch("modules.config.get_config_section", return_value={"query_token": "tok"}):
+            with patch("modules.api_db.db.validate_write_sql_for_api", return_value=None) as mock_val:
+                with patch("modules.db_connector.get_connector", return_value=mock_connector):
+                    resp = client.post(
+                        "/api/db/transaction",
+                        headers={"X-DB-Write-Token": "tok"},
+                        json={"statements": [{"sql": "UPDATE images SET rating=3 WHERE id=1", "params": []}]},
+                    )
+        mock_val.assert_called()


### PR DESCRIPTION
Closes #209
Closes #210
Closes #211

- validate_readonly_sql_for_api: add pg_read_file, pg_read_binary_file,
  pg_ls_dir, pg_stat_file, lo_export, lo_import, dblink, and
  pg_execute_server_program to the deny-list so CTE-wrapped file-exfil
  calls are rejected at the validator layer.
- execute_readonly_sql_for_api (Postgres path): enforce read-only at
  the transport level via conn.set_session(readonly=True) so the DB
  connection itself cannot mutate state even if the deny-list is bypassed.
- validate_write_sql_for_api: replace ";--" with bare ";", "--", and "/*"
  so multi-statement injection (UPDATE …; DROP TABLE …) is blocked, matching
  the read validator's behaviour.
- POST /api/db/transaction: call validate_write_sql_for_api for each
  statement before dispatching so DDL (DROP TABLE, TRUNCATE, ALTER…) cannot
  reach the DB via the transaction endpoint even with a valid write token.
- Add tests/test_sql_validators.py: 29 unit tests covering all three issues.

https://claude.ai/code/session_01MtkL4tHhPUoaXFFEtJ6tXQ