### PR TITLE
feat(culling): CLIP B/32 prompt-quality pick/reject signal (clip_quality_v0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **CLIP B/32 prompt-quality pick/reject signal (auxiliary, default-off)**: `clip_quality_v0` — a 0–1 "good photo" probability derived from the persisted `clip_vit_b32_image` (512-d) embedding compared against antonym text prompts (CLIP-IQA style). New `modules/clip_quality.py` persists to `image_model_scores` (surfaces in the API as `clip_quality_v0_score`); culling blends it into the within-stack ranking behind `culling.clip_quality.*` (weight 0.15 default, optional `reject_below` floor) without touching `score_general`. B/32 is JIT-generated pre-culling and reused by the keywords phase (`embeddings.reuse_clip_image_for_keywords`). Backfill: `scripts/backfill_clip_quality.py`. Benchmark (`reports/clip-culling/prompt-quality/`): global pick/reject AUC 0.89, within-stack concordance 0.986.
+
 ### Roadmap (not yet released)
 
 Phase 4c keyword legacy column soft deprecation (target a future release; see `docs/planning/database/PHASE4_KEYWORDS_DEPRECATION.md`):

--- a/config.example.json
+++ b/config.example.json
@@ -101,6 +101,11 @@
       "min_stack_size_for_substack": 3,
       "skip_single_leaf_persist": true
     },
+    "clip_quality": {
+      "enabled": false,
+      "weight": 0.15,
+      "reject_below": null
+    },
     "agent_review": {
       "enabled": false,
       "dry_run_default": true,
@@ -198,6 +203,7 @@
     "persist_clip_image": true,
     "persist_blip_image": true,
     "persist_bioclip_image": true,
+    "reuse_clip_image_for_keywords": true,
     "culling_spaces": ["openclip_l14_laion2b_image"],
     "model_versions": {
       "clip_vit_b32_image": "openai/clip-vit-base-patch32",

--- a/docs/technical/API_CONTRACT.md
+++ b/docs/technical/API_CONTRACT.md
@@ -219,6 +219,13 @@ Both fields are omitted when the image has no `image_model_scores` rows (e.g.
 Firebird, or before the model has run). Backed by
 `db.get_image_model_scores` / `db.get_batch_image_model_scores`.
 
+> **Auxiliary `clip_quality_v0`.** The CLIP B/32 prompt-quality signal
+> (`modules/clip_quality.py`) is stored in `image_model_scores` like any other
+> model, so it auto-surfaces as `model_scores.clip_quality_v0` and the flat
+> `clip_quality_v0_score` (0–1) with **no endpoint change**. It is an auxiliary
+> culling tie-breaker, not a primary IQA score — see
+> [CULLING_ANALYTICS.md](CULLING_ANALYTICS.md#clip-prompt-quality-signal).
+
 ### Image identity: `image_hash`, `hash_version`, and `image_uuid` (developer reference)
 
 These fields serve different purposes. Do not substitute one for another when integrating.

--- a/docs/technical/CONFIG.md
+++ b/docs/technical/CONFIG.md
@@ -110,6 +110,9 @@ Session-based culling UI and selection pipeline. Duplicates **`default_threshold
 | `enabled` | `GET /api/config` → `enable_culling` (React feature flag) |
 | `sub_cluster_distance_threshold` | Legacy path in `selection.py` when `two_level.enabled=false` (default **0.05** in `config.example.json`); in-memory sub-clusters then 33/33 bands per sub-group |
 | `two_level` | `selection.py` when `enabled=true` — best-M/N-cap for multi-image root stacks; **implicit JIT** level-2 embed for stacked images via `modules/culling_embeddings.py` when `level2.embedding_space` is a culling tower; unstacked bucket and singletons still use legacy 33/33 / neutral. See [two-level-culling.md](../features/planned/embeddings/two-level-culling.md) |
+| `clip_quality.enabled` | `selection.py` — **default false**. When true, the CLIP B/32 prompt-quality score (`clip_quality_v0`) is JIT-computed for stacked images (`modules/clip_quality.py`) and blended into the within-stack ranking. See [CULLING_ANALYTICS.md](CULLING_ANALYTICS.md#clip-prompt-quality-signal). |
+| `clip_quality.weight` | Blend weight (default **0.15**, clamped 0–1): `(1-w)·score_general + w·clip_quality_v0` for within-stack ranking. |
+| `clip_quality.reject_below` | Optional float (default `null` = off). Frames with `clip_quality_v0` below this are downgraded to `reject` — conservative (never strips a stack's last pick). |
 | `analytics.*` | `culling_analytics/composite.py` |
 
 ### `tagging`
@@ -134,7 +137,7 @@ Gallery page size, export format, `last_selected_folder` (runtime).
 
 ### `embeddings`
 
-Persistence flags, `culling_spaces` for bulk backfill CLI defaults, `model_versions` map. JIT level-2 generation during culling reads `culling.two_level.level2.embedding_space` directly (not `culling_spaces`).
+Persistence flags, `culling_spaces` for bulk backfill CLI defaults, `model_versions` map. JIT level-2 generation during culling reads `culling.two_level.level2.embedding_space` directly (not `culling_spaces`). **`reuse_clip_image_for_keywords`** (default true): when the culling phase already persisted a `clip_vit_b32_image` vector (e.g. via `culling.clip_quality`), the keywords phase (`tagging.py`) reuses it instead of re-running the CLIP image forward pass.
 
 ### `embedding_map`
 

--- a/docs/technical/CULLING_ANALYTICS.md
+++ b/docs/technical/CULLING_ANALYTICS.md
@@ -22,6 +22,7 @@ Library/folder analytics expose **two flag layers**:
 | `flags.by_cull_decision` | Raw `cull_decision` histogram | Always (includes `unset`) |
 | `flags.auto_cull_stacks` | `cull_decision` per `stack_id` | Stack pick pattern + N=20 cap violations |
 | `flags.auto_cull_substacks` | `sub_stacks` + `cull_decision` | Singleton-leaf %, M=3 violations, giant leaves |
+| `hierarchy` | `stacks` + `sub_stacks` + `images` | Degenerate vs populated tiers, per-level decision averages, RCA samples |
 
 **Note:** `SelectionService` writes `cull_decision` on every auto-cull run and (since 2026-06)
 also syncs `pick_status` via `batch_update_cull_decisions`. Libraries upgraded before that
@@ -82,6 +83,48 @@ Query params (library): `per_stack_limit`, `per_stack_offset` for paginated `sco
 - Empty folder: zero counts, no error.
 - Missing embeddings: `embeddings.coverage_pct` only; stack similarity omitted.
 - `pick_status` vs `cull_decision` mismatch: listed in `warnings`.
+- Degenerate hierarchy: `warnings` may include `singleton_root_stacks`, `single_leaf_stacks`.
 - Stale `stack_cache`: per-stack score summary reads cache; use live `images` for flags.
 
+## Hierarchy tiers (`hierarchy`)
+
+| Tier | Condition | Degenerate? |
+|------|-----------|-------------|
+| `singleton_root` | Root stack `n = 1` | Yes — dissolve via `normalize_stack_hierarchy` |
+| `single_leaf` | `n >= 2`, exactly one sub-stack covering all members | Yes — collapse sub-stack layer |
+| `flat` | Multi-image stack, no `sub_stack_id` assignments | No |
+| `populated_multi_leaf` | Two or more sub-stacks | No |
+| Singleton leaves inside multi-leaf stacks | `image_count = 1` per sub-stack | Expected (~35% at threshold 0.06) |
+
+**Tools:**
+
+- Read-only audit: `python -m scripts.analyze_stack_hierarchy --json`
+- SQL: [`06_stack_hierarchy_audit.sql`](../../scripts/sql/culling_analytics_diagnostics/06_stack_hierarchy_audit.sql)
+- Maintenance: `python -m scripts.maintenance.normalize_degenerate_stacks` (dry-run default)
+
+Per-stack drill-down (`GET /api/analytics/stacks/{id}`) adds `hierarchy_tier`, `decisions`,
+`substacks`, `rca_hints`, and `embedding_coverage_pct`.
+
 See diagnostic SQL files for copy-paste exploration queries.
+
+## CLIP prompt-quality signal
+
+`clip_quality_v0` is an **auxiliary** pick/reject signal (not a primary IQA model):
+a 0–1 "good photo" probability from the persisted `clip_vit_b32_image` (512-d)
+embedding compared against antonym text prompts (CLIP-IQA style). Benchmark:
+[`reports/clip-culling/prompt-quality/`](../../reports/clip-culling/prompt-quality/)
+— B/32 beat OpenCLIP/OpenAI-L14/BioCLIP, global pick/reject **AUC 0.89**, within-stack
+keeper-vs-reject **concordance 0.986**.
+
+- **Compute/storage:** [`modules/clip_quality.py`](../../modules/clip_quality.py) →
+  `image_model_scores` (`model_name = clip_quality_v0`); surfaces in the API as
+  `clip_quality_v0_score`. Backfill: `python -m scripts.backfill_clip_quality`.
+- **Phase-order note:** `clip_vit_b32_image` is normally produced in the *keywords*
+  phase (after culling). When `culling.clip_quality.enabled`, culling JIT-generates it
+  for stacked images via `ensure_embeddings_for_space` (same pattern as two-level
+  level-2); the keywords phase then **reuses** that vector
+  (`embeddings.reuse_clip_image_for_keywords`, default true) instead of re-encoding.
+- **Use in culling:** blended into the within-stack `sort_key` at
+  `culling.clip_quality.weight` (default 0.15), with an optional conservative
+  `reject_below` floor. Default-off; `score_general` is left untouched. Config keys:
+  [CONFIG.md](CONFIG.md#culling).

--- a/modules/clip_quality.py
+++ b/modules/clip_quality.py
@@ -1,0 +1,212 @@
+"""CLIP ViT-B/32 prompt-quality (``clip_quality_v0``) — auxiliary pick/reject signal.
+
+Computes a 0–1 "good photo" score from the persisted ``clip_vit_b32_image`` (512-d)
+embeddings and antonym text prompts (CLIP-IQA antonym softmax). This is an *auxiliary*
+signal used as a low-weight within-stack tie-breaker in culling
+(:mod:`modules.selection`) — never the primary quality model.
+
+Benchmark and rationale: ``reports/clip-culling/prompt-quality/`` (B/32 wins; global
+pick/reject AUC 0.89, within-stack concordance 0.986).
+
+Tower-match (critical): the B/32 *image* embeddings (``KeywordScorer`` /
+``embedding_extractors`` ``hf_clip`` loader) and the *text* tower
+(:func:`modules.similar_search._get_clip_text_embedding`) use the same HF
+``openai/clip-vit-base-patch32`` weights. Mixing image/text encoders silently
+corrupts cosine similarity.
+
+Postgres-only; a no-op on other engines. Scores persist to ``image_model_scores``
+under ``model_name = "clip_quality_v0"``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+CLIP_QUALITY_MODEL = "clip_quality_v0"
+PROMPT_SET_VERSION = "v0"
+# CLIP temperature for the antonym softmax (cosine margins are ~0.01–0.05, so a raw
+# sigmoid(pos-neg) collapses to ~0.5; the logit scale gives a real 0–1 spread).
+LOGIT_SCALE = 100.0
+
+# Six caption templates; short adjectival phrases are expanded through all of them and
+# averaged. Full captions (containing the verbatim tokens below) are used as-is.
+TEMPLATES = (
+    "a photo that is {phrase}",
+    "a photograph that is {phrase}",
+    "an image that is {phrase}",
+    "a {phrase} photograph",
+    "a {phrase} image",
+    "this is a {phrase} photo",
+)
+_VERBATIM_TOKENS = ("photo", "photograph", "image", "bird", "wildlife", "subject")
+
+# Positive / negative prompt banks for clip_quality_v0 (validated in the benchmark).
+GOOD = [
+    "high quality", "good", "beautiful", "sharp", "clear", "well focused",
+    "properly exposed", "clean", "detailed", "professional", "well composed",
+    "visually pleasing", "good lighting", "natural colors",
+    "a photo with strong subject separation", "crisp details",
+    "a photo with a clear subject", "balanced contrast", "good dynamic range",
+    "a keeper photo",
+]
+BAD = [
+    "low quality", "bad", "poor", "blurry", "out of focus", "misfocused",
+    "overexposed", "underexposed", "noisy", "grainy", "soft", "dull",
+    "washed out", "poorly composed", "a photo with no clear subject",
+    "a missed shot", "a poorly timed photo", "technically flawed",
+    "bad lighting", "a rejected photo",
+]
+
+# Process-cached text matrices: {"good": (P,512), "bad": (M,512)} L2-normalized.
+_text_cache: dict[str, np.ndarray] = {}
+
+
+def _l2_normalize(arr: np.ndarray) -> np.ndarray:
+    arr = np.asarray(arr, dtype=np.float32)
+    n = np.linalg.norm(arr, axis=-1, keepdims=True)
+    n[n == 0] = 1.0
+    return arr / n
+
+
+def _is_verbatim(phrase: str) -> bool:
+    p = phrase.lower()
+    return any(tok in p for tok in _VERBATIM_TOKENS)
+
+
+def _expand(phrase: str) -> list[str]:
+    if _is_verbatim(phrase):
+        return [phrase]
+    return [t.format(phrase=phrase) for t in TEMPLATES]
+
+
+def _encode_bank(phrases: list[str]) -> np.ndarray:
+    """Encode each phrase (template-averaged) -> (n_phrases, 512) L2-normalized."""
+    from modules.similar_search import _get_clip_text_embedding
+
+    vecs = []
+    for phrase in phrases:
+        variants = _expand(phrase)
+        per_variant = np.vstack([_get_clip_text_embedding(v) for v in variants])
+        vecs.append(_l2_normalize(per_variant.mean(axis=0)))
+    return np.vstack(vecs).astype(np.float32)
+
+
+def _prompt_matrices() -> tuple[np.ndarray, np.ndarray]:
+    """Return cached (good, bad) text matrices, encoding them on first use."""
+    if "good" not in _text_cache:
+        _text_cache["good"] = _encode_bank(GOOD)
+        _text_cache["bad"] = _encode_bank(BAD)
+        logger.info(
+            "clip_quality: encoded prompt banks (good=%d, bad=%d phrases)",
+            len(GOOD), len(BAD),
+        )
+    return _text_cache["good"], _text_cache["bad"]
+
+
+def score_embeddings(img: np.ndarray, good: np.ndarray, bad: np.ndarray
+                     ) -> tuple[np.ndarray, np.ndarray]:
+    """Score L2-normalized image vectors against the prompt banks.
+
+    Returns ``(margin, normalized)`` where ``margin = mean cos(img, good) -
+    mean cos(img, bad)`` and ``normalized`` is the antonym softmax probability in
+    ``[0, 1]`` at :data:`LOGIT_SCALE`.
+    """
+    img = _l2_normalize(img)
+    pos_mean = (img @ good.T).mean(axis=1)
+    neg_mean = (img @ bad.T).mean(axis=1)
+    margin = pos_mean - neg_mean
+    logits = np.stack([pos_mean, neg_mean], axis=1) * LOGIT_SCALE
+    logits -= logits.max(axis=1, keepdims=True)
+    e = np.exp(logits)
+    normalized = e[:, 0] / e.sum(axis=1)
+    return margin.astype(np.float32), normalized.astype(np.float32)
+
+
+def _persist_scores(scored: list[tuple[int, float, float]], chunk: int = 500) -> int:
+    """Batch-upsert (image_id, margin, normalized) into image_model_scores."""
+    from modules import db_postgres
+
+    written = 0
+    cols = "(image_id, model_name, raw_score, normalized, status, is_shadow, model_version, scored_at)"
+    for i in range(0, len(scored), chunk):
+        batch = scored[i:i + chunk]
+        values = ", ".join(
+            ["(%s, %s, %s, %s, %s, %s, %s, CURRENT_TIMESTAMP)"] * len(batch)
+        )
+        params: list = []
+        for image_id, margin, norm in batch:
+            params += [int(image_id), CLIP_QUALITY_MODEL, float(margin), float(norm),
+                       "success", False, PROMPT_SET_VERSION]
+        sql = (
+            f"INSERT INTO image_model_scores {cols} VALUES {values} "
+            "ON CONFLICT (image_id, model_name) DO UPDATE SET "
+            "raw_score = EXCLUDED.raw_score, normalized = EXCLUDED.normalized, "
+            "status = EXCLUDED.status, is_shadow = EXCLUDED.is_shadow, "
+            "model_version = EXCLUDED.model_version, scored_at = CURRENT_TIMESTAMP"
+        )
+        try:
+            db_postgres.execute_write(sql, tuple(params))
+            written += len(batch)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("clip_quality persist chunk failed (%d rows): %s", len(batch), exc)
+    return written
+
+
+def compute_clip_quality(image_ids, *, persist: bool = True, ensure: bool = True,
+                         dim: int = 512) -> dict[int, float]:
+    """Compute ``clip_quality_v0`` (0–1) for ``image_ids`` from B/32 embeddings.
+
+    When ``ensure`` is true, missing ``clip_vit_b32_image`` vectors are generated
+    just-in-time (Postgres + GPU); this is what lets the signal run *before* the
+    keywords phase produces them. Returns ``{image_id: normalized_score}`` for the
+    images that had (or gained) an embedding. No-op (empty dict) on non-Postgres.
+    """
+    from modules import db
+    from modules.embedding_spaces import CLIP_IMAGE_SPACE_CODE
+
+    ids = sorted({int(i) for i in (image_ids or []) if i is not None})
+    if not ids:
+        return {}
+    if db._get_db_engine() != "postgres":  # noqa: SLF001
+        logger.debug("clip_quality: skipped (engine != postgres)")
+        return {}
+
+    if ensure:
+        try:
+            from modules.culling_embeddings import ensure_embeddings_for_space
+            ensure_embeddings_for_space(CLIP_IMAGE_SPACE_CODE, ids)
+        except Exception as exc:  # noqa: BLE001 — degrade to whatever vectors exist
+            logger.warning("clip_quality: ensure embeddings failed: %s", exc)
+
+    raw = db.get_image_embeddings_batch_for_space(CLIP_IMAGE_SPACE_CODE, ids)
+    if not raw:
+        logger.warning("clip_quality: no clip_vit_b32_image embeddings for %d ids", len(ids))
+        return {}
+
+    vec_ids: list[int] = []
+    mats: list[np.ndarray] = []
+    for iid, emb in raw.items():
+        try:
+            v = np.frombuffer(bytes(emb), dtype=np.float32)
+        except (TypeError, ValueError):
+            continue
+        if v.size != dim:
+            continue
+        vec_ids.append(int(iid))
+        mats.append(v)
+    if not mats:
+        return {}
+
+    good, bad = _prompt_matrices()
+    img = np.vstack(mats).astype(np.float32)
+    margin, normalized = score_embeddings(img, good, bad)
+
+    if persist:
+        _persist_scores([(vec_ids[i], float(margin[i]), float(normalized[i]))
+                         for i in range(len(vec_ids))])
+
+    return {vec_ids[i]: float(normalized[i]) for i in range(len(vec_ids))}

--- a/modules/embedding_extractors.py
+++ b/modules/embedding_extractors.py
@@ -27,6 +27,8 @@ from dataclasses import dataclass
 from typing import Iterable, List, Sequence, Tuple
 
 from modules.embedding_spaces import (
+    CLIP_IMAGE_DIM,
+    CLIP_IMAGE_SPACE_CODE,
     CULLING_TOWER_IMAGE_DIM,
     DINOV2_REG_BASE_IMAGE_SPACE_CODE,
     OPENAI_CLIP_L14_IMAGE_SPACE_CODE,
@@ -62,6 +64,13 @@ SUPPORTED_CULLING_SPACES: dict[str, CullingSpaceSpec] = {
     ),
     SIGLIP2_BASE_IMAGE_SPACE_CODE: CullingSpaceSpec(
         SIGLIP2_BASE_IMAGE_SPACE_CODE, "hf_siglip2", "google/siglip2-base-patch16-224"
+    ),
+    # CLIP ViT-B/32 (512-d) — produced by the keywords phase (tagging.py) in normal
+    # runs, but registered here as a culling tower so the JIT ensure path can generate
+    # it *before* culling for the clip_quality_v0 pick/reject signal. Uses the same HF
+    # weights as KeywordScorer / similar_search so image↔text towers match.
+    CLIP_IMAGE_SPACE_CODE: CullingSpaceSpec(
+        CLIP_IMAGE_SPACE_CODE, "hf_clip", "openai/clip-vit-base-patch32", dim=CLIP_IMAGE_DIM
     ),
 }
 
@@ -128,6 +137,8 @@ class CullingEmbedder:
             self._load_timm()
         elif self.spec.loader in ("hf_siglip2", "hf_dinov2"):
             self._load_hf()
+        elif self.spec.loader == "hf_clip":
+            self._load_hf_clip()
         else:  # pragma: no cover - guarded by get_spec
             raise ValueError(f"Unknown loader {self.spec.loader!r}")
         logger.info(
@@ -174,6 +185,26 @@ class CullingEmbedder:
         model = AutoModel.from_pretrained(self.spec.model_name, torch_dtype=dtype)
         self._model = model.to(self.device).eval()
 
+    def _load_hf_clip(self) -> None:
+        """HF ``CLIPModel`` image tower (ViT-B/32, 512-d).
+
+        Resolves the model id from ``tagging.clip_model`` (falling back to the spec)
+        so the image embeddings match the text tower used by
+        ``similar_search._get_clip_text_embedding`` and ``KeywordScorer``.
+        """
+        import torch
+        from transformers import CLIPModel, CLIPProcessor
+
+        from modules import config
+
+        model_id = config.get_config_section("tagging").get(
+            "clip_model", self.spec.model_name
+        )
+        dtype = torch.float16 if self.fp16 else torch.float32
+        self._processor = CLIPProcessor.from_pretrained(model_id)
+        model = CLIPModel.from_pretrained(model_id, torch_dtype=dtype)
+        self._model = model.to(self.device).eval()
+
     def unload(self) -> None:
         self._model = None
         self._preprocess = None
@@ -198,6 +229,8 @@ class CullingEmbedder:
             out = self._embed_open_clip(pil_images, batch_size)
         elif self.spec.loader == "timm":
             out = self._embed_timm(pil_images, batch_size)
+        elif self.spec.loader == "hf_clip":
+            out = self._embed_hf_clip(pil_images, batch_size)
         else:
             out = self._embed_hf(pil_images, batch_size)
         if out.shape[1] != self.spec.dim:
@@ -235,6 +268,23 @@ class CullingEmbedder:
                 tensors = tensors.half()
             with torch.no_grad():
                 feats = self._model(tensors)
+                feats = feats / feats.norm(dim=-1, keepdim=True)
+            out.append(feats.float().cpu().numpy())
+        return np.concatenate(out, axis=0)
+
+    def _embed_hf_clip(self, pils, batch_size):
+        import numpy as np
+        import torch
+
+        out = []
+        for i in range(0, len(pils), batch_size):
+            chunk = pils[i : i + batch_size]
+            batch = self._processor(images=list(chunk), return_tensors="pt")
+            pixel_values = batch["pixel_values"].to(self.device)
+            if self.fp16:
+                pixel_values = pixel_values.half()
+            with torch.no_grad():
+                feats = self._model.get_image_features(pixel_values=pixel_values)
                 feats = feats / feats.norm(dim=-1, keepdim=True)
             out.append(feats.float().cpu().numpy())
         return np.concatenate(out, axis=0)

--- a/modules/selection.py
+++ b/modules/selection.py
@@ -90,6 +90,70 @@ def _two_level_enabled(cfg: SelectionConfig) -> bool:
     return bool(get_config_value("culling.two_level.enabled", default=False))
 
 
+def blended_rank_value(img: dict, score_field: str, clip_weight: float) -> float:
+    """Within-stack ranking value: base quality blended with clip_quality_v0.
+
+    ``(1 - w) * score_field + w * clip_quality_v0`` when a clip value is present and
+    ``w > 0``; otherwise the plain ``score_field`` value. Pure + side-effect-free so
+    the ranking math is unit-testable.
+    """
+    s = img.get(score_field) or 0
+    base = float(s) if s else 0.0
+    if clip_weight > 0.0:
+        cq = img.get("clip_quality_v0")
+        if cq is not None:
+            base = (1.0 - clip_weight) * base + clip_weight * float(cq)
+    return base
+
+
+def apply_clip_reject_guard(
+    folder_decisions: list[tuple[int, str, str]],
+    clip_map: dict[int, float],
+    stack_of: dict[int, object],
+    threshold: float,
+) -> list[tuple[int, str, str]]:
+    """Downgrade frames with ``clip_quality_v0 < threshold`` to ``reject``.
+
+    Conservative: never upgrades to pick, and never strips a stack's last surviving
+    pick. Pure function over the decision list so the guard is unit-testable.
+    """
+    picks_per_stack: dict = defaultdict(int)
+    for img_id, decision, _ in folder_decisions:
+        if decision == "pick":
+            picks_per_stack[stack_of.get(img_id)] += 1
+    guarded: list[tuple[int, str, str]] = []
+    for img_id, decision, path in folder_decisions:
+        cq = clip_map.get(img_id)
+        if cq is not None and cq < threshold and decision != "reject":
+            st = stack_of.get(img_id)
+            if decision == "pick" and picks_per_stack.get(st, 0) <= 1:
+                pass  # keep the stack's only surviving pick
+            else:
+                if decision == "pick":
+                    picks_per_stack[st] -= 1
+                decision = "reject"
+        guarded.append((img_id, decision, path))
+    return guarded
+
+
+def _clip_quality_cfg() -> dict:
+    """Resolve the auxiliary CLIP prompt-quality culling settings from config.json.
+
+    Default-off: when ``enabled`` is false the culling path is byte-identical to the
+    pre-feature behaviour. ``weight`` blends ``clip_quality_v0`` into the within-stack
+    ranking; ``reject_below`` (optional) downgrades obviously-bad frames to reject.
+    See docs/technical/CULLING_ANALYTICS.md and reports/clip-culling/prompt-quality/.
+    """
+    cfg = get_config_value("culling.clip_quality", default={}) or {}
+    weight = float(cfg.get("weight", 0.15))
+    weight = min(1.0, max(0.0, weight))
+    return {
+        "enabled": bool(cfg.get("enabled", False)),
+        "weight": weight,
+        "reject_below": cfg.get("reject_below", None),
+    }
+
+
 @dataclass
 class SelectionSummary:
     total_images: int
@@ -259,13 +323,35 @@ class SelectionService:
                     unstacked_n,
                 )
                     
+                # Auxiliary CLIP prompt-quality signal (default-off). When enabled, the
+                # clip_quality_v0 score (0–1) is generated just-in-time for stacked
+                # images (clip_vit_b32_image embeddings are otherwise produced later in
+                # the keywords phase) and blended into the within-stack ranking below.
+                clip_cfg = _clip_quality_cfg()
+                clip_map: dict[int, float] = {}
+                if clip_cfg["enabled"]:
+                    try:
+                        from modules import clip_quality
+                        stacked_ids = collect_stacked_image_ids(by_stack)
+                        if stacked_ids:
+                            self._progress(progress_cb, pct_base,
+                                           "Computing CLIP prompt-quality...")
+                            clip_map = clip_quality.compute_clip_quality(stacked_ids)
+                            for im in images:
+                                cq = clip_map.get(im["id"])
+                                if cq is not None:
+                                    im["clip_quality_v0"] = cq
+                    except Exception as exc:  # noqa: BLE001 — degrade to score_general
+                        logger.warning("[culling] clip_quality compute failed: %s", exc)
+                        clip_map = {}
+
                 score_col = cfg.score_field
+                clip_w = clip_cfg["weight"] if clip_cfg["enabled"] else 0.0
                 def sort_key(img):
-                    s = img.get(score_col) or 0
                     c = img.get("created_at") or ""
                     i = img.get("id") or 0
                     return (
-                        -float(s) if s else 0,
+                        -blended_rank_value(img, score_col, clip_w),
                         quality_tiebreak_sort_key_best_first(img),
                         str(c),
                         int(i),
@@ -371,6 +457,20 @@ class SelectionService:
                         use_two_level,
                         sub_thr_val,
                     )
+
+                # 4b. Optional obvious-reject guard: downgrade frames whose CLIP
+                # prompt-quality is below a configured floor to 'reject'. Conservative —
+                # never upgrades to pick, and never strips a stack's last surviving pick.
+                if clip_cfg["enabled"] and clip_cfg["reject_below"] is not None and clip_map:
+                    try:
+                        thr = float(clip_cfg["reject_below"])
+                    except (TypeError, ValueError):
+                        thr = None
+                    if thr is not None:
+                        stack_of = {img["id"]: img.get("stack_id") for img in images}
+                        folder_decisions = apply_clip_reject_guard(
+                            folder_decisions, clip_map, stack_of, thr
+                        )
 
                 # 5. Persist DB
                 db.batch_update_cull_decisions(folder_decisions, policy_version=policy_version)

--- a/modules/tagging.py
+++ b/modules/tagging.py
@@ -249,6 +249,44 @@ class KeywordScorer:
                 logger.error(f"Failed to load CLIP model: {e}")
                 raise
 
+    def _logit_scale(self) -> float:
+        try:
+            ls = float(self.model.logit_scale.exp().item())
+        except Exception:  # noqa: BLE001 — fall back to no rescale
+            ls = 1.0
+        return ls if ls > 0 else 1.0
+
+    def _score_prompts_from_embedding(self, image_embedding, prompts):
+        """Score ``prompts`` against a precomputed CLIP image embedding (text-only).
+
+        Returns ``(probs_list, cosine_list, normalized_embedding)``. Lets the
+        keywords phase reuse the ``clip_vit_b32_image`` vector that the culling
+        phase already persisted, skipping the (expensive) image forward pass.
+        Raises on dimension mismatch so the caller can fall back to image encode.
+        """
+        import numpy as np
+
+        emb = np.asarray(image_embedding, dtype=np.float32).reshape(-1)
+        norm = float(np.linalg.norm(emb))
+        if norm > 0:
+            emb = emb / norm
+        text_inputs = self.processor(text=prompts, return_tensors="pt", padding=True)
+        text_inputs = {k: v.to(self.device) for k, v in text_inputs.items()}
+        with torch.no_grad():
+            text_feats = self.model.get_text_features(**text_inputs)
+            text_feats = text_feats / text_feats.norm(dim=-1, keepdim=True)
+        text_np = text_feats.float().cpu().numpy()  # (T, d)
+        if text_np.shape[1] != emb.shape[0]:
+            raise ValueError(
+                f"embedding dim {emb.shape[0]} != text dim {text_np.shape[1]}"
+            )
+        cosine = text_np @ emb  # (T,)
+        logits = cosine * self._logit_scale()
+        logits = logits - logits.max()
+        e = np.exp(logits)
+        probs = e / e.sum()
+        return probs.tolist(), [float(c) for c in cosine.tolist()], emb
+
     def predict(
         self,
         image_path: str,
@@ -256,6 +294,7 @@ class KeywordScorer:
         threshold: float = 0.2,
         top_k: int = 5,
         return_scores: bool = False,
+        image_embedding=None,
     ):
         """
         Predict keywords for an image using zero-shot classification.
@@ -267,6 +306,11 @@ class KeywordScorer:
         stable ``(0, 1)`` weight derived from the raw image/text cosine
         similarity (see ``modules.keyword_relevance``). Keys are the keyword
         strings exactly as returned in the list.
+
+        When ``image_embedding`` (a CLIP ViT-B/32 512-d vector) is supplied, the
+        image is **not** re-encoded — the culling phase already persisted this
+        vector under ``clip_vit_b32_image`` — and only the text prompts are
+        encoded. Falls back to a full image forward pass on any mismatch/error.
         """
         self.load_model()
 
@@ -280,37 +324,47 @@ class KeywordScorer:
             return kw_list
 
         try:
-            from modules.thumbnails import open_image_for_ml
+            probs_list = None
+            cosine_list = None
 
-            image = open_image_for_ml(image_path)
+            # Fast path: reuse the embedding persisted by the culling phase.
+            if image_embedding is not None:
+                try:
+                    probs_list, cosine_list, reused_emb = self._score_prompts_from_embedding(
+                        image_embedding, prompts
+                    )
+                    self.last_image_embedding = reused_emb
+                except Exception as reuse_err:  # noqa: BLE001 — fall back to image encode
+                    logger.debug(
+                        "CLIP embedding reuse failed (%s); encoding image %s",
+                        reuse_err, image_path,
+                    )
+                    probs_list = None
 
-            inputs = self.processor(text=prompts, images=image, return_tensors="pt", padding=True)
-            inputs = {k: v.to(self.device) for k, v in inputs.items()}
+            if probs_list is None:
+                from modules.thumbnails import open_image_for_ml
 
-            with torch.no_grad():
-                outputs = self.model(**inputs)
+                image = open_image_for_ml(image_path)
 
-            try:
-                from modules.embeddings_extract import extract_clip_image_features_from_outputs
+                inputs = self.processor(text=prompts, images=image, return_tensors="pt", padding=True)
+                inputs = {k: v.to(self.device) for k, v in inputs.items()}
 
-                self.last_image_embedding = extract_clip_image_features_from_outputs(outputs)
-            except Exception as emb_err:  # noqa: BLE001 — best-effort side effect
-                logger.debug("CLIP image embedding extraction failed: %s", emb_err)
+                with torch.no_grad():
+                    outputs = self.model(**inputs)
 
-            logits_per_image = outputs.logits_per_image
-            probs = logits_per_image.softmax(dim=1)
+                try:
+                    from modules.embeddings_extract import extract_clip_image_features_from_outputs
 
-            probs_list = probs[0].tolist()
+                    self.last_image_embedding = extract_clip_image_features_from_outputs(outputs)
+                except Exception as emb_err:  # noqa: BLE001 — best-effort side effect
+                    logger.debug("CLIP image embedding extraction failed: %s", emb_err)
 
-            # Raw cosine similarity = logits / logit_scale; logits_per_image is
-            # the scaled dot product of L2-normalized image/text features.
-            try:
-                logit_scale = float(self.model.logit_scale.exp().item())
-            except Exception:  # noqa: BLE001 — fall back to no rescale
-                logit_scale = 1.0
-            if logit_scale <= 0:
-                logit_scale = 1.0
-            cosine_list = [float(v) / logit_scale for v in logits_per_image[0].tolist()]
+                logits_per_image = outputs.logits_per_image
+                probs_list = logits_per_image.softmax(dim=1)[0].tolist()
+                # Raw cosine similarity = logits / logit_scale; logits_per_image is
+                # the scaled dot product of L2-normalized image/text features.
+                ls = self._logit_scale()
+                cosine_list = [float(v) / ls for v in logits_per_image[0].tolist()]
 
             valid_results = []
             for i, score in enumerate(probs_list):
@@ -714,12 +768,19 @@ class TaggingRunner:
                         import textwrap
                         title = textwrap.shorten(caption, width=50, placeholder="...")
                 else:
+                    # Reuse the clip_vit_b32_image embedding the culling phase already
+                    # persisted (if any) so we skip the CLIP image forward pass here.
+                    reuse_emb = self._reuse_clip_embedding(row['id']) if _persist_clip else None
                     if write_keyword_relevance:
                         tags, confidence_map, relevance_map = self.scorer.predict(
-                            inference_path, keywords=custom_keywords, return_scores=True
+                            inference_path, keywords=custom_keywords, return_scores=True,
+                            image_embedding=reuse_emb,
                         )
                     else:
-                        tags = self.scorer.predict(inference_path, keywords=custom_keywords)
+                        tags = self.scorer.predict(
+                            inference_path, keywords=custom_keywords,
+                            image_embedding=reuse_emb,
+                        )
                     caption = ""
                     title = ""
                     if generate_captions:
@@ -979,6 +1040,37 @@ class TaggingRunner:
                          log(f"Folder marked as fully processed: {f}")
                  except Exception as e:
                      log(f"Failed to update status for {f}: {e}")
+
+    def _reuse_clip_embedding(self, image_id: int):
+        """Return the persisted ``clip_vit_b32_image`` vector for ``image_id``, or None.
+
+        Lets ``KeywordScorer.predict`` skip the CLIP image forward pass when the
+        culling phase (clip_quality JIT) already generated the embedding. Gated by
+        ``embeddings.reuse_clip_image_for_keywords`` (default true); best-effort.
+        """
+        if image_id is None:
+            return None
+        try:
+            from modules import config as _cfg
+            if not bool((_cfg.get_config_section('embeddings') or {}).get(
+                    'reuse_clip_image_for_keywords', True)):
+                return None
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            import numpy as np
+
+            from modules.embedding_spaces import CLIP_IMAGE_DIM, CLIP_IMAGE_SPACE_CODE
+
+            raw = db.get_image_embeddings_batch_for_space(CLIP_IMAGE_SPACE_CODE, [int(image_id)])
+            emb = raw.get(int(image_id))
+            if emb is None:
+                return None
+            vec = np.frombuffer(bytes(emb), dtype=np.float32)
+            return vec if vec.size == CLIP_IMAGE_DIM else None
+        except Exception as exc:  # noqa: BLE001 — degrade to image encode
+            logger.debug("reuse clip embedding lookup failed for image_id=%s: %s", image_id, exc)
+            return None
 
     def _persist_tagging_embeddings(self, image_id: int, persist_clip: bool, persist_blip: bool) -> None:
         """Upsert CLIP / BLIP image embeddings produced during the last inference.

--- a/reports/clip-culling/prompt-quality/README.md
+++ b/reports/clip-culling/prompt-quality/README.md
@@ -1,0 +1,117 @@
+# CLIP prompt-quality benchmark (v0) — results
+
+**Date:** 2026-06-13 · **Script:** `scripts/research/clip_culling/clip_prompt_quality.py`
+**Corpus:** production `image_scoring` @5432, **read-only**, all human-labeled images
+(62,932 with `rating` 1–5 + color `label`; 21,466 picked / 13,301 rejected).
+**Prompt set:** `v0`, 7 dimensions, 6-template expansion, antonym-softmax @ temp 100.
+
+Auxiliary signal only — *not* a primary IQA model (per the experiment spec).
+
+## What ran
+
+Only CLIP-family spaces whose **text** tower matches the persisted **image**
+encoder were scored (mismatch silently corrupts cosine). Spaces present in prod:
+
+| Space | dim | text tower |
+|---|---|---|
+| `clip_vit_b32_image` | 512 | HF `openai/clip-vit-base-patch32` |
+| `openclip_l14_laion2b_image` | 768 | open_clip `ViT-L-14` / `laion2b_s32b_b82k` |
+| `bioclip_2_image` | 768 | open_clip `hf-hub:imageomics/bioclip-2` |
+
+**Not testable here:** `openai_clip_vit_l14_image` and `siglip2_base_image` have
+**0** rows in prod — they exist only in the stopped E2E spike DB (`@5433`). DINOv2
+and MobileNet have no text encoder. To compare those, start + re-seed the E2E
+container (`embed_persist`, a GPU job) or backfill them into prod.
+
+## Headline (`clip_quality_v0`)
+
+| Space | spearman(rating) | AUC pick/reject | within-stack concordance | mean picked | mean rejected |
+|---|---|---|---|---|---|
+| **`clip_vit_b32_image`** | **0.567** | **0.890** | **0.986** | 0.599 | 0.401 |
+| `openclip_l14_laion2b_image` | 0.405 | 0.800 | 0.983 | 0.608 | 0.380 |
+| `bioclip_2_image` | 0.083 | 0.556 | 0.424 | 0.890 | 0.872 |
+
+**CLIP B/32 (the original OpenAI CLIP) wins decisively** and is also the cheapest
+(512-d, already ~94% populated). LAION L/14 is a solid second. **BioCLIP is useless
+for generic quality** — its taxonomy-trained text space gives no spread (scores
+saturate ~0.88; within-stack worse than random). Drop BioCLIP from quality prompts.
+
+## Per-dimension (CLIP B/32 — best space)
+
+| Dimension | spearman | AUC | within-stack conc. | verdict |
+|---|---|---|---|---|
+| `clip_quality_v0` | 0.567 | 0.890 | 0.986 | ⭐ best overall |
+| `clip_exposure_v0` | 0.527 | 0.873 | 0.617 | strong global, weak intra-stack |
+| `clip_focus_v0` | 0.478 | 0.842 | **0.997** | ⭐ best tie-breaker |
+| `clip_misshot_v0` | 0.377 | 0.763 | 0.941 | useful |
+| `clip_composition_v0` | 0.300 | 0.731 | 0.549 | global only |
+| `clip_wildlife_quality_v0` | 0.268 | 0.689 | 0.985 | modest global, strong tie-break |
+| `clip_noise_v0` | 0.155 | 0.603 | 0.546 | weak (known CLIP blind spot) |
+
+> within-stack concordance is computed over the ~34 stacks that contain both a
+> picked and a rejected frame (7,556 pick×reject pairs); treat it as the
+> tie-break metric, AUC/spearman as the global metric.
+
+## Acceptance criteria (from the spec) — met
+
+1. ✅ Rejected score below picked **inside the same cluster** — B/32 `clip_quality`
+   concordance 0.986, `clip_focus` 0.997.
+2. ✅ Obvious technical failures score lower — AUC 0.890.
+3. ✅ Dimensions directionally meaningful — all positive spearman for B/32 & L/14.
+4. ✅ Improves tie-breaking — within-stack concordance ≈ 0.99 (quality/focus).
+5. ✅ False positives explainable — `top_positive_prompt` / `top_negative_prompt`
+   in the CSV (rejects dominated by "out of focus" / "misfocused").
+
+## Recommendation
+
+- Use **CLIP B/32** for the auxiliary prompt-quality signal (cheapest, best,
+  already populated). Most reliable dimensions: **quality + focus** (and **wildlife**
+  for intra-burst tie-breaks).
+- **Drop** BioCLIP for quality prompting and the **noise** dimension (no signal).
+- Treat **exposure/composition** as global priors, not intra-stack tie-breakers.
+- Only after this: consider persisting scores (`image_prompt_quality_scores`) —
+  check `docs/CANONICAL_SOURCES.md` / `DB_SCHEMA.md` first, per the spec.
+- Open gap: re-seed E2E (or backfill prod) to benchmark **OpenAI L/14** + **SigLIP2**,
+  the two CLIP variants most likely to challenge B/32.
+
+## Update 2026-06-14 — E2E run (OpenAI L/14 + SigLIP2)
+
+The E2E spike DB (`image_scoring_test` @5433) was started; it holds the seeded
+**4-folder subset** (62/44/45/676 ≈ 2,126 images) and is the *only* DB with
+`openai_clip_vit_l14_image` + `siglip2_base_image`. Runs in `e2e/` and
+`folders_prod/` (prod restricted to the same 4 folders, run as the control).
+
+**E2E embeddings are sound** — prod-restricted-to-same-folders reproduces E2E to
+3 decimals (B/32 AUC 0.754 = 0.754; OpenCLIP 0.493 ≈ 0.492). So the weak numbers
+below are *corpus difficulty*, not a data bug: these 4 folders were hand-picked
+for near-duplicate **culling** bursts, so absolute-quality prompts barely separate
+them (OpenCLIP L/14 collapses to ~random here yet scores 0.80 on the full corpus).
+
+Same-corpus (4 folders) `clip_quality_v0` AUC — the only fair head-to-head that
+includes OpenAI L/14:
+
+| Space | AUC | source |
+|---|---|---|
+| **`clip_vit_b32_image`** | **0.754** | folders_prod |
+| `bioclip_2_image` | 0.672 | folders_prod (full coverage) |
+| `openai_clip_vit_l14_image` | 0.613 | e2e (only source) |
+| `openclip_l14_laion2b_image` | 0.493 | folders_prod |
+
+**OpenAI L/14 (#1) does not beat B/32** on the only shared corpus (0.613 vs 0.754).
+Note openclip↔bioclip swap ranks vs the full corpus — proof this subset is
+unrepresentative; **trust the full-corpus table above for ranking.**
+
+**SigLIP2 is untestable in this env** — its text tower needs `GemmaTokenizer`,
+which the `~/.venvs/tf` transformers build can't load (image side worked; text
+side can't). Would require upgrading the venv's transformers/tokenizers stack.
+
+**Remaining open item:** to get a *full-corpus* OpenAI L/14 vs B/32 verdict,
+backfill `openai_clip_vit_l14_image` into prod (GPU job, ~62.9k images) and re-run
+the headline table. On current evidence B/32 stays the recommendation.
+
+## Artifacts
+
+- `clip_prompt_quality__<space>.csv` — per-image, all dimensions + debug similarities
+- `summary.json` — full metrics
+- `run_full.log` — run log
+- `e2e/`, `folders_prod/` — 4-folder subset runs (OpenAI L/14 + same-folder control)

--- a/reports/clip-culling/prompt-quality/summary.json
+++ b/reports/clip-culling/prompt-quality/summary.json
@@ -1,0 +1,214 @@
+{
+  "prompt_set_version": "v0",
+  "temp": 100.0,
+  "templates": [
+    "a photo that is {phrase}",
+    "a photograph that is {phrase}",
+    "an image that is {phrase}",
+    "a {phrase} photograph",
+    "a {phrase} image",
+    "this is a {phrase} photo"
+  ],
+  "n_meta": 62932,
+  "folders": null,
+  "results": [
+    {
+      "space": "clip_vit_b32_image",
+      "n_images": 59001,
+      "dim_dim": 512,
+      "n_picked": 20700,
+      "n_rejected": 12226,
+      "dimensions": {
+        "clip_quality_v0": {
+          "spearman_rating": 0.5669,
+          "auc_pick_vs_reject": 0.8901,
+          "within_stack_pairs": 7556,
+          "within_stack_concordance": 0.986,
+          "score_mean_picked": 0.5993,
+          "score_mean_rejected": 0.4009
+        },
+        "clip_focus_v0": {
+          "spearman_rating": 0.4777,
+          "auc_pick_vs_reject": 0.842,
+          "within_stack_pairs": 7556,
+          "within_stack_concordance": 0.9967,
+          "score_mean_picked": 0.6545,
+          "score_mean_rejected": 0.4289
+        },
+        "clip_exposure_v0": {
+          "spearman_rating": 0.5274,
+          "auc_pick_vs_reject": 0.8733,
+          "within_stack_pairs": 7556,
+          "within_stack_concordance": 0.6171,
+          "score_mean_picked": 0.7775,
+          "score_mean_rejected": 0.587
+        },
+        "clip_noise_v0": {
+          "spearman_rating": 0.1551,
+          "auc_pick_vs_reject": 0.6026,
+          "within_stack_pairs": 7556,
+          "within_stack_concordance": 0.5462,
+          "score_mean_picked": 0.3497,
+          "score_mean_rejected": 0.2956
+        },
+        "clip_misshot_v0": {
+          "spearman_rating": 0.3772,
+          "auc_pick_vs_reject": 0.7633,
+          "within_stack_pairs": 7556,
+          "within_stack_concordance": 0.9406,
+          "score_mean_picked": 0.4794,
+          "score_mean_rejected": 0.3465
+        },
+        "clip_composition_v0": {
+          "spearman_rating": 0.2996,
+          "auc_pick_vs_reject": 0.7312,
+          "within_stack_pairs": 7556,
+          "within_stack_concordance": 0.5491,
+          "score_mean_picked": 0.668,
+          "score_mean_rejected": 0.5569
+        },
+        "clip_wildlife_quality_v0": {
+          "spearman_rating": 0.2681,
+          "auc_pick_vs_reject": 0.6887,
+          "within_stack_pairs": 7556,
+          "within_stack_concordance": 0.9848,
+          "score_mean_picked": 0.4402,
+          "score_mean_rejected": 0.3056
+        }
+      },
+      "csv": "/mnt/d/Projects/image-scoring-backend/reports/clip-culling/prompt-quality/clip_prompt_quality__clip_vit_b32_image.csv"
+    },
+    {
+      "space": "openclip_l14_laion2b_image",
+      "n_images": 62932,
+      "dim_dim": 768,
+      "n_picked": 21466,
+      "n_rejected": 13301,
+      "dimensions": {
+        "clip_quality_v0": {
+          "spearman_rating": 0.405,
+          "auc_pick_vs_reject": 0.8003,
+          "within_stack_pairs": 7559,
+          "within_stack_concordance": 0.9832,
+          "score_mean_picked": 0.6076,
+          "score_mean_rejected": 0.3797
+        },
+        "clip_focus_v0": {
+          "spearman_rating": 0.4031,
+          "auc_pick_vs_reject": 0.7955,
+          "within_stack_pairs": 7559,
+          "within_stack_concordance": 0.993,
+          "score_mean_picked": 0.7201,
+          "score_mean_rejected": 0.4325
+        },
+        "clip_exposure_v0": {
+          "spearman_rating": 0.4223,
+          "auc_pick_vs_reject": 0.8118,
+          "within_stack_pairs": 7559,
+          "within_stack_concordance": 0.6369,
+          "score_mean_picked": 0.771,
+          "score_mean_rejected": 0.55
+        },
+        "clip_noise_v0": {
+          "spearman_rating": 0.2379,
+          "auc_pick_vs_reject": 0.666,
+          "within_stack_pairs": 7559,
+          "within_stack_concordance": 0.7666,
+          "score_mean_picked": 0.7636,
+          "score_mean_rejected": 0.6307
+        },
+        "clip_misshot_v0": {
+          "spearman_rating": 0.2587,
+          "auc_pick_vs_reject": 0.6937,
+          "within_stack_pairs": 7559,
+          "within_stack_concordance": 0.7423,
+          "score_mean_picked": 0.4219,
+          "score_mean_rejected": 0.2592
+        },
+        "clip_composition_v0": {
+          "spearman_rating": 0.188,
+          "auc_pick_vs_reject": 0.6472,
+          "within_stack_pairs": 7559,
+          "within_stack_concordance": 0.7254,
+          "score_mean_picked": 0.6701,
+          "score_mean_rejected": 0.5472
+        },
+        "clip_wildlife_quality_v0": {
+          "spearman_rating": 0.1669,
+          "auc_pick_vs_reject": 0.6161,
+          "within_stack_pairs": 7559,
+          "within_stack_concordance": 0.9517,
+          "score_mean_picked": 0.2692,
+          "score_mean_rejected": 0.1752
+        }
+      },
+      "csv": "/mnt/d/Projects/image-scoring-backend/reports/clip-culling/prompt-quality/clip_prompt_quality__openclip_l14_laion2b_image.csv"
+    },
+    {
+      "space": "bioclip_2_image",
+      "n_images": 62932,
+      "dim_dim": 768,
+      "n_picked": 21466,
+      "n_rejected": 13301,
+      "dimensions": {
+        "clip_quality_v0": {
+          "spearman_rating": 0.0829,
+          "auc_pick_vs_reject": 0.556,
+          "within_stack_pairs": 7559,
+          "within_stack_concordance": 0.4241,
+          "score_mean_picked": 0.8899,
+          "score_mean_rejected": 0.872
+        },
+        "clip_focus_v0": {
+          "spearman_rating": 0.1958,
+          "auc_pick_vs_reject": 0.6399,
+          "within_stack_pairs": 7559,
+          "within_stack_concordance": 0.7079,
+          "score_mean_picked": 0.3274,
+          "score_mean_rejected": 0.2425
+        },
+        "clip_exposure_v0": {
+          "spearman_rating": 0.1512,
+          "auc_pick_vs_reject": 0.6226,
+          "within_stack_pairs": 7559,
+          "within_stack_concordance": 0.1134,
+          "score_mean_picked": 0.9933,
+          "score_mean_rejected": 0.9887
+        },
+        "clip_noise_v0": {
+          "spearman_rating": 0.1086,
+          "auc_pick_vs_reject": 0.583,
+          "within_stack_pairs": 7559,
+          "within_stack_concordance": 0.6234,
+          "score_mean_picked": 0.3555,
+          "score_mean_rejected": 0.3064
+        },
+        "clip_misshot_v0": {
+          "spearman_rating": -0.0272,
+          "auc_pick_vs_reject": 0.4736,
+          "within_stack_pairs": 7559,
+          "within_stack_concordance": 0.2645,
+          "score_mean_picked": 0.5887,
+          "score_mean_rejected": 0.6013
+        },
+        "clip_composition_v0": {
+          "spearman_rating": 0.2193,
+          "auc_pick_vs_reject": 0.6577,
+          "within_stack_pairs": 7559,
+          "within_stack_concordance": 0.76,
+          "score_mean_picked": 0.9281,
+          "score_mean_rejected": 0.873
+        },
+        "clip_wildlife_quality_v0": {
+          "spearman_rating": -0.0432,
+          "auc_pick_vs_reject": 0.4611,
+          "within_stack_pairs": 7559,
+          "within_stack_concordance": 0.6402,
+          "score_mean_picked": 0.0031,
+          "score_mean_rejected": 0.0042
+        }
+      },
+      "csv": "/mnt/d/Projects/image-scoring-backend/reports/clip-culling/prompt-quality/clip_prompt_quality__bioclip_2_image.csv"
+    }
+  ]
+}

--- a/scripts/backfill_clip_quality.py
+++ b/scripts/backfill_clip_quality.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Backfill ``clip_quality_v0`` over existing images (Postgres).
+
+Computes the auxiliary CLIP prompt-quality score from already-persisted
+``clip_vit_b32_image`` (512-d) embeddings and upserts it into
+``image_model_scores`` (model ``clip_quality_v0``). Images without a B/32
+embedding are skipped (``ensure=False`` — no GPU image inference here; run the
+keywords phase or ``scripts/backfill_culling_embeddings.py --space
+clip_vit_b32_image`` first if you need to generate them).
+
+Run in WSL with the app venv (CLIP text tower)::
+
+    source ~/.venvs/tf/bin/activate
+    python -m scripts.backfill_clip_quality --batch-size 1000
+    python -m scripts.backfill_clip_quality --folder-id 62 --dry-run
+
+Postgres-only. See modules/clip_quality.py and reports/clip-culling/prompt-quality/.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import time
+
+logger = logging.getLogger("backfill_clip_quality")
+
+
+def _ids_with_b32(folder_id: int | None, limit: int | None) -> list[int]:
+    from modules import db_postgres
+    from modules.embedding_spaces import CLIP_IMAGE_SPACE_CODE, get_embedding_space_id
+
+    sid = get_embedding_space_id(CLIP_IMAGE_SPACE_CODE)
+    if sid is None:
+        raise RuntimeError(f"Space {CLIP_IMAGE_SPACE_CODE!r} not registered.")
+    sql = (
+        "SELECT e.image_id FROM image_embeddings_512 e "
+        "JOIN images i ON i.id = e.image_id "
+        "WHERE e.embedding_space_id = %s"
+    )
+    params: list = [sid]
+    if folder_id is not None:
+        sql += " AND i.folder_id = %s"
+        params.append(folder_id)
+    sql += " ORDER BY e.image_id"
+    if limit is not None:
+        sql += f" LIMIT {int(limit)}"
+    rows = db_postgres.execute_select(sql, tuple(params))
+    return [int(r["image_id"]) for r in rows]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--folder-id", type=int, default=None, help="Restrict to one folder")
+    parser.add_argument("--limit", type=int, default=None, help="Cap number of images")
+    parser.add_argument("--batch-size", type=int, default=1000)
+    parser.add_argument("--dry-run", action="store_true", help="Count eligible images only")
+    parser.add_argument("--verbose", "-v", action="store_true")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    from modules import clip_quality, db
+
+    db.init_db()
+    if db._get_db_engine() != "postgres":  # noqa: SLF001
+        logger.error("Backfill requires database.engine = 'postgres'.")
+        return 2
+
+    ids = _ids_with_b32(args.folder_id, args.limit)
+    logger.info("Images with %s embeddings: %d", "clip_vit_b32_image", len(ids))
+    if args.dry_run or not ids:
+        return 0
+
+    total = len(ids)
+    scored = 0
+    t0 = time.time()
+    last_log = t0
+    for start in range(0, total, args.batch_size):
+        batch = ids[start:start + args.batch_size]
+        # ensure=False: embeddings already exist (we selected on them).
+        out = clip_quality.compute_clip_quality(batch, persist=True, ensure=False)
+        scored += len(out)
+        now = time.time()
+        if now - last_log >= 15 or start + args.batch_size >= total:
+            processed = min(start + args.batch_size, total)
+            rate = processed / max(now - t0, 1e-6)
+            eta = (total - processed) / max(rate, 1e-6)
+            logger.info("clip_quality_v0 %d/%d (%.1f%%) scored=%d %.0f img/s ETA %.0f min",
+                        processed, total, 100 * processed / total, scored, rate, eta / 60)
+            last_log = now
+
+    logger.info("Done: persisted clip_quality_v0 for %d/%d images in %.1f min",
+                scored, total, (time.time() - t0) / 60)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/research/clip_culling/clip_prompt_quality.py
+++ b/scripts/research/clip_culling/clip_prompt_quality.py
@@ -1,0 +1,620 @@
+#!/usr/bin/env python3
+"""Offline CLIP prompt-quality benchmark over the seeded E2E corpus.
+
+Estimates generic photo-quality / reject-reason signals from **persisted** CLIP
+image embeddings + zero-shot text prompts (CLIP-IQA antonym style). Treated as an
+*auxiliary* signal, not a primary IQA model. No DB/API/schema changes — read-only
+against the E2E DB (``image_scoring_test`` @5433, pinned by ``common``), CSV out.
+
+Dimensions (prompt_set_version ``v0``):
+
+    clip_quality_v0  clip_focus_v0  clip_exposure_v0  clip_noise_v0
+    clip_misshot_v0  clip_composition_v0  clip_wildlife_quality_v0
+
+Each dimension compares the image to a positive and a negative prompt bank. We
+report two readings per dimension:
+
+* ``*_margin``  = mean cos(img, pos) - mean cos(img, neg)   (raw, can be tiny)
+* ``*_score``   = antonym softmax prob of pos vs neg at the model's logit scale
+  (a real 0..1 spread; the spec's literal ``sigmoid(pos-neg)`` collapses to ~0.5
+  because cosine margins are ~0.01-0.05 — softmax/temperature is the CLIP-IQA fix).
+
+Spaces are compared **only** if their persisted image embeddings have a matching
+*text* tower (image/text encoder mismatch silently corrupts cosine):
+
+    clip_vit_b32_image          HF openai/clip-vit-base-patch32   (512-d)
+    openai_clip_vit_l14_image   open_clip ViT-L-14-quickgelu/openai
+    openclip_l14_laion2b_image  open_clip ViT-L-14/laion2b_s32b_b82k
+    siglip2_base_image          HF google/siglip2-base-patch16-224
+    bioclip_2_image             open_clip hf-hub:imageomics/bioclip-2
+
+DINOv2 / MobileNet are image-only and skipped.
+
+Template expansion: short adjectival phrases are expanded through 6 caption
+templates and averaged; full descriptive captions (containing photo/image/bird/
+wildlife) are used verbatim to avoid ungrammatical prompts.
+
+Runs **read-only** against the app's configured Postgres (``database.engine`` /
+``db_postgres.get_pg_config``) — production by default. Only SELECTs are issued;
+no DB/API/schema changes. Spaces with no persisted embeddings are skipped.
+
+Run in WSL with the app venv::
+
+    source ~/.venvs/tf/bin/activate
+    python -m scripts.research.clip_culling.clip_prompt_quality --spaces all
+    python -m scripts.research.clip_culling.clip_prompt_quality --folders 62,44,45 --limit 2000
+
+Ground truth for evaluation is **human** ``rating`` (1-5) + ``label`` (color);
+``cull_decision`` is MobileNet-pipeline-derived and only carried for reference.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import logging
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.research.clip_culling.wrappers import (  # noqa: E402
+    HFImageTower, Tower, l2_normalize,
+)
+
+logger = logging.getLogger("clip_culling.prompt_quality")
+
+PROMPT_SET_VERSION = "v0"
+RESULTS_DIR = PROJECT_ROOT / "reports" / "clip-culling" / "prompt-quality"
+
+# --------------------------------------------------------------------------- #
+# Prompt template expansion
+# --------------------------------------------------------------------------- #
+TEMPLATES = (
+    "a photo that is {phrase}",
+    "a photograph that is {phrase}",
+    "an image that is {phrase}",
+    "a {phrase} photograph",
+    "a {phrase} image",
+    "this is a {phrase} photo",
+)
+
+# Phrases containing these tokens are full captions -> used verbatim (no template).
+_VERBATIM_TOKENS = ("photo", "photograph", "image", "bird", "wildlife", "subject")
+
+
+def _is_verbatim(phrase: str) -> bool:
+    p = phrase.lower()
+    return any(tok in p for tok in _VERBATIM_TOKENS)
+
+
+def expand(phrase: str) -> list[str]:
+    """Return the prompt variants for *phrase* (templated, or verbatim)."""
+    if _is_verbatim(phrase):
+        return [phrase]
+    return [t.format(phrase=phrase) for t in TEMPLATES]
+
+
+# --------------------------------------------------------------------------- #
+# Prompt banks (from the experiment spec)
+# --------------------------------------------------------------------------- #
+GOOD = [
+    "high quality", "good", "beautiful", "sharp", "clear", "well focused",
+    "properly exposed", "clean", "detailed", "professional", "well composed",
+    "visually pleasing", "good lighting", "natural colors",
+    "a photo with strong subject separation", "crisp details",
+    "a photo with a clear subject", "balanced contrast", "good dynamic range",
+    "a keeper photo",
+]
+BAD = [
+    "low quality", "bad", "poor", "blurry", "out of focus", "misfocused",
+    "overexposed", "underexposed", "noisy", "grainy", "soft", "dull",
+    "washed out", "poorly composed", "a photo with no clear subject",
+    "a missed shot", "a poorly timed photo", "technically flawed",
+    "bad lighting", "a rejected photo",
+]
+
+FOCUS_POS = [
+    "sharp", "tack sharp", "well focused", "crisp and detailed",
+    "a photo with clear fine details", "a photo with a sharp subject",
+    "a photo with sharp eyes", "a photo with detailed texture",
+]
+FOCUS_NEG = [
+    "blurry", "out of focus", "misfocused", "soft", "motion blurred",
+    "a photo with camera shake", "a photo with smeared details",
+    "a photo with an unsharp subject", "a photo with blurry eyes",
+]
+
+EXPO_POS = [
+    "properly exposed", "well exposed", "a photo with balanced highlights and shadows",
+    "a photo with good dynamic range", "a photo with preserved highlight detail",
+    "a photo with visible shadow detail", "naturally lit",
+]
+EXPO_NEG = [
+    "overexposed", "underexposed", "blown out", "a photo with clipped highlights",
+    "a photo with crushed shadows", "too dark", "too bright", "washed out",
+    "harshly lit",
+]
+
+NOISE_POS = [
+    "clean", "smooth", "a photo with low noise", "a photo with clean details",
+    "a photo with a smooth background", "a high quality clean image",
+]
+NOISE_NEG = [
+    "noisy", "grainy", "a high ISO noisy photo", "a photo with color noise",
+    "a photo with luminance noise", "a photo with rough background noise",
+    "a photo with digital artifacts", "degraded",
+]
+
+MISSHOT_POS = [
+    "well timed", "a photo with a clear subject", "a photo with good subject placement",
+    "well composed", "a photo with an interesting pose", "a photo with good eye contact",
+    "a photo capturing the decisive moment",
+]
+MISSHOT_NEG = [
+    "a missed shot", "a poorly timed photo", "a photo with no clear subject",
+    "a photo with the subject cut off", "a photo with a hidden subject",
+    "a photo with the subject facing away", "a photo with awkward framing",
+    "a poorly composed photo", "a throwaway photo",
+]
+
+COMP_POS = [
+    "a photo with beautiful composition", "a photo with balanced composition",
+    "visually pleasing", "a photo with strong subject separation",
+    "a photo with good background blur", "a photo with harmonious colors",
+    "a photo with pleasing light", "professional looking",
+]
+COMP_NEG = [
+    "poorly composed", "cluttered", "a photo with a distracting background",
+    "boring", "flat", "messy", "a photo with bad framing",
+    "a photo with awkward cropping", "a photo with distracting elements",
+]
+
+WILDLIFE_POS = [
+    "a bird photo with a sharp eye", "a bird photo with crisp feather detail",
+    "a bird photo with a well focused subject", "a wildlife photo with sharp eyes",
+    "a bird in its natural habitat", "a striking wildlife photo",
+]
+WILDLIFE_NEG = [
+    "a bird photo with an out of focus eye", "a bird photo with blurry feathers",
+    "a bird photo with a soft subject", "a wildlife photo with blurry eyes",
+    "a photo with a bird facing away", "a photo with a bird cut off",
+    "a photo with a bird hidden behind branches", "a photo with obstructing branches",
+]
+
+# dimension name -> (positive phrases, negative phrases)
+DIMENSIONS: dict[str, tuple[list[str], list[str]]] = {
+    "clip_quality_v0": (GOOD, BAD),
+    "clip_focus_v0": (FOCUS_POS, FOCUS_NEG),
+    "clip_exposure_v0": (EXPO_POS, EXPO_NEG),
+    "clip_noise_v0": (NOISE_POS, NOISE_NEG),
+    "clip_misshot_v0": (MISSHOT_POS, MISSHOT_NEG),
+    "clip_composition_v0": (COMP_POS, COMP_NEG),
+    "clip_wildlife_quality_v0": (WILDLIFE_POS, WILDLIFE_NEG),
+}
+
+# --------------------------------------------------------------------------- #
+# Space -> text tower registry (must match the image encoder that produced the
+# persisted embeddings). DINOv2/MobileNet omitted: no text encoder.
+# --------------------------------------------------------------------------- #
+OPEN_CLIP_SPACES: dict[str, tuple[str, str | None]] = {
+    "openai_clip_vit_l14_image": ("ViT-L-14-quickgelu", "openai"),
+    "openclip_l14_laion2b_image": ("ViT-L-14", "laion2b_s32b_b82k"),
+    "bioclip_2_image": ("hf-hub:imageomics/bioclip-2", None),
+}
+SIGLIP2_SPACES = {"siglip2_base_image": "google/siglip2-base-patch16-224"}
+HF_CLIP_SPACES = {"clip_vit_b32_image"}  # HF openai/clip-vit-base-patch32
+
+ALL_TEXT_SPACES = (
+    list(HF_CLIP_SPACES) + list(OPEN_CLIP_SPACES) + list(SIGLIP2_SPACES)
+)
+
+
+# --------------------------------------------------------------------------- #
+# Text encoders (one per tower family)
+# --------------------------------------------------------------------------- #
+class _B32TextTower:
+    """HF ``openai/clip-vit-base-patch32`` text tower (batched), 512-d."""
+
+    def __init__(self):
+        self._cache: dict = {}
+
+    def encode_text(self, prompts: list[str]) -> np.ndarray:
+        import torch
+        from transformers import CLIPModel, CLIPProcessor
+
+        from modules import config
+
+        if "model" not in self._cache:
+            name = config.get_config_section("tagging").get(
+                "clip_model", "openai/clip-vit-base-patch32"
+            )
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+            self._cache["model"] = CLIPModel.from_pretrained(name).to(device).eval()
+            self._cache["proc"] = CLIPProcessor.from_pretrained(name)
+            self._cache["device"] = device
+            logger.info("Loaded HF CLIP text tower %s on %s", name, device)
+        model, proc, device = (
+            self._cache["model"], self._cache["proc"], self._cache["device"]
+        )
+        out = []
+        for i in range(0, len(prompts), 256):
+            chunk = prompts[i:i + 256]
+            inputs = proc(text=chunk, return_tensors="pt", padding=True, truncation=True)
+            inputs = {k: v.to(device) for k, v in inputs.items()}
+            with torch.no_grad():
+                feats = model.get_text_features(**inputs)
+            out.append(feats.detach().cpu().numpy().astype(np.float32))
+        return l2_normalize(np.concatenate(out, axis=0))
+
+    def unload(self):
+        self._cache.clear()
+        try:
+            import torch
+            torch.cuda.empty_cache()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def make_text_tower(space_code: str):
+    """Return an object exposing ``encode_text(list[str]) -> (n,d) np.ndarray``."""
+    if space_code in HF_CLIP_SPACES:
+        return _B32TextTower()
+    if space_code in OPEN_CLIP_SPACES:
+        name, pretrained = OPEN_CLIP_SPACES[space_code]
+        return Tower(name, pretrained or "")
+    if space_code in SIGLIP2_SPACES:
+        return HFImageTower(SIGLIP2_SPACES[space_code], kind="siglip2")
+    raise ValueError(f"No text tower mapping for space {space_code!r}")
+
+
+def _encode_phrase_banks(tower, phrases: list[str]) -> np.ndarray:
+    """Encode each phrase (template-averaged) -> (n_phrases, d) L2-normalized."""
+    vecs = []
+    for phrase in phrases:
+        variants = expand(phrase)
+        v = tower.encode_text(variants)  # (n_variants, d), normalized
+        vecs.append(l2_normalize(v.mean(axis=0)))
+    return np.vstack(vecs).astype(np.float32)
+
+
+# --------------------------------------------------------------------------- #
+# Read-only DB loaders (configured engine — production by default)
+# --------------------------------------------------------------------------- #
+def _folder_clause(folders: list[int] | None) -> str:
+    if not folders:
+        return ""
+    return " AND i.folder_id IN (" + ",".join(str(int(f)) for f in folders) + ")"
+
+
+def load_meta(folders: list[int] | None, limit: int | None) -> dict[int, dict]:
+    """image_id -> metadata (human rating/label + scores/stack/path)."""
+    from modules import db_postgres
+
+    sql = (
+        "SELECT i.id, i.folder_id, i.stack_id, i.file_path, i.score_general, "
+        "i.rating, i.label, i.cull_decision FROM images i "
+        "WHERE i.rating IS NOT NULL" + _folder_clause(folders) + " ORDER BY i.id"
+    )
+    if limit:
+        sql += f" LIMIT {int(limit)}"
+    rows = db_postgres.execute_select(sql)
+    return {r["id"]: dict(r) for r in rows}
+
+
+def _parse_vec(v) -> np.ndarray | None:
+    if v is None:
+        return None
+    if isinstance(v, str):
+        s = v.strip().lstrip("[").rstrip("]")
+        return np.array([float(x) for x in s.split(",")], dtype=np.float32) if s else None
+    if isinstance(v, (bytes, bytearray, memoryview)):
+        return np.frombuffer(bytes(v), dtype=np.float32).copy()
+    return np.asarray(v, dtype=np.float32)
+
+
+def load_embeddings(space_code: str, folders: list[int] | None,
+                    ids: set[int] | None) -> dict[int, np.ndarray]:
+    """image_id -> raw vector for ``space_code`` (configured DB, read-only)."""
+    from modules import db_postgres
+    from modules.db_legacy import _pg_embedding_table_for_dim
+    from modules.embedding_spaces import SPACE_DIMS, get_embedding_space_id
+
+    sid = get_embedding_space_id(space_code)
+    if sid is None:
+        return {}
+    dim = SPACE_DIMS.get(space_code)
+    table = _pg_embedding_table_for_dim(dim)
+    sql = (
+        f"SELECT e.image_id, e.embedding FROM {table} e "
+        f"JOIN images i ON i.id = e.image_id "
+        f"WHERE e.embedding_space_id = %s" + _folder_clause(folders)
+    )
+    rows = db_postgres.execute_select(sql, (sid,))
+    out: dict[int, np.ndarray] = {}
+    for r in rows:
+        if ids is not None and r["image_id"] not in ids:
+            continue
+        vec = _parse_vec(r["embedding"])
+        if vec is not None:
+            out[r["image_id"]] = vec
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Scoring
+# --------------------------------------------------------------------------- #
+@dataclass
+class DimScore:
+    margin: np.ndarray          # (N,) mean(pos) - mean(neg)
+    score: np.ndarray           # (N,) antonym softmax prob in [0,1]
+    top_pos_idx: np.ndarray     # (N,) argmax positive phrase
+    top_neg_idx: np.ndarray     # (N,) argmax negative phrase
+    pos_mean: np.ndarray        # (N,) mean positive cosine
+    neg_mean: np.ndarray        # (N,) mean negative cosine
+
+
+def score_dimension(img: np.ndarray, pos_t: np.ndarray, neg_t: np.ndarray,
+                    temp: float) -> DimScore:
+    pos_cos = img @ pos_t.T  # (N, P)
+    neg_cos = img @ neg_t.T  # (N, M)
+    pos_mean = pos_cos.mean(axis=1)
+    neg_mean = neg_cos.mean(axis=1)
+    margin = pos_mean - neg_mean
+    logits = np.stack([pos_mean, neg_mean], axis=1) * temp
+    logits -= logits.max(axis=1, keepdims=True)
+    e = np.exp(logits)
+    prob = e[:, 0] / e.sum(axis=1)
+    return DimScore(
+        margin=margin, score=prob,
+        top_pos_idx=pos_cos.argmax(axis=1), top_neg_idx=neg_cos.argmax(axis=1),
+        pos_mean=pos_mean, neg_mean=neg_mean,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Ground truth helpers (human labels only)
+# --------------------------------------------------------------------------- #
+def pick_label(meta: dict) -> str:
+    rating = meta.get("rating")
+    label = (meta.get("label") or "").lower()
+    if (rating is not None and rating <= 2) or label == "red":
+        return "rejected"
+    if rating is not None and rating >= 4:
+        return "picked"
+    return "neutral"
+
+
+def _auc(scores: np.ndarray, positive: np.ndarray) -> float | None:
+    """ROC-AUC of `scores` separating positive(=1) from negative(=0). Mann-Whitney."""
+    pos = scores[positive == 1]
+    neg = scores[positive == 0]
+    if pos.size == 0 or neg.size == 0:
+        return None
+    # rank-based AUC
+    allv = np.concatenate([pos, neg])
+    order = allv.argsort()
+    ranks = np.empty_like(order, dtype=float)
+    ranks[order] = np.arange(1, allv.size + 1)
+    # average ties
+    _, inv, counts = np.unique(allv, return_inverse=True, return_counts=True)
+    sums = np.zeros(counts.size)
+    np.add.at(sums, inv, ranks)
+    avg = sums / counts
+    ranks = avg[inv]
+    r_pos = ranks[: pos.size].sum()
+    return float((r_pos - pos.size * (pos.size + 1) / 2) / (pos.size * neg.size))
+
+
+def _spearman(a: np.ndarray, b: np.ndarray) -> float | None:
+    m = np.isfinite(a) & np.isfinite(b)
+    if m.sum() < 5:
+        return None
+    try:
+        from scipy.stats import spearmanr
+        return round(float(spearmanr(a[m], b[m]).correlation), 4)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+# --------------------------------------------------------------------------- #
+# Per-space run
+# --------------------------------------------------------------------------- #
+def run_space(space_code: str, meta: dict, temp: float, out_dir,
+              folders: list[int] | None) -> dict | None:
+    emb_raw = load_embeddings(space_code, folders, set(meta))
+    if not emb_raw:
+        logger.warning("No persisted embeddings for %s — skipping.", space_code)
+        return None
+    ids = [i for i in emb_raw if i in meta]
+    if not ids:
+        logger.warning("No labeled images intersect %s — skipping.", space_code)
+        return None
+    img = l2_normalize(np.vstack([emb_raw[i] for i in ids]).astype(np.float32))
+    logger.info("[%s] %d images (dim=%d)", space_code, len(ids), img.shape[1])
+
+    tower = make_text_tower(space_code)
+    dim_scores: dict[str, DimScore] = {}
+    bank_text: dict[str, tuple[list[str], list[str], np.ndarray, np.ndarray]] = {}
+    try:
+        for dim, (pos, neg) in DIMENSIONS.items():
+            pos_t = _encode_phrase_banks(tower, pos)
+            neg_t = _encode_phrase_banks(tower, neg)
+            if pos_t.shape[1] != img.shape[1]:
+                logger.error("[%s] text dim %d != image dim %d (tower mismatch!) — skip",
+                             space_code, pos_t.shape[1], img.shape[1])
+                return None
+            dim_scores[dim] = score_dimension(img, pos_t, neg_t, temp)
+            bank_text[dim] = (pos, neg, pos_t, neg_t)
+    finally:
+        if hasattr(tower, "unload"):
+            tower.unload()
+
+    # ---- CSV ----
+    out_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = out_dir / f"clip_prompt_quality__{space_code}.csv"
+    dim_names = list(DIMENSIONS)
+    header = (
+        ["image_id", "file_path", "stack_id", "rating", "label", "cull_decision",
+         "picked_or_rejected"]
+        + [d for d in dim_names]                       # *_score (0..1)
+        + [f"{d}__margin" for d in dim_names]
+        + ["top_positive_prompt", "top_negative_prompt"]
+        + [f"{d}__pos_sim" for d in dim_names]
+        + [f"{d}__neg_sim" for d in dim_names]
+        + ["prompt_set_version", "space"]
+    )
+    with open(csv_path, "w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(header)
+        q = dim_scores["clip_quality_v0"]
+        gpos, gneg, _, _ = bank_text["clip_quality_v0"]
+        for k, iid in enumerate(ids):
+            m = meta[iid]
+            row = [
+                iid, m.get("file_path"), m.get("stack_id"), m.get("rating"),
+                m.get("label"), m.get("cull_decision"), pick_label(m),
+            ]
+            row += [round(float(dim_scores[d].score[k]), 4) for d in dim_names]
+            row += [round(float(dim_scores[d].margin[k]), 4) for d in dim_names]
+            row += [gpos[int(q.top_pos_idx[k])], gneg[int(q.top_neg_idx[k])]]
+            row += [round(float(dim_scores[d].pos_mean[k]), 4) for d in dim_names]
+            row += [round(float(dim_scores[d].neg_mean[k]), 4) for d in dim_names]
+            row += [PROMPT_SET_VERSION, space_code]
+            w.writerow(row)
+    logger.info("[%s] wrote %s", space_code, csv_path)
+
+    # ---- evaluation ----
+    rating = np.array([float(meta[i].get("rating") or np.nan) for i in ids])
+    picks = np.array([pick_label(meta[i]) for i in ids])
+    keeper = (picks == "picked").astype(int)
+    reject = (picks == "rejected").astype(int)
+    pr_mask = (keeper == 1) | (reject == 1)
+
+    # within-stack separation (keeper vs reject inside the same stack)
+    stack_of = np.array([meta[i].get("stack_id") for i in ids])
+    metrics = {"space": space_code, "n_images": len(ids), "dim_dim": int(img.shape[1]),
+               "n_picked": int(keeper.sum()), "n_rejected": int(reject.sum()),
+               "dimensions": {}}
+    for dim in dim_names:
+        s = dim_scores[dim].score
+        global_auc = (_auc(s[pr_mask], keeper[pr_mask]) if pr_mask.sum() else None)
+        # within-stack AUC: pool per-stack pick/reject decisions
+        ws_pairs, ws_correct = 0, 0
+        for st in set(stack_of[pr_mask]):
+            if st is None:
+                continue
+            sel = (stack_of == st) & pr_mask
+            kp = s[sel][keeper[sel] == 1]
+            rj = s[sel][reject[sel] == 1]
+            for a in kp:
+                for b in rj:
+                    ws_pairs += 1
+                    ws_correct += int(a > b)
+        metrics["dimensions"][dim] = {
+            "spearman_rating": _spearman(s, rating),
+            "auc_pick_vs_reject": (round(global_auc, 4) if global_auc is not None else None),
+            "within_stack_pairs": ws_pairs,
+            "within_stack_concordance": (round(ws_correct / ws_pairs, 4) if ws_pairs else None),
+            "score_mean_picked": (round(float(s[keeper == 1].mean()), 4) if keeper.sum() else None),
+            "score_mean_rejected": (round(float(s[reject == 1].mean()), 4) if reject.sum() else None),
+        }
+    metrics["csv"] = str(csv_path)
+    return metrics
+
+
+# --------------------------------------------------------------------------- #
+def _print_table(results: list[dict]) -> None:
+    print("\n=== clip_quality_v0 — pick/reject separation by space "
+          "(higher AUC/concordance = better) ===")
+    print(f"{'space':28} {'n':>5} {'pick':>5} {'rej':>5} {'spear':>7} "
+          f"{'AUC':>6} {'ws_conc':>8} {'mPick':>6} {'mRej':>6}")
+    for r in results:
+        d = r["dimensions"]["clip_quality_v0"]
+        print(f"{r['space']:28} {r['n_images']:5d} {r['n_picked']:5d} "
+              f"{r['n_rejected']:5d} {str(d['spearman_rating']):>7} "
+              f"{str(d['auc_pick_vs_reject']):>6} "
+              f"{str(d['within_stack_concordance']):>8} "
+              f"{str(d['score_mean_picked']):>6} {str(d['score_mean_rejected']):>6}")
+
+
+def _write_json(name: str, payload) -> Path:
+    import json
+
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    out = RESULTS_DIR / name
+    with open(out, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, default=str)
+    logger.info("Wrote %s (%d bytes)", out, out.stat().st_size)
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--spaces", default="all",
+                    help="comma list or 'all': " + ",".join(ALL_TEXT_SPACES))
+    ap.add_argument("--folders", default="",
+                    help="optional comma list of folder_id to restrict the corpus")
+    ap.add_argument("--limit", type=int, default=None,
+                    help="optional cap on number of images (debug)")
+    ap.add_argument("--temp", type=float, default=100.0,
+                    help="antonym-softmax temperature (CLIP logit scale ~100)")
+    ap.add_argument("--out", default="",
+                    help="output subdirectory under reports/clip-culling/prompt-quality/"
+                         " (e.g. 'e2e' to avoid clobbering a prod run)")
+    args = ap.parse_args(argv)
+
+    global RESULTS_DIR
+    if args.out:
+        RESULTS_DIR = RESULTS_DIR / args.out
+
+    logging.basicConfig(level=logging.INFO,
+                        format="%(asctime)s - %(levelname)s - %(message)s")
+
+    from modules import db
+    if db._get_db_engine() != "postgres":  # noqa: SLF001
+        raise SystemExit("This benchmark requires database.engine = 'postgres'.")
+
+    spaces = ALL_TEXT_SPACES if args.spaces == "all" else \
+        [s.strip() for s in args.spaces.split(",") if s.strip()]
+    unknown = [s for s in spaces if s not in ALL_TEXT_SPACES]
+    if unknown:
+        raise SystemExit(f"Unknown/text-incapable spaces: {unknown}; "
+                         f"valid: {ALL_TEXT_SPACES}")
+    folders = [int(x) for x in args.folders.split(",") if x.strip()] or None
+
+    meta = load_meta(folders, args.limit)
+    logger.info("Loaded meta for %d labeled images%s", len(meta),
+                f" (folders {folders})" if folders else "")
+    if not meta:
+        raise SystemExit("No labeled images found for the given filter.")
+
+    results = []
+    for space in spaces:
+        try:
+            m = run_space(space, meta, args.temp, RESULTS_DIR, folders)
+        except Exception as e:  # noqa: BLE001
+            logger.exception("[%s] failed: %s", space, e)
+            continue
+        if m:
+            results.append(m)
+
+    if not results:
+        logger.error("No spaces produced results (no persisted embeddings?).")
+        return 1
+
+    summary = {"prompt_set_version": PROMPT_SET_VERSION, "temp": args.temp,
+               "templates": list(TEMPLATES), "n_meta": len(meta),
+               "folders": folders, "results": results}
+    _write_json("summary.json", summary)
+    _print_table(results)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_clip_quality.py
+++ b/tests/test_clip_quality.py
@@ -1,0 +1,120 @@
+"""Unit tests for the CLIP prompt-quality pick/reject signal (no GPU/DB).
+
+Covers the pure math/logic: antonym-softmax scoring, prompt template expansion,
+the within-stack rank blend, and the obvious-reject guard.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from modules import clip_quality
+from modules.selection import apply_clip_reject_guard, blended_rank_value
+
+
+def _unit(vecs):
+    a = np.asarray(vecs, dtype=np.float32)
+    return a / np.linalg.norm(a, axis=-1, keepdims=True)
+
+
+# --------------------------------------------------------------------------- #
+# score_embeddings
+# --------------------------------------------------------------------------- #
+def test_score_embeddings_range_and_direction():
+    # 2-D toy space: good prompt points +x, bad prompt points -x.
+    good = _unit([[1.0, 0.0]])
+    bad = _unit([[-1.0, 0.0]])
+    img = _unit([[1.0, 0.0], [-1.0, 0.0], [0.0, 1.0]])  # good, bad, neutral
+    margin, norm = clip_quality.score_embeddings(img, good, bad)
+
+    assert norm.shape == (3,)
+    assert np.all(norm >= 0.0) and np.all(norm <= 1.0)
+    assert norm[0] > 0.5 > norm[1]          # good above 0.5, bad below
+    assert abs(norm[2] - 0.5) < 1e-3        # orthogonal ~ uncertain
+    assert margin[0] > 0 > margin[1]
+
+
+def test_score_embeddings_normalizes_unnormalized_input():
+    good = _unit([[1.0, 0.0]])
+    bad = _unit([[-1.0, 0.0]])
+    scaled = np.array([[5.0, 0.0]], dtype=np.float32)  # not unit length
+    _, norm = clip_quality.score_embeddings(scaled, good, bad)
+    assert norm[0] > 0.5
+
+
+# --------------------------------------------------------------------------- #
+# prompt template expansion
+# --------------------------------------------------------------------------- #
+def test_expand_templates_short_phrase():
+    out = clip_quality._expand("sharp")
+    assert len(out) == len(clip_quality.TEMPLATES)
+    assert "a sharp photograph" in out
+
+
+def test_expand_verbatim_full_caption():
+    # contains a verbatim token ('photo') -> used as-is, not templated
+    out = clip_quality._expand("a keeper photo")
+    assert out == ["a keeper photo"]
+
+
+# --------------------------------------------------------------------------- #
+# blended_rank_value
+# --------------------------------------------------------------------------- #
+def test_blend_disabled_returns_score_general():
+    img = {"score_general": 0.8, "clip_quality_v0": 0.0}
+    assert blended_rank_value(img, "score_general", 0.0) == 0.8
+
+
+def test_blend_mixes_when_weight_positive():
+    img = {"score_general": 0.8, "clip_quality_v0": 0.3}
+    val = blended_rank_value(img, "score_general", 0.5)
+    assert abs(val - (0.5 * 0.8 + 0.5 * 0.3)) < 1e-9
+
+
+def test_blend_falls_back_when_clip_missing():
+    img = {"score_general": 0.8}  # no clip value
+    assert blended_rank_value(img, "score_general", 0.5) == 0.8
+
+
+def test_blend_changes_order_as_weight_rises():
+    # a: high IQA, low CLIP; b: low IQA, high CLIP.
+    a = {"id": 1, "score_general": 0.9, "clip_quality_v0": 0.1}
+    b = {"id": 2, "score_general": 0.6, "clip_quality_v0": 0.95}
+    assert blended_rank_value(a, "score_general", 0.0) > blended_rank_value(b, "score_general", 0.0)
+    assert blended_rank_value(b, "score_general", 0.6) > blended_rank_value(a, "score_general", 0.6)
+
+
+# --------------------------------------------------------------------------- #
+# apply_clip_reject_guard
+# --------------------------------------------------------------------------- #
+def test_guard_downgrades_neutral_below_threshold():
+    decisions = [(1, "pick", ""), (2, "neutral", ""), (3, "reject", "")]
+    clip_map = {1: 0.9, 2: 0.05, 3: 0.5}
+    stack_of = {1: 10, 2: 10, 3: 10}
+    out = dict((i, d) for i, d, _ in apply_clip_reject_guard(decisions, clip_map, stack_of, 0.2))
+    assert out == {1: "pick", 2: "reject", 3: "reject"}
+
+
+def test_guard_never_strips_last_pick():
+    # sole pick of its stack is below threshold but must survive
+    decisions = [(1, "pick", ""), (2, "reject", "")]
+    clip_map = {1: 0.01, 2: 0.5}
+    stack_of = {1: 7, 2: 7}
+    out = dict((i, d) for i, d, _ in apply_clip_reject_guard(decisions, clip_map, stack_of, 0.2))
+    assert out[1] == "pick"
+
+
+def test_guard_downgrades_extra_pick_keeps_one():
+    # two picks below threshold -> one downgraded, one kept
+    decisions = [(1, "pick", ""), (2, "pick", "")]
+    clip_map = {1: 0.05, 2: 0.06}
+    stack_of = {1: 7, 2: 7}
+    out = [d for _, d, _ in apply_clip_reject_guard(decisions, clip_map, stack_of, 0.2)]
+    assert out.count("pick") == 1 and out.count("reject") == 1
+
+
+def test_guard_never_upgrades():
+    decisions = [(1, "neutral", "")]
+    clip_map = {1: 0.99}  # above threshold -> unchanged
+    out = [d for _, d, _ in apply_clip_reject_guard(decisions, clip_map, {1: 1}, 0.2)]
+    assert out == ["neutral"]

--- a/tests/test_culling_embedding_spaces.py
+++ b/tests/test_culling_embedding_spaces.py
@@ -27,12 +27,16 @@ def test_culling_codes_registered_in_space_dims():
 
 
 def test_embedder_registry_matches_space_dims():
+    # The four 768-d culling towers are all supported embedders...
+    assert CULLING_SPACE_CODES <= set(ee.SUPPORTED_CULLING_SPACES)
+    # ...plus CLIP B/32 (512-d), registered so the clip_quality signal can JIT-embed
+    # it before culling (see modules/clip_quality.py).
+    assert es.CLIP_IMAGE_SPACE_CODE in ee.SUPPORTED_CULLING_SPACES
     # Every supported embedder maps to a registered space of the right dim.
-    assert set(ee.SUPPORTED_CULLING_SPACES) == CULLING_SPACE_CODES
     for code, spec in ee.SUPPORTED_CULLING_SPACES.items():
         assert spec.code == code
         assert spec.dim == es.SPACE_DIMS[code]
-        assert spec.loader in {"open_clip", "timm", "hf_siglip2", "hf_dinov2"}
+        assert spec.loader in {"open_clip", "timm", "hf_siglip2", "hf_dinov2", "hf_clip"}
 
 
 def test_open_clip_specs_have_pretrained():


### PR DESCRIPTION
Closes #271

## What

Adds an **auxiliary** (not primary IQA) within-stack pick/reject signal for culling: `clip_quality_v0`, a 0–1 "good photo" probability from the persisted `clip_vit_b32_image` (512-d) embedding scored against antonym text prompts (CLIP-IQA style).

## Why

Offline benchmark (`reports/clip-culling/prompt-quality/`): B/32 beat OpenCLIP-L/14, OpenAI-L/14, BioCLIP — global pick/reject **AUC 0.89**, within-stack keeper-vs-reject **concordance 0.986**.

## How

- `modules/clip_quality.py` — prompt banks + antonym-softmax scorer; persists to `image_model_scores` (`model_name = clip_quality_v0`), auto-surfaces in the API as `clip_quality_v0_score` (no endpoint change).
- `modules/embedding_extractors.py` — B/32 added as a JIT-generatable culling space (`hf_clip` loader) so the vector exists pre-culling; keywords phase reuses it (`embeddings.reuse_clip_image_for_keywords`).
- `modules/selection.py` — blends `clip_quality_v0` into the within-stack `sort_key` behind `culling.clip_quality.*` (**default off**, weight 0.15, optional `reject_below` floor). `score_general` is untouched; with the flag off the path is byte-identical to before.
- `scripts/backfill_clip_quality.py` — library backfill from existing B/32 embeddings.
- Config (`config.example.json`) + docs (`CONFIG.md`, `API_CONTRACT.md`, `CULLING_ANALYTICS.md`).

## Notes

- Feature-only PR: rebased onto current `master` (dropped a stale local `v8.6.0` release commit). CHANGELOG entry under `[Unreleased]`; release cut separately.
- No new DB table (reuses `image_model_scores`); no `score_general` / `scoring.fusion` change.

## Test

- `pytest tests/test_clip_quality.py tests/test_culling_embedding_spaces.py -q` → 19 passed.
- `ruff check` clean on touched modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)