### PR TITLE
fix(input-size): harden study runner configuration

### DIFF
--- a/scripts/research/clip_culling/run_input_size_study.sh
+++ b/scripts/research/clip_culling/run_input_size_study.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Pipeline input-size study — resumable end-to-end (E2E DB @5433).
+# Pipeline input-size study - resumable end-to-end (E2E DB @5433).
 # Skips existing NPZ files. MobileNet omitted by default (TF GPU contention).
 #
 # Recommended detached launch (WSL):

--- a/scripts/research/clip_culling/run_input_size_study.sh
+++ b/scripts/research/clip_culling/run_input_size_study.sh
@@ -8,13 +8,47 @@
 #
 # Override models: MODELS=openclip,openai,dinov2,siglip2,clip_b32 bash ...
 # Include MobileNet: MODELS=mobilenet,openclip,... bash ...
-# Phase control: PHASE=1|2|3|all (default all)
+# Override venv: VENV_PATH=/path/to/venv bash ...
+# Phase control: PHASE=1|2|3|all|eval (default all)
 set -euo pipefail
+
+usage() {
+  cat >&2 <<EOF
+Usage: $0 [PHASE=1|2|3|all|eval] [MODELS=a,b] [EDGES=128,224,...]
+          [POSTGRES_HOST=host] [POSTGRES_PORT=port] [POSTGRES_DB=name]
+          [VENV_PATH=/path/to/venv]
+EOF
+}
+
+# Accept a small allowlist of KEY=VALUE arguments so detached invocations like
+# `setsid bash run_input_size_study.sh PHASE=1` behave as documented without
+# accepting arbitrary environment mutations.
+for arg in "$@"; do
+  if [[ "$arg" == "-h" || "$arg" == "--help" ]]; then
+    usage
+    exit 0
+  fi
+  key="${arg%%=*}"
+  value="${arg#*=}"
+  if [[ "$key" == "$arg" ]]; then
+    echo "Unknown argument: $arg" >&2
+    usage
+    exit 2
+  fi
+  case "$key" in
+    PHASE|MODELS|EDGES|POSTGRES_HOST|POSTGRES_PORT|POSTGRES_DB|VENV_PATH)
+      export "$key=$value"
+      ;;
+    *)
+      echo "Unknown override: $key" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
 ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 cd "$ROOT"
-source "${HOME}/.venvs/tf/bin/activate"
-export POSTGRES_HOST=127.0.0.1 POSTGRES_PORT=5433 POSTGRES_DB=image_scoring_test
-export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}:${ROOT}/FirebirdLinux/Firebird-5.0.0.1306-0-linux-x64/opt/firebird/lib"
 
 LOG_DIR="$ROOT/reports/clip-culling/input-size"
 mkdir -p "$LOG_DIR/npz"
@@ -24,6 +58,27 @@ MAIN_LOG="$LOG_DIR/study.log"
 MODELS="${MODELS:-clip_b32,openai,openclip,dinov2,siglip2}"
 EDGES="${EDGES:-128,224,384,512,768}"
 PHASE="${PHASE:-all}"
+case "$PHASE" in
+  1|2|3|all|eval) ;;
+  *) echo "Unknown PHASE=$PHASE (use 1|2|3|all|eval)" >&2; exit 2 ;;
+esac
+
+VENV_PATH="${VENV_PATH:-${HOME}/.venvs/tf}"
+if [[ ! -f "${VENV_PATH}/bin/activate" ]]; then
+  echo "Virtualenv not found: ${VENV_PATH}/bin/activate" >&2
+  echo "Set VENV_PATH=/path/to/venv or create ${HOME}/.venvs/tf." >&2
+  exit 2
+fi
+source "${VENV_PATH}/bin/activate"
+export POSTGRES_HOST="${POSTGRES_HOST:-127.0.0.1}"
+export POSTGRES_PORT="${POSTGRES_PORT:-5433}"
+export POSTGRES_DB="${POSTGRES_DB:-image_scoring_test}"
+FIREBIRD_LIB="${ROOT}/FirebirdLinux/Firebird-5.0.0.1306-0-linux-x64/opt/firebird/lib"
+if [[ -n "${LD_LIBRARY_PATH:-}" ]]; then
+  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${FIREBIRD_LIB}"
+else
+  export LD_LIBRARY_PATH="${FIREBIRD_LIB}"
+fi
 
 log() { echo "[$(date -Iseconds)] $*" | tee -a "$MAIN_LOG"; }
 


### PR DESCRIPTION
### Motivation
- Make the documented virtualenv override explicit and validated so detached `KEY=VALUE` launches behave predictably.
- Preserve the safe allowlist of positional `KEY=VALUE` overrides to avoid accidental arbitrary environment mutation.
- Avoid introducing an empty leading `LD_LIBRARY_PATH` segment and ensure Firebird lib path is appended cleanly.

### Description
- Added `VENV_PATH` to the script header, usage output, and the allowlist so callers can override the virtualenv via `VENV_PATH=/path/to/venv` and the script now supports `--help`/`-h` for discoverability.
- Introduced an explicit existence check for `${VENV_PATH}/bin/activate` (defaulting to `${HOME}/.venvs/tf`) and fail-fast with a clear message if the venv is missing before sourcing.
- Kept strict argument parsing and early `PHASE` validation (now accepting `1|2|3|all|eval`) to fail fast on malformed or unknown overrides.
- Changed `LD_LIBRARY_PATH` handling to append the Firebird library path only when `LD_LIBRARY_PATH` is already set, otherwise set it cleanly to the Firebird path.

### Testing
- Ran shell syntax check with `bash -n scripts/research/clip_culling/run_input_size_study.sh`, which succeeded.
- Ran `git diff --check`, which succeeded with no whitespace errors.
- Verified help output with `bash scripts/research/clip_culling/run_input_size_study.sh --help`, which printed usage and exited `0`.
- Exercised error cases `bash .../run_input_size_study.sh BAD=1` and `bash .../run_input_size_study.sh VENV_PATH=/tmp/nope PHASE=eval`, both of which failed as expected with clear error messages.
- Performed an end-to-end dry run using a temporary fake venv and stub `python` with `VENV_PATH="$tmp/venv" ... PHASE=eval POSTGRES_HOST=dbhost POSTGRES_PORT=6543 POSTGRES_DB=customdb`, which completed successfully (status `0`).

Closes #277