### PR TITLE
docs: bump Claude LLM-judge example model ID to claude-opus-4-8

### DIFF
--- a/docs/MODEL_RECOMMENDATIONS_PIPELINES.md
+++ b/docs/MODEL_RECOMMENDATIONS_PIPELINES.md
@@ -41,7 +41,7 @@ What the codebase runs **today** (see [`config.example.json`](../config.example.
 | **TOPIQ-NR** | PyTorch (`pyiqa` `topiq_nr`) | pyiqa pretrained | **On** (fused) | No-reference technical quality |
 | **QPT-V2** | PyTorch | `models/qpt_v2.pth` | **Shadow only** | Experimental unified quality+aesthetic |
 | **Cursor** (LLM judge) | API | e.g. `composer-2.5` | **Off** | Optional editorial judgment |
-| **Claude** (LLM judge) | API | e.g. `claude-opus-4-7` | **Off** | Optional editorial judgment |
+| **Claude** (LLM judge) | API | e.g. `claude-opus-4-8` | **Off** | Optional editorial judgment |
 
 **Fusion** (`scoring.fusion` in example): `general` = LIQE + AVA + SPAQ; `technical` = LIQE; `aesthetic` = AVA + SPAQ.
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -6,6 +6,10 @@ Parse with: `grep "^## \[" docs/log.md | tail -10`
 
 ---
 
+## [2026-06-19] updated — bump LLM judge example model ID
+
+Updated `MODEL_RECOMMENDATIONS_PIPELINES.md` Claude LLM-judge example from `claude-opus-4-7` to `claude-opus-4-8` (current Opus-tier default as of June 2026).
+
 ## [2026-06-16] created — OKF lint in GitHub Actions
 
 Wired OKF bundle lint into [`.github/workflows/docs-lint.yml`](../.github/workflows/docs-lint.yml): pytest `tests/test_okf_lint.py`, full gallery bundle lint, and `scripts/ci/okf_lint_changed.py` for PR/push diffs. Gallery `test-and-contract.yml` runs full OKF lint via cloned backend. Documented in [OKF_ADOPTION.md](OKF_ADOPTION.md) and [TESTING.md](TESTING.md).


### PR DESCRIPTION
claude-opus-4-7 is still valid but claude-opus-4-8 is the current
recommended Opus-tier default as of June 2026.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018wyomGQS4f3RzkBX9qtMHU