### PR TITLE
Add strict arg parsing, PHASE validation, and overridable DB/venv envs to run_input_size_study.sh

### DIFF
--- a/scripts/research/clip_culling/run_input_size_study.sh
+++ b/scripts/research/clip_culling/run_input_size_study.sh
@@ -10,11 +10,37 @@
 # Include MobileNet: MODELS=mobilenet,openclip,... bash ...
 # Phase control: PHASE=1|2|3|all (default all)
 set -euo pipefail
+
+usage() {
+  echo "Usage: $0 [PHASE=1|2|3|all|eval] [MODELS=a,b] [EDGES=128,224,...]" >&2
+  echo "          [POSTGRES_HOST=host] [POSTGRES_PORT=port] [POSTGRES_DB=name]" >&2
+}
+
+# Accept a small allowlist of KEY=VALUE arguments so detached invocations like
+# `setsid bash run_input_size_study.sh PHASE=1` behave as documented without
+# accepting arbitrary environment mutations.
+for arg in "$@"; do
+  key="${arg%%=*}"
+  value="${arg#*=}"
+  if [[ "$key" == "$arg" ]]; then
+    echo "Unknown argument: $arg" >&2
+    usage
+    exit 2
+  fi
+  case "$key" in
+    PHASE|MODELS|EDGES|POSTGRES_HOST|POSTGRES_PORT|POSTGRES_DB)
+      export "$key=$value"
+      ;;
+    *)
+      echo "Unknown override: $key" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
 ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 cd "$ROOT"
-source "${HOME}/.venvs/tf/bin/activate"
-export POSTGRES_HOST=127.0.0.1 POSTGRES_PORT=5433 POSTGRES_DB=image_scoring_test
-export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}:${ROOT}/FirebirdLinux/Firebird-5.0.0.1306-0-linux-x64/opt/firebird/lib"
 
 LOG_DIR="$ROOT/reports/clip-culling/input-size"
 mkdir -p "$LOG_DIR/npz"
@@ -24,6 +50,16 @@ MAIN_LOG="$LOG_DIR/study.log"
 MODELS="${MODELS:-clip_b32,openai,openclip,dinov2,siglip2}"
 EDGES="${EDGES:-128,224,384,512,768}"
 PHASE="${PHASE:-all}"
+case "$PHASE" in
+  1|2|3|all|eval) ;;
+  *) echo "Unknown PHASE=$PHASE (use 1|2|3|all|eval)" >&2; exit 2 ;;
+esac
+
+source "${HOME}/.venvs/tf/bin/activate"
+export POSTGRES_HOST="${POSTGRES_HOST:-127.0.0.1}"
+export POSTGRES_PORT="${POSTGRES_PORT:-5433}"
+export POSTGRES_DB="${POSTGRES_DB:-image_scoring_test}"
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}:${ROOT}/FirebirdLinux/Firebird-5.0.0.1306-0-linux-x64/opt/firebird/lib"
 
 log() { echo "[$(date -Iseconds)] $*" | tee -a "$MAIN_LOG"; }
 

--- a/scripts/research/clip_culling/run_input_size_study.sh
+++ b/scripts/research/clip_culling/run_input_size_study.sh
@@ -8,18 +8,26 @@
 #
 # Override models: MODELS=openclip,openai,dinov2,siglip2,clip_b32 bash ...
 # Include MobileNet: MODELS=mobilenet,openclip,... bash ...
-# Phase control: PHASE=1|2|3|all (default all)
+# Override venv: VENV_PATH=/path/to/venv bash ...
+# Phase control: PHASE=1|2|3|all|eval (default all)
 set -euo pipefail
 
 usage() {
-  echo "Usage: $0 [PHASE=1|2|3|all|eval] [MODELS=a,b] [EDGES=128,224,...]" >&2
-  echo "          [POSTGRES_HOST=host] [POSTGRES_PORT=port] [POSTGRES_DB=name]" >&2
+  cat >&2 <<EOF
+Usage: $0 [PHASE=1|2|3|all|eval] [MODELS=a,b] [EDGES=128,224,...]
+          [POSTGRES_HOST=host] [POSTGRES_PORT=port] [POSTGRES_DB=name]
+          [VENV_PATH=/path/to/venv]
+EOF
 }
 
 # Accept a small allowlist of KEY=VALUE arguments so detached invocations like
 # `setsid bash run_input_size_study.sh PHASE=1` behave as documented without
 # accepting arbitrary environment mutations.
 for arg in "$@"; do
+  if [[ "$arg" == "-h" || "$arg" == "--help" ]]; then
+    usage
+    exit 0
+  fi
   key="${arg%%=*}"
   value="${arg#*=}"
   if [[ "$key" == "$arg" ]]; then
@@ -28,7 +36,7 @@ for arg in "$@"; do
     exit 2
   fi
   case "$key" in
-    PHASE|MODELS|EDGES|POSTGRES_HOST|POSTGRES_PORT|POSTGRES_DB)
+    PHASE|MODELS|EDGES|POSTGRES_HOST|POSTGRES_PORT|POSTGRES_DB|VENV_PATH)
       export "$key=$value"
       ;;
     *)
@@ -55,11 +63,22 @@ case "$PHASE" in
   *) echo "Unknown PHASE=$PHASE (use 1|2|3|all|eval)" >&2; exit 2 ;;
 esac
 
-source "${HOME}/.venvs/tf/bin/activate"
+VENV_PATH="${VENV_PATH:-${HOME}/.venvs/tf}"
+if [[ ! -f "${VENV_PATH}/bin/activate" ]]; then
+  echo "Virtualenv not found: ${VENV_PATH}/bin/activate" >&2
+  echo "Set VENV_PATH=/path/to/venv or create ${HOME}/.venvs/tf." >&2
+  exit 2
+fi
+source "${VENV_PATH}/bin/activate"
 export POSTGRES_HOST="${POSTGRES_HOST:-127.0.0.1}"
 export POSTGRES_PORT="${POSTGRES_PORT:-5433}"
 export POSTGRES_DB="${POSTGRES_DB:-image_scoring_test}"
-export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}:${ROOT}/FirebirdLinux/Firebird-5.0.0.1306-0-linux-x64/opt/firebird/lib"
+FIREBIRD_LIB="${ROOT}/FirebirdLinux/Firebird-5.0.0.1306-0-linux-x64/opt/firebird/lib"
+if [[ -n "${LD_LIBRARY_PATH:-}" ]]; then
+  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${FIREBIRD_LIB}"
+else
+  export LD_LIBRARY_PATH="${FIREBIRD_LIB}"
+fi
 
 log() { echo "[$(date -Iseconds)] $*" | tee -a "$MAIN_LOG"; }
 


### PR DESCRIPTION
### Motivation
- Make the pipeline script tolerant of detached launches while avoiding accidental arbitrary environment mutations by accepting only a small allowlist of `KEY=VALUE` overrides.
- Allow runtime configuration of Postgres connection and virtualenv activation without hard-coded exports so the script can run in different environments.
- Validate the `PHASE` argument early to fail fast on invalid invocations.

### Description
- Added a `usage()` helper and an allowlist-based argument parser that accepts `PHASE`, `MODELS`, `EDGES`, `POSTGRES_HOST`, `POSTGRES_PORT`, and `POSTGRES_DB` only, and exits with an error for unknown overrides.
- Reordered and moved `source "${HOME}/.venvs/tf/bin/activate"` and the `POSTGRES_*`/`LD_LIBRARY_PATH` exports to after parsing so they respect provided overrides and use defaults when unset.
- Introduced validation for `PHASE` to accept only `1`, `2`, `3`, `all`, or `eval` and emit a clear error for invalid values.
- Kept existing defaults for `MODELS` and `EDGES` and preserved current logging and embedding loop behavior.

### Testing
- Ran a shell syntax check using `bash -n scripts/research/clip_culling/run_input_size_study.sh`, which succeeded.
- No other automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dad84878c832397bf1b78e0491fdc)